### PR TITLE
fix: correct factual errors in packages.md

### DIFF
--- a/assistant-ui/skills/assistant-ui/references/packages.md
+++ b/assistant-ui/skills/assistant-ui/references/packages.md
@@ -20,6 +20,11 @@
 | @assistant-ui/react-hook-form | React Hook Form integration |
 | @assistant-ui/react-a2a | Agent-to-Agent protocol for multi-agent systems |
 | @assistant-ui/react-ag-ui | AG-UI protocol adapter for agent backends |
+| @assistant-ui/cloud-ai-sdk | AI SDK hooks for assistant-cloud persistence |
+| @assistant-ui/core | Framework-agnostic core runtime |
+| @assistant-ui/react-native | React Native bindings |
+| @assistant-ui/react-o11y | Observability primitives |
+| @assistant-ui/react-streamdown | Streamdown-based markdown rendering |
 | @assistant-ui/tap | Reactive state management and testing |
 | @assistant-ui/mcp-docs-server | MCP server for IDE integration |
 | assistant-stream | Streaming protocol |
@@ -28,6 +33,7 @@
 | create-assistant-ui | Project scaffolding |
 | safe-content-frame | Sandboxed iframe content |
 | tw-shimmer | Tailwind shimmer effects |
+| tw-glass | Tailwind CSS v4 glass refraction effects |
 | mcp-app-studio | MCP app builder |
 
 ## Core Packages

--- a/assistant-ui/skills/assistant-ui/references/packages.md
+++ b/assistant-ui/skills/assistant-ui/references/packages.md
@@ -117,8 +117,9 @@ npm install @assistant-ui/react-markdown
 ```
 
 **Exports:**
-- `MarkdownText` - Renders markdown content
-- `makeMarkdownText` - Create custom markdown component
+- `MarkdownTextPrimitive` - Renders markdown content
+- `useIsMarkdownCodeBlock` - Check if code block is inside markdown
+- `unstable_memoizeMarkdownComponents` - Memoize markdown components for performance
 
 ### @assistant-ui/react-syntax-highlighter
 

--- a/assistant-ui/skills/assistant-ui/references/packages.md
+++ b/assistant-ui/skills/assistant-ui/references/packages.md
@@ -28,7 +28,7 @@
 | create-assistant-ui | Project scaffolding |
 | safe-content-frame | Sandboxed iframe content |
 | tw-shimmer | Tailwind shimmer effects |
-| chatgpt-app-studio | ChatGPT app builder |
+| mcp-app-studio | MCP app builder |
 
 ## Core Packages
 

--- a/assistant-ui/skills/assistant-ui/references/packages.md
+++ b/assistant-ui/skills/assistant-ui/references/packages.md
@@ -4,7 +4,7 @@
 
 **To check latest version:** Run `npm view <package-name> version` or check the package on npmjs.com.
 
-- All published packages only expose the `latest` dist-tag (no `next/beta/canary`).
+- Most published packages only expose the `latest` dist-tag; always install from `latest`.
 - Monorepo-only: `@assistant-ui/x-buildutils` (not on npm).
 
 | Package | Notes |

--- a/assistant-ui/skills/assistant-ui/references/packages.md
+++ b/assistant-ui/skills/assistant-ui/references/packages.md
@@ -142,5 +142,5 @@ npm install @assistant-ui/react-syntax-highlighter
 ## Version Compatibility
 
 - `@assistant-ui/react` requires React 18+ or 19
-- `@assistant-ui/react-ai-sdk` requires AI SDK v6 (`ai@^6.0.42`)
+- `@assistant-ui/react-ai-sdk` requires AI SDK v6 (`ai@^6`)
 - Node.js >=24 recommended (monorepo requirement)


### PR DESCRIPTION
## Summary
- Fix dist-tag claim: "All" → "Most" (alpha tag exists on react-ai-sdk)
- Rename chatgpt-app-studio → mcp-app-studio (package was renamed)
- Fix react-markdown exports: MarkdownText/makeMarkdownText → MarkdownTextPrimitive/useIsMarkdownCodeBlock/unstable_memoizeMarkdownComponents
- Broaden AI SDK version constraint: `ai@^6.0.42` → `ai@^6`
- Add 6 missing published packages to table: cloud-ai-sdk, core, react-native, react-o11y, react-streamdown, tw-glass

## Verification
All changes verified against npm registry and monorepo source:

| Check | Result |
|-------|--------|
| `npm view @assistant-ui/react-ai-sdk dist-tags` | `alpha` tag exists → "All" claim was false |
| `npm view mcp-app-studio version` | 0.7.2 (active); chatgpt-app-studio frozen at 0.2.0 |
| react-markdown `src/index.ts` exports | MarkdownTextPrimitive, useIsMarkdownCodeBlock, unstable_memoizeMarkdownComponents |
| `npm view ai version` | 6.0.105 → `^6` is correct |
| 6 new packages on npm | cloud-ai-sdk@0.1.3, core@0.1.2, react-native@0.1.1, react-o11y@0.0.2, react-streamdown@0.1.4, tw-glass@0.0.2 |
| No stale refs remaining | grep for chatgpt-app-studio, makeMarkdownText, non-Primitive MarkdownText → 0 matches |