### PR TITLE
feat: add 0.12.x migration documentation

### DIFF
--- a/assistant-ui/skills/update/SKILL.md
+++ b/assistant-ui/skills/update/SKILL.md
@@ -34,6 +34,7 @@ npm view ai version
 | Package | Check For |
 |---------|-----------|
 | `ai` | < 6.0.0 → needs AI SDK v6 migration |
+| `@assistant-ui/react` | < 0.12.0 → needs unified state API migration |
 | `@assistant-ui/react` | < 0.11.0 → needs runtime migration |
 | `@assistant-ui/react` | < 0.10.0 → needs ESM migration |
 | `@assistant-ui/react` | < 0.8.0 → needs UI split migration |

--- a/assistant-ui/skills/update/references/assistant-ui.md
+++ b/assistant-ui/skills/update/references/assistant-ui.md
@@ -9,30 +9,129 @@ npm ls @assistant-ui/react
 npm view @assistant-ui/react version  # Latest
 ```
 
+## Migration: → 0.12.x (Unified State API)
+
+### From 0.11.x
+
+Unified state API replaces individual context hooks.
+
+**Automatic migration available:**
+```bash
+npx assistant-ui@latest upgrade
+```
+
+**Assistant API hooks renamed (deprecated until v0.13):**
+
+```diff
+- import { useAssistantApi, useAssistantState, useAssistantEvent, AssistantIf } from "@assistant-ui/react";
++ import { useAui, useAuiState, useAuiEvent, AuiIf } from "@assistant-ui/react";
+
+- const api = useAssistantApi();
++ const aui = useAui();
+
+- const messages = useAssistantState(s => s.thread.messages);
++ const messages = useAuiState(s => s.thread.messages);
+
+- useAssistantEvent("thread.run-start", callback);
++ useAuiEvent("thread.runStart", callback);
+
+- <AssistantIf condition={...}>
++ <AuiIf condition={...}>
+```
+
+**Context hooks replaced with unified state API:**
+
+All individual context hooks replaced by `useAuiState` / `useAui`:
+
+```diff
+- const { messages } = useThread();
++ const messages = useAuiState(s => s.thread.messages);
+
+- const runtime = useThreadRuntime();
++ const thread = useAui().thread();
+
+- const { isEditing } = useComposer();
++ const isEditing = useAuiState(s => s.composer.isEditing);
+
+- const runtime = useComposerRuntime();
++ const composer = useAui().composer();
+
+- const { status } = useMessage();
++ const status = useAuiState(s => s.message.status);
+
+- const runtime = useMessageRuntime();
++ const message = useAui().message();
+```
+
+Other deprecated hooks: `useAssistantRuntime`, `useEditComposer`, `useThreadListItem`, `useThreadListItemRuntime`, `useMessagePart`, `useMessagePartRuntime`, `useAttachment`, `useAttachmentRuntime`, `useThreadModelContext`, `useThreadComposer`, `useThreadList`.
+
+**Event names changed to camelCase:**
+
+| Old | New |
+|-----|-----|
+| `thread.run-start` | `thread.runStart` |
+| `thread.run-end` | `thread.runEnd` |
+| `thread.model-context-update` | `thread.modelContextUpdate` |
+| `composer.attachment-add` | `composer.attachmentAdd` |
+| `thread-list-item.switched-to` | `threadListItem.switchedTo` |
+| `thread-list-item.switched-away` | `threadListItem.switchedAway` |
+
+Unchanged: `thread.initialize`, `composer.send`.
+
+**`thread().composer()` invocation (0.12.11):**
+
+```diff
+- aui.thread().composer.send();
++ aui.thread().composer().send();
+```
+
+**`submitMode` prop (0.12.10) — deprecates `submitOnEnter`:**
+- `"enter"` (default) — submit on Enter
+- `"ctrlEnter"` — submit on Ctrl/Cmd+Enter, plain Enter for newlines
+- `"none"` — disable keyboard submission
+
+**Zod 4 required** — `@assistant-ui/react-ai-sdk` 1.3.x requires `zod@^4.3.6`
+
+**New primitives:**
+- `ChainOfThoughtPrimitive` (0.12.8)
+- `SelectionToolbarPrimitive` (0.12.10)
+- `SuggestionPrimitive` (0.12.3)
+
+**`@assistant-ui/core` extraction (0.12.11):**
+- Framework-agnostic core extracted to `@assistant-ui/core`
+- Shared React code in `@assistant-ui/core/react` (re-exported by `@assistant-ui/react` and `@assistant-ui/react-native`)
+
+**Search for deprecated patterns:**
+```bash
+grep -rn "useAssistantApi\|useAssistantState\|useAssistantEvent\|AssistantIf\|submitOnEnter\|useThread()\|useComposer()\|useMessage()\|useThreadRuntime\|useComposerRuntime\|useMessageRuntime" --include="*.tsx" --include="*.ts"
+```
+
+---
+
 ## Migration: → 0.11.x (Runtime Rearchitecture)
 
 ### From 0.10.x
 
-**New unified state API:**
+**New unified state API** (hooks renamed to `useAui`/`useAuiState`/`useAuiEvent` in 0.12.x):
 
 ```typescript
 import {
-  useAui,
-  useAuiState,
-  useAuiEvent
+  useAssistantApi,
+  useAssistantState,
+  useAssistantEvent
 } from "@assistant-ui/react";
 
 // State access (replaces various useThread* hooks)
-const messages = useAuiState(s => s.thread.messages);
-const isRunning = useAuiState(s => s.thread.isRunning);
+const messages = useAssistantState(s => s.thread.messages);
+const isRunning = useAssistantState(s => s.thread.isRunning);
 
 // Actions
-const api = useAui();
+const api = useAssistantApi();
 api.thread().append({ role: "user", content: [{ type: "text", text: "Hello" }] });
 api.thread().cancelRun();
 
 // Events
-useAuiEvent("composer.send", (e) => {
+useAssistantEvent("composer.send", (e) => {
   console.log("Message sent:", e.messageId);
 });
 ```

--- a/assistant-ui/skills/update/references/breaking-changes.md
+++ b/assistant-ui/skills/update/references/breaking-changes.md
@@ -102,6 +102,7 @@ See [./ai-sdk-v6.md](./ai-sdk-v6.md) for AI SDK specific migrations:
 
 | @assistant-ui/react | react-ai-sdk | AI SDK | Zod |
 |---------------------|--------------|--------|-----|
+| 0.12.x | 1.3.x | 6.x | 4.x |
 | 0.11.x | 1.2.x | 6.x | 3.25+ or 4.x |
 | 0.10.x | 0.x | 4.x-5.x | 3.x |
 | 0.8.x-0.9.x | 0.x | 4.x | 3.x |


### PR DESCRIPTION
## Summary
- Add 0.12.x row to the version compatibility table in breaking-changes.md (react 0.12.x, react-ai-sdk 1.3.x, AI SDK 6.x, Zod 4.x)
- Add version routing entry in SKILL.md so the update skill detects `< 0.12.0` and routes to the unified state API migration
- Add full 0.12.x migration section in assistant-ui.md covering: hook renames (useAssistantApi → useAui, etc.), context hooks → unified state API, event name camelCase changes, thread().composer() invocation change, submitMode prop, Zod 4 requirement, new primitives, and @assistant-ui/core extraction

## Verification

| Check | Result |
|-------|--------|
| `npm view @assistant-ui/react version` → 0.12.14 | Confirmed |
| `npm view @assistant-ui/react-ai-sdk version` → 1.3.10 | Confirmed |
| react-ai-sdk peerDep on react → ^0.12.14 | Confirmed |
| react-ai-sdk zod dep → ^4.3.6 | Confirmed |
| Event name mappings match codemod `event-names-to-camelcase.ts` (6 mappings) | Confirmed |
| Hook renames match official migration guide `v0-12.mdx` | Confirmed |
| Context hook replacements match official guide section 2 | Confirmed |
| submitMode options match source (`"enter" \| "ctrlEnter" \| "none"`) | Confirmed |
| `thread().composer()` invocation change in CHANGELOG | Confirmed |
| New primitive versions (ChainOfThought 0.12.8, SelectionToolbar 0.12.10, Suggestion 0.12.3) match CHANGELOG | Confirmed |