### PR TITLE
fix: update skill documentation accuracy

### DIFF
--- a/assistant-ui/skills/update/references/ai-sdk-v6.md
+++ b/assistant-ui/skills/update/references/ai-sdk-v6.md
@@ -186,8 +186,10 @@ yarn add ai@latest @ai-sdk/react@latest @ai-sdk/openai@latest zod@latest
 ### 3.2 Run Codemods
 
 ```bash
-npx @ai-sdk/codemod v6
+npx @ai-sdk/codemod upgrade
 ```
+
+This is the recommended approach - it detects your current version and applies all necessary codemods (v4→v5→v6) automatically.
 
 **VERIFY:**
 - Review codemod output

--- a/assistant-ui/skills/update/references/assistant-ui.md
+++ b/assistant-ui/skills/update/references/assistant-ui.md
@@ -111,6 +111,7 @@ Components are copied to your project (e.g., `components/assistant-ui/thread.tsx
 
 ```diff
 // Styled components - now local files
+// Note: ThreadWelcome is now embedded inside Thread (shows when thread is empty)
 - import { Thread, ThreadWelcome } from "@assistant-ui/react";
 + import { Thread } from "@/components/assistant-ui/thread";
 
@@ -233,7 +234,7 @@ grep -rn "AssistantMessage\[^C\]\|UserMessage\[^C\]" --include="*.tsx" --include
 # Old tool API
 grep -rn "setResult\|setArtifact" --include="*.tsx" --include="*.ts"
 
-# Styled imports (need react-ui)
+# Styled imports (need shadcn registry migration)
 grep -rn "from ['\"]@assistant-ui/react['\"]" --include="*.tsx" | grep -v "Primitive\|Runtime\|use"
 ```
 

--- a/assistant-ui/skills/update/references/breaking-changes.md
+++ b/assistant-ui/skills/update/references/breaking-changes.md
@@ -9,7 +9,7 @@ Fast lookup for breaking changes by version.
 | **0.11.0** | Runtime rearchitecture | Use `useAssistantApi`, `useAssistantState`, `useAssistantEvent` |
 | **0.10.0** | CommonJS dropped | Use ESM, set `"type": "module"` |
 | **0.8.18** | `setResult`/`setArtifact` merged | Use `setResponse({ result, artifact })` |
-| **0.8.0** | UI → `@assistant-ui/react-ui` | Install react-ui or use primitives |
+| **0.8.0** | UI moved out of core | Use shadcn registry (recommended) or primitives |
 | **0.7.44** | `runtime.switchToThread()` moved | Use `runtime.threads.switchToThread()` |
 | **0.7.44** | `runtime.threadList` renamed | Use `runtime.threads` |
 | **0.7.0** | Deprecated features dropped | Update to non-deprecated APIs |
@@ -24,9 +24,10 @@ Fast lookup for breaking changes by version.
 ### Import Changes
 
 ```diff
-# Styled components (0.8.0+)
+# Styled components (0.8.0+) - use shadcn registry (recommended)
 - import { Thread } from "@assistant-ui/react";
-+ import { Thread } from "@assistant-ui/react-ui";
++ import { Thread } from "@/components/assistant-ui/thread";
+# Note: Run `npx assistant-ui add thread` to install
 
 # Message types (0.4.0+)
 - import type { AssistantMessage, UserMessage } from "@assistant-ui/react";


### PR DESCRIPTION
- Use `npx @ai-sdk/codemod upgrade` as recommended (auto-detects version)
- Add ThreadWelcome note (now embedded inside Thread component)
- Update breaking-changes.md to show shadcn registry as recommended
- Fix import examples to use @/components/assistant-ui/thread path
- Update comments to reference shadcn registry migration instead of react-ui