### PR TITLE
fix: remove deleted integrations skill references and fix docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,6 @@
         "./skills/runtime",
         "./skills/tools",
         "./skills/streaming",
-        "./skills/integrations",
         "./skills/cloud",
         "./skills/thread-list"
       ]

--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ npx skills add assistant-ui/skills
 | Skill | Description |
 |-------|-------------|
 | `/assistant-ui` | Main guide - architecture, packages, patterns |
-| `/setup` | Project setup and configuration |
+| `/setup` | Project setup and configuration (AI SDK, LangGraph, custom backends) |
 | `/primitives` | UI component primitives (Thread, Composer, Message, etc.) |
 | `/runtime` | Runtime system and state management |
 | `/tools` | Tool registration and tool UI |
 | `/streaming` | Streaming protocol and backends |
-| `/integrations` | Backend integrations (AI SDK, LangGraph, etc.) |
+| `/cloud` | Cloud persistence and authentication |
+| `/thread-list` | Multi-thread management |
 
 ## Usage
 
@@ -26,12 +27,13 @@ After installation, use skills in Claude Code by typing `/` followed by the skil
 
 ```
 /assistant-ui    # Get architecture overview
-/setup           # Setup a new project
+/setup           # Setup a new project (AI SDK, LangGraph, etc.)
 /primitives      # Customize UI components
 /runtime         # Work with state and runtimes
 /tools           # Implement LLM tools
 /streaming       # Handle streaming responses
-/integrations    # Connect to backends
+/cloud           # Persistence and auth
+/thread-list     # Multi-thread management
 ```
 
 ## Links

--- a/assistant-ui/skills/primitives/SKILL.md
+++ b/assistant-ui/skills/primitives/SKILL.md
@@ -104,9 +104,9 @@ function CustomThread() {
 ```tsx
 <MessagePrimitive.If hasBranches>
   <BranchPickerPrimitive.Root className="flex items-center gap-1">
-    <BranchPickerPrimitive.Previous></BranchPickerPrimitive.Previous>
+    <BranchPickerPrimitive.Previous>←</BranchPickerPrimitive.Previous>
     <span><BranchPickerPrimitive.Number /> / <BranchPickerPrimitive.Count /></span>
-    <BranchPickerPrimitive.Next></BranchPickerPrimitive.Next>
+    <BranchPickerPrimitive.Next>→</BranchPickerPrimitive.Next>
   </BranchPickerPrimitive.Root>
 </MessagePrimitive.If>
 ```

--- a/assistant-ui/skills/tools/SKILL.md
+++ b/assistant-ui/skills/tools/SKILL.md
@@ -58,7 +58,7 @@ const WeatherToolUI = makeAssistantToolUI({
   toolName: "get_weather",
   render: ({ args, result, status }) => {
     if (status === "running") return <div>Loading weather...</div>;
-    return <div>{result?.city}: {result?.temp}C</div>;
+    return <div>{result?.city}: {result?.temp}°C</div>;
   },
 });
 


### PR DESCRIPTION
## Summary
- Remove `/integrations` skill references (skill was merged into `/setup`)
- Fix empty `BranchPickerPrimitive` tags in primitives docs
- Restore degree symbol in tools example

## Changes
- **README.md**: Updated skill list to remove `/integrations`, add `/cloud` and `/thread-list`
- **marketplace.json**: Removed `./skills/integrations` path that no longer exists
- **primitives/SKILL.md**: Added ← → arrows to `BranchPickerPrimitive.Previous/Next` tags
- **tools/SKILL.md**: Fixed `{result?.temp}C` → `{result?.temp}°C`

## Verification Sources
- **npm registry**: `npm view @assistant-ui/react-ai-sdk` - confirmed exports
- **GitHub source**: `gh api repos/assistant-ui/assistant-ui/contents/packages/react-ai-sdk/src/index.ts` - verified API
- **Directory check**: `ls assistant-ui/skills/assistant-ui/skills/integrations/` returns "Directory does not exist"