### PR TITLE
fix: replace deprecated hook names in skills docs

### DIFF
--- a/assistant-ui/skills/update/references/assistant-ui.md
+++ b/assistant-ui/skills/update/references/assistant-ui.md
@@ -17,22 +17,22 @@ npm view @assistant-ui/react version  # Latest
 
 ```typescript
 import {
-  useAssistantApi,
-  useAssistantState,
-  useAssistantEvent
+  useAui,
+  useAuiState,
+  useAuiEvent
 } from "@assistant-ui/react";
 
 // State access (replaces various useThread* hooks)
-const messages = useAssistantState(s => s.thread.messages);
-const isRunning = useAssistantState(s => s.thread.isRunning);
+const messages = useAuiState(s => s.thread.messages);
+const isRunning = useAuiState(s => s.thread.isRunning);
 
 // Actions
-const api = useAssistantApi();
+const api = useAui();
 api.thread().append({ role: "user", content: [{ type: "text", text: "Hello" }] });
 api.thread().cancelRun();
 
 // Events
-useAssistantEvent("composer.send", (e) => {
+useAuiEvent("composer.send", (e) => {
   console.log("Message sent:", e.messageId);
 });
 ```

--- a/assistant-ui/skills/update/references/breaking-changes.md
+++ b/assistant-ui/skills/update/references/breaking-changes.md
@@ -6,7 +6,7 @@ Fast lookup for breaking changes by version.
 
 | Version | Breaking Change | Migration |
 |---------|-----------------|-----------|
-| **0.11.0** | Runtime rearchitecture | Use `useAssistantApi`, `useAssistantState`, `useAssistantEvent` |
+| **0.11.0** | Runtime rearchitecture | Use `useAui`, `useAuiState`, `useAuiEvent` |
 | **0.10.0** | CommonJS dropped | Use ESM, set `"type": "module"` |
 | **0.8.18** | `setResult`/`setArtifact` merged | Use `setResponse({ result, artifact })` |
 | **0.8.0** | UI moved out of core | Use shadcn registry (recommended) or primitives |
@@ -57,11 +57,11 @@ Fast lookup for breaking changes by version.
 
 # State access (0.11.0+)
 - const { messages } = useThread();
-+ const messages = useAssistantState(s => s.thread.messages);
++ const messages = useAuiState(s => s.thread.messages);
 
 # Actions (0.11.0+)
 - useThreadActions().append(...)
-+ useAssistantApi().thread().append(...)
++ useAui().thread().append(...)
 ```
 
 ### Config Changes


### PR DESCRIPTION
## Summary
- Replace `useAssistantApi`, `useAssistantState`, `useAssistantEvent` with their non-deprecated replacements (`useAui`, `useAuiState`, `useAuiEvent`) in migration target code
- Fixes breaking-changes.md: version table migration column and `+` diff lines
- Fixes assistant-ui.md: 0.11.x migration code examples (imports, state access, actions, events)

## Verification

| Check | Result |
|-------|--------|
| `grep -n "useAssistantApi\|useAssistantState\|useAssistantEvent" breaking-changes.md` | 0 matches |
| `grep -n "useAssistantApi\|useAssistantState\|useAssistantEvent" assistant-ui.md` | 0 matches |
| Source confirms deprecation (`react/src/index.ts` @deprecated JSDoc) | `useAui`, `useAuiState`, `useAuiEvent` are canonical; old names removed in v0.13 |
| `-` diff lines in breaking-changes.md still use old API names (correct — showing what to migrate FROM) | Verified: `useThread()`, `useThreadActions()` remain on `-` lines |