### PR TITLE
fix: update stale version pins and correct AI SDK v6 property name

### DIFF
--- a/assistant-ui/skills/setup/references/ai-sdk.md
+++ b/assistant-ui/skills/setup/references/ai-sdk.md
@@ -96,7 +96,7 @@ const runtime = useChatRuntime({
     headers: { "X-Workspace": "acme" },
     body: { model: "gpt-4o-mini" },
   }),
-  initialMessages: [
+  messages: [
     { id: "1", role: "assistant", parts: [{ type: "text", text: "Hello! How can I help?" }] },
   ],
   sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,

--- a/assistant-ui/skills/setup/references/tanstack.md
+++ b/assistant-ui/skills/setup/references/tanstack.md
@@ -153,10 +153,10 @@ export function MyRuntimeProvider({ children }: { children: ReactNode }) {
 ```json
 {
   "@assistant-ui/react": "latest",
-  "@tanstack/react-router": "^1.153.2",
-  "@tanstack/react-start": "^1.154.0",
-  "@tailwindcss/vite": "^4.1.18",
-  "react": "^19.2.3",
+  "@tanstack/react-router": "^1.162.9",
+  "@tanstack/react-start": "^1.162.9",
+  "@tailwindcss/vite": "^4.2.1",
+  "react": "^19.2.4",
   "vite": "^7.3.1"
 }
 ```

--- a/assistant-ui/skills/update/references/ai-sdk-v6.md
+++ b/assistant-ui/skills/update/references/ai-sdk-v6.md
@@ -383,8 +383,8 @@ Then re-analyze what went wrong before retrying.
   "@ai-sdk/react": "^3.0.0",
   "@ai-sdk/provider": "^3.0.0",
   "@ai-sdk/provider-utils": "^4.0.0",
-  "@assistant-ui/react": "^0.11.58",
-  "@assistant-ui/react-ai-sdk": "^1.2.0"
+  "@assistant-ui/react": "^0.12.14",
+  "@assistant-ui/react-ai-sdk": "^1.3.10"
 }
 ```
 
@@ -1855,8 +1855,8 @@ npx @ai-sdk/codemod v6       # v5→v6 only
 - [ ] Update `@ai-sdk/provider-utils` to `^4.0.0`
 - [ ] Update all `@ai-sdk/*` provider packages to `^3.0.0`
 - [ ] Update `zod` to `^3.25.76` or `^4.1.8` (both supported)
-- [ ] Update `@assistant-ui/react` to `^0.11.58`
-- [ ] Update `@assistant-ui/react-ai-sdk` to `^1.2.0`
+- [ ] Update `@assistant-ui/react` to `^0.12.14`
+- [ ] Update `@assistant-ui/react-ai-sdk` to `^1.3.10`
 - [ ] If using MCP: Install `@ai-sdk/mcp` to `^1.0.0`
 
 ### Automated Migration


### PR DESCRIPTION
## Summary
- Update `@assistant-ui/react` from `^0.11.58` to `^0.12.14` and `@assistant-ui/react-ai-sdk` from `^1.2.0` to `^1.3.10` in ai-sdk-v6.md — the old pins caused unresolvable npm install conflicts because `react-ai-sdk@^1.2.0` resolves to 1.3.10 which has peerDep `@assistant-ui/react@^0.12.14`, incompatible with `^0.11.58`
- Fix `initialMessages` → `messages` in ai-sdk.md setup example — AI SDK v6's `ChatInit` type uses `messages`, the old name was from v4/v5
- Update 4 stale dependency versions in tanstack.md to match the upstream `with-tanstack` example

## Verification

| Check | Result |
|-------|--------|
| `npm view @assistant-ui/react version` | 0.12.14 |
| `npm view @assistant-ui/react-ai-sdk version` | 1.3.10 |
| `npm view @assistant-ui/react-ai-sdk peerDependencies` | `@assistant-ui/react: ^0.12.14` |
| ChatInit type in ai dist/index.d.ts | Has `messages?`, no `initialMessages` |
| `grep "0\.11\.58\|1\.2\.0" ai-sdk-v6.md` | 0 matches after fix |
| TanStack example package.json versions match | react-router ^1.162.9, react-start ^1.162.9, tailwindcss/vite ^4.2.1, react ^19.2.4 |