### PR TITLE
feat: update skills to assistant-ui 0.14 and add 4 new skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Agent skills for building AI chat interfaces with assistant-ui",
-    "version": "0.0.1"
+    "version": "0.0.2"
   },
   "plugins": [
     {
@@ -22,7 +22,11 @@
         "./skills/streaming",
         "./skills/cloud",
         "./skills/thread-list",
-        "./skills/update"
+        "./skills/update",
+        "./skills/copilots",
+        "./skills/react-mcp",
+        "./skills/observability",
+        "./skills/markdown"
       ]
     }
   ]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ npx skills add assistant-ui/skills
 | `/cloud` | Cloud persistence and authentication |
 | `/thread-list` | Multi-thread management |
 | `/update` | Update assistant-ui and AI SDK to latest versions |
+| `/copilots` | Ground the assistant in your app (instructions, context, visible components, interactables) |
+| `/markdown` | Markdown rendering (syntax highlighting, LaTeX, Mermaid, Streamdown) |
+| `/react-mcp` | User-managed MCP server UIs (connect, OAuth, manage) |
+| `/observability` | Backend tracing and telemetry (Langfuse, LangSmith, Helicone) |
 
 ## Usage
 
@@ -36,6 +40,10 @@ After installation, use skills in Claude Code by typing `/` followed by the skil
 /cloud           # Persistence and auth
 /thread-list     # Multi-thread management
 /update          # Update assistant-ui and AI SDK versions
+/copilots        # Ground the assistant in your app
+/markdown        # Markdown rendering and customization
+/react-mcp       # User-managed MCP servers
+/observability   # Backend tracing and telemetry
 ```
 
 ## Links

--- a/assistant-ui/.claude-plugin/plugin.json
+++ b/assistant-ui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "assistant-ui",
   "description": "Skills for building AI chat interfaces with assistant-ui React library",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": {
     "name": "assistant-ui"
   },

--- a/assistant-ui/skills/assistant-ui/SKILL.md
+++ b/assistant-ui/skills/assistant-ui/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: assistant-ui
-description: Guide for assistant-ui library - AI chat UI components. Use when asking about architecture, debugging, or understanding the codebase.
-version: 0.0.1
+description: "Overview and router for assistant-ui, the React library for building AI chat interfaces from composable primitives. Use for high-level, cross-cutting, or architecture-overview questions: choosing packages, picking a runtime, or understanding the layered model (RuntimeCore, Runtime, context hooks, primitives) and message model. Covers the `@assistant-ui/react` core plus `@assistant-ui/react-ai-sdk`, `@assistant-ui/react-langgraph`, `assistant-stream`, and `assistant-cloud`; `AssistantRuntimeProvider`; the primitives `ThreadPrimitive`, `MessagePrimitive`, `ComposerPrimitive`; the hooks `useAui`, `useAuiState`, `useAuiEvent`; and runtime selection across `useChatRuntime`, `useExternalStoreRuntime`, `useLangGraphRuntime`, `useLocalRuntime`. For a specific area route to a focused sibling instead: setup, runtime, primitives, tools, streaming, cloud, thread-list, or update. Not for hands-on tasks already owned by those siblings."
 license: MIT
 ---
 
 # assistant-ui
 
-**Always consult [assistant-ui.com/llms.txt](https://assistant-ui.com/llms.txt) for latest API.**
+**Always consult [assistant-ui.com/llms.txt](https://www.assistant-ui.com/llms.txt) for the latest API.**
 
 React library for building AI chat interfaces with composable primitives.
 

--- a/assistant-ui/skills/assistant-ui/references/architecture.md
+++ b/assistant-ui/skills/assistant-ui/references/architecture.md
@@ -59,13 +59,10 @@ React hooks for accessing runtime:
 // Modern API (recommended)
 import { useAui, useAuiState, useAuiEvent } from "@assistant-ui/react";
 
-// Get API for imperative actions
 const api = useAui();
 
-// Subscribe to state changes
 const messages = useAuiState(s => s.thread.messages);
 
-// Listen to events
 useAuiEvent("composer.send", (e) => console.log(e));
 ```
 
@@ -126,7 +123,8 @@ interface ThreadAssistantMessage {
   id: string;
   role: "assistant";
   content: MessagePart[];
-  status: "running" | "complete" | "incomplete" | "requires-action";
+  // status is an object, not a string. Check status.type.
+  status: MessageStatus; // { type: "running" | "complete" | "incomplete" | "requires-action"; reason?: string }
   createdAt: Date;
 }
 

--- a/assistant-ui/skills/assistant-ui/references/packages.md
+++ b/assistant-ui/skills/assistant-ui/references/packages.md
@@ -18,6 +18,7 @@
 | @assistant-ui/store | State management |
 | @assistant-ui/react-devtools | Developer tools |
 | @assistant-ui/react-hook-form | React Hook Form integration |
+| @assistant-ui/react-mcp | User-managed MCP server tools |
 | @assistant-ui/react-a2a | Agent-to-Agent protocol for multi-agent systems |
 | @assistant-ui/react-ag-ui | AG-UI protocol adapter for agent backends |
 | @assistant-ui/cloud-ai-sdk | AI SDK hooks for assistant-cloud persistence |
@@ -34,7 +35,6 @@
 | safe-content-frame | Sandboxed iframe content |
 | tw-shimmer | Tailwind shimmer effects |
 | tw-glass | Tailwind CSS v4 glass refraction effects |
-| mcp-app-studio | MCP app builder |
 
 ## Core Packages
 
@@ -95,6 +95,7 @@ npm install @assistant-ui/react-ai-sdk @ai-sdk/react
 - `useChatRuntime` - Main hook (recommended)
 - `useAISDKRuntime` - Lower-level hook
 - `AssistantChatTransport` - Custom transport class
+- `frontendTools` - Forward frontend-registered tools to the backend route
 
 ### @assistant-ui/react-langgraph
 
@@ -147,6 +148,6 @@ npm install @assistant-ui/react-syntax-highlighter
 
 ## Version Compatibility
 
-- `@assistant-ui/react` requires React 18+ or 19
-- `@assistant-ui/react-ai-sdk` requires AI SDK v6 (`ai@^6`)
-- Node.js >=24 recommended (monorepo requirement)
+- `@assistant-ui/react` requires React 18 or 19 (`react@^18 || ^19`)
+- `@assistant-ui/react-ai-sdk` depends on AI SDK v6 (`ai@^6`), which requires `zod@^3.25.76 || ^4.1.8`
+- Node.js >=24 is only required to build the assistant-ui monorepo itself; consuming apps follow their framework's Node requirement

--- a/assistant-ui/skills/cloud/SKILL.md
+++ b/assistant-ui/skills/cloud/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: cloud
-description: Guide for assistant-cloud persistence and authorization. Use when setting up thread persistence, file uploads, or authentication.
-version: 0.0.1
+description: "Sets up assistant-ui Cloud persistence and authorization with the assistant-cloud package and AssistantCloud client. Use when adding cross-session thread/message persistence, multi-device chat history, file uploads, or auth to an assistant-ui app: passing the cloud option to useChatRuntime (with AssistantChatTransport from @assistant-ui/react-ai-sdk), configuring AssistantCloud with authToken (JWT), apiKey plus userId/workspaceId (server-side), or anonymous mode, and wiring auth providers like NextAuth, Clerk, or Firebase. Covers cloud.threads.list/get/create/update/delete, cloud.threads.messages(threadId), cloud.files.generatePresignedUploadUrl, the aui/v0 message format, custom adapters (CloudMessagePersistence, createFormattedPersistence, ThreadHistoryAdapter, RemoteThreadListAdapter), auto title generation, external_id/metadata mapping, and env vars NEXT_PUBLIC_ASSISTANT_BASE_URL and ASSISTANT_API_KEY. For the thread-list sidebar UI itself use thread-list."
 license: MIT
 ---
 
 # assistant-ui Cloud
 
-**Always consult [assistant-ui.com/llms.txt](https://assistant-ui.com/llms.txt) for latest API.**
+**Always consult [assistant-ui.com/llms.txt](https://www.assistant-ui.com/llms.txt) for the latest API.**
 
 Cloud persistence for threads, messages, and files.
 
@@ -15,6 +14,8 @@ Cloud persistence for threads, messages, and files.
 
 - [./references/persistence.md](./references/persistence.md) -- Thread and message persistence
 - [./references/authorization.md](./references/authorization.md) -- Authentication patterns
+- [./references/custom-persistence.md](./references/custom-persistence.md) -- Self-hosted message persistence
+- [./references/auth-integrations.md](./references/auth-integrations.md) -- better-auth and Clerk integrations
 
 ## Installation
 
@@ -78,16 +79,13 @@ const cloud = new AssistantCloud({
 ## Cloud API
 
 ```tsx
-// Thread operations
 const threads = await cloud.threads.list();
 await cloud.threads.create({ title: "New Chat" });
 await cloud.threads.update(threadId, { title: "Updated" });
 await cloud.threads.delete(threadId);
 
-// Message operations
 const messages = await cloud.threads.messages(threadId).list();
 
-// File uploads
 const { signedUrl, publicUrl } = await cloud.files.generatePresignedUploadUrl({
   filename: "document.pdf",
 });

--- a/assistant-ui/skills/cloud/references/auth-integrations.md
+++ b/assistant-ui/skills/cloud/references/auth-integrations.md
@@ -1,0 +1,263 @@
+# Auth Integrations
+
+Auth provider patterns beyond the bare JWT snippet: better-auth and full server-side Clerk, including 401 gating, per-user and per-org scoping, and reloading the thread list on auth transitions.
+
+## Contents
+
+- [Scope](#scope)
+- [better-auth: mount the handler](#better-auth-mount-the-handler)
+- [better-auth: gate the chat route](#better-auth-gate-the-chat-route)
+- [better-auth: scope threads by user.id](#better-auth-scope-threads-by-userid)
+- [better-auth: React client](#better-auth-react-client)
+- [better-auth: reload threads on auth](#better-auth-reload-threads-on-auth)
+- [Clerk: gate the chat route](#clerk-gate-the-chat-route)
+- [Clerk: per-user thread scoping](#clerk-per-user-thread-scoping)
+- [Clerk: per-org scoping](#clerk-per-org-scoping)
+- [Clerk: ReloadOnAuth](#clerk-reloadonauth)
+- [Pairing AssistantCloud with a backend token endpoint](#pairing-assistantcloud-with-a-backend-token-endpoint)
+- [Verify](#verify)
+
+## Scope
+
+Two paths exist for auth. With AssistantCloud, the cloud handles the JWT exchange and gives you workspace-scoped threads with no DB code (see [authorization.md](./authorization.md) for the `authToken` client snippet and direct provider integration). Without AssistantCloud, you gate your own routes and scope queries against the signed-in user's id, pairing with [custom thread persistence](./custom-persistence.md). The sections below cover the non-cloud path for better-auth and Clerk, then show how to pair AssistantCloud with a backend token endpoint when you need custom workspace logic.
+
+## better-auth: mount the handler
+
+better-auth owns the session, user table, and cookie. Its catch-all handler must be wired so sign-in, sign-out, and session refresh have somewhere to land.
+
+```ts title="app/api/auth/[...all]/route.ts"
+import { auth } from "@/auth";
+import { toNextJsHandler } from "better-auth/next-js";
+
+export const { GET, POST } = toNextJsHandler(auth);
+```
+
+## better-auth: gate the chat route
+
+Resolve the session server-side with `auth.api.getSession`. It takes the request headers (which carry the session cookie) and returns `null` for unauthenticated callers. Return 401 before calling the model so unauthenticated traffic does not burn provider credits.
+
+```ts title="app/api/chat/route.ts"
+import { auth } from "@/auth";
+import { headers } from "next/headers";
+import { openai } from "@ai-sdk/openai";
+import { streamText, convertToModelMessages } from "ai";
+import type { UIMessage } from "ai";
+
+export async function POST(req: Request) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) return new Response("Unauthorized", { status: 401 });
+
+  const { messages }: { messages: UIMessage[] } = await req.json();
+  const result = streamText({
+    model: openai("gpt-5.4-nano"),
+    messages: await convertToModelMessages(messages),
+  });
+  return result.toUIMessageStreamResponse();
+}
+```
+
+`headers()` from `next/headers` returns the active request's headers in App Router route handlers; always `await` it.
+
+## better-auth: scope threads by user.id
+
+With custom thread persistence, every thread endpoint filters by `session.user.id`. The `id` field comes from the user row better-auth manages, so no callback configuration is needed.
+
+```ts title="app/api/threads/route.ts"
+import { auth } from "@/auth";
+import { headers } from "next/headers";
+import { db } from "@/db";
+import { threads } from "@/db/schema";
+import { eq, desc } from "drizzle-orm";
+
+export async function GET() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) return new Response(null, { status: 401 });
+
+  const rows = await db
+    .select()
+    .from(threads)
+    .where(eq(threads.userId, session.user.id))
+    .orderBy(desc(threads.updatedAt));
+
+  return Response.json(rows);
+}
+```
+
+If better-auth's user schema and your threads table share a database, a foreign key from `threads` to `user.id` keeps deletes consistent.
+
+## better-auth: React client
+
+Create the client once and import it from a shared module so all hooks share state.
+
+```ts title="lib/auth-client.ts"
+import { createAuthClient } from "better-auth/react";
+
+export const authClient = createAuthClient();
+```
+
+## better-auth: reload threads on auth
+
+`useSession` from the React client tracks the live session. The first render may run before the session resolves, so drop a small effect inside `<AssistantRuntimeProvider>` that reloads the thread list once the user is signed in.
+
+```tsx title="app/components/ReloadOnAuth.tsx"
+"use client";
+
+import { useAui } from "@assistant-ui/react";
+import { authClient } from "@/lib/auth-client";
+import { useEffect } from "react";
+
+export function ReloadOnAuth() {
+  const aui = useAui();
+  const { data: session, isPending } = authClient.useSession();
+  useEffect(() => {
+    if (!isPending && session) aui.threads().reload();
+  }, [isPending, session?.user?.id]);
+  return null;
+}
+```
+
+Mount it anywhere inside your `<AssistantRuntimeProvider>` subtree (typically next to the runtime provider in `MyProvider`). `reload()` discards in-flight responses from superseded calls, so it is safe to invoke on every auth transition.
+
+## Clerk: gate the chat route
+
+Clerk's `auth()` from `@clerk/nextjs/server` runs in any Next.js server context (server components, route handlers, server actions) and returns `userId` directly. Return 401 before calling the model. This does not reproduce `clerkMiddleware`; the guide assumes `<ClerkProvider>` and `clerkMiddleware()` are already in place.
+
+```ts title="app/api/chat/route.ts"
+import { auth } from "@clerk/nextjs/server";
+import { openai } from "@ai-sdk/openai";
+import { streamText, convertToModelMessages } from "ai";
+import type { UIMessage } from "ai";
+
+export async function POST(req: Request) {
+  const { userId } = await auth();
+  if (!userId) return new Response("Unauthorized", { status: 401 });
+
+  const { messages }: { messages: UIMessage[] } = await req.json();
+  const result = streamText({
+    model: openai("gpt-5.4-nano"),
+    messages: await convertToModelMessages(messages),
+  });
+  return result.toUIMessageStreamResponse();
+}
+```
+
+## Clerk: per-user thread scoping
+
+With custom thread persistence, every thread-list endpoint filters by `userId`. Without scoping, any signed-in user can list everyone's threads.
+
+```ts title="app/api/threads/route.ts"
+import { auth } from "@clerk/nextjs/server";
+import { db } from "@/db";
+import { threads } from "@/db/schema";
+import { eq, desc } from "drizzle-orm";
+
+export async function GET() {
+  const { userId } = await auth();
+  if (!userId) return new Response(null, { status: 401 });
+
+  const rows = await db
+    .select()
+    .from(threads)
+    .where(eq(threads.userId, userId))
+    .orderBy(desc(threads.updatedAt));
+
+  return Response.json(rows);
+}
+```
+
+## Clerk: per-org scoping
+
+For organization-scoped threads (Clerk Orgs), pull `orgId` from `auth()` and add it to the where clause. The `orgId` plus `userId` combination is a stable workspace key.
+
+```ts
+import { and, eq } from "drizzle-orm";
+
+const { userId, orgId } = await auth();
+if (!userId) return new Response(null, { status: 401 });
+
+const rows = await db
+  .select()
+  .from(threads)
+  .where(
+    orgId
+      ? and(eq(threads.orgId, orgId), eq(threads.userId, userId))
+      : eq(threads.userId, userId),
+  );
+```
+
+Surface Clerk's `<OrganizationSwitcher>` (from `@clerk/nextjs`) and re-fetch threads on org change.
+
+## Clerk: ReloadOnAuth
+
+The first render of `<MyProvider>` may run before Clerk resolves the user on the client. `useUser` from `@clerk/nextjs` exposes that state; reload once the user is loaded and signed in.
+
+```tsx title="app/components/ReloadOnAuth.tsx"
+"use client";
+
+import { useAui } from "@assistant-ui/react";
+import { useUser } from "@clerk/nextjs";
+import { useEffect } from "react";
+
+export function ReloadOnAuth() {
+  const aui = useAui();
+  const { isLoaded, isSignedIn, user } = useUser();
+  useEffect(() => {
+    if (isLoaded && isSignedIn) aui.threads().reload();
+  }, [isLoaded, isSignedIn, user?.id]);
+  return null;
+}
+```
+
+Mount it inside your `<AssistantRuntimeProvider>` subtree. Because `reload()` discards superseded in-flight responses, it is safe on every transition including sign in, sign out, and organization switch.
+
+## Pairing AssistantCloud with a backend token endpoint
+
+When you want Cloud-managed threads but custom workspace logic (for example, to derive the workspace from better-auth's `session.user.id` or from Clerk's `orgId`), use the backend token endpoint instead of a direct provider integration. Resolve the user server-side, compute a `workspaceId`, mint a token with the server-side client from `assistant-cloud`, and return it.
+
+```ts title="app/api/assistant-ui-token/route.ts"
+import { AssistantCloud } from "assistant-cloud";
+import { auth } from "@clerk/nextjs/server"; // or auth.api.getSession for better-auth
+
+export const POST = async (req: Request) => {
+  const { userId, orgId } = await auth();
+  if (!userId) return new Response("Unauthorized", { status: 401 });
+
+  const workspaceId = orgId ? `${orgId}_${userId}` : userId;
+
+  const assistantCloud = new AssistantCloud({
+    apiKey: process.env.ASSISTANT_API_KEY!,
+    userId,
+    workspaceId,
+  });
+
+  const { token } = await assistantCloud.auth.tokens.create();
+  return new Response(token);
+};
+```
+
+The frontend client (from `@assistant-ui/react`) fetches that endpoint and returns the body as its `authToken`.
+
+```tsx title="app/chat/page.tsx"
+import { AssistantCloud } from "@assistant-ui/react";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+
+const cloud = new AssistantCloud({
+  baseUrl: process.env.NEXT_PUBLIC_ASSISTANT_BASE_URL!,
+  authToken: () =>
+    fetch("/api/assistant-ui-token", { method: "POST" }).then((r) => r.text()),
+});
+
+const runtime = useChatRuntime({ cloud });
+```
+
+For better-auth, swap the `auth()` call for `await auth.api.getSession({ headers: await headers() })` and read `session.user.id`. Personal chats use `userId` as the workspace; org or project apps combine ids (`orgId_userId`, `projectId_userId`).
+
+## Verify
+
+Sign in, then check:
+
+- `/api/chat` returns `200` when authenticated and `401` when not.
+- `/api/threads` returns only the current user's threads.
+- A second user (incognito tab, different account) sees a different thread list.
+- For Clerk Orgs, switching the active organization in `<OrganizationSwitcher>` triggers a reload when `orgId` is wired into the where clause.
+- The session cookie travels with same-origin fetches. If you split the API onto another host, set `credentials: "include"` and configure CORS.

--- a/assistant-ui/skills/cloud/references/authorization.md
+++ b/assistant-ui/skills/cloud/references/authorization.md
@@ -20,7 +20,6 @@ Recommended for production. Token is fetched dynamically.
 const cloud = new AssistantCloud({
   baseUrl: process.env.NEXT_PUBLIC_ASSISTANT_BASE_URL,
   authToken: async () => {
-    // Return your JWT token
     const token = await getAuthToken();
     return token;
   },
@@ -197,7 +196,6 @@ const cloud = new AssistantCloud({
     } catch (error) {
       console.error("Auth error:", error);
 
-      // Redirect to login
       window.location.href = "/login";
       return null;
     }
@@ -227,7 +225,6 @@ Implement in your backend:
 export async function DELETE(req: Request, { params }) {
   const session = await getServerSession();
 
-  // Check permissions
   const thread = await cloud.threads.get(params.id);
   if (thread.metadata.ownerId !== session.user.id) {
     if (!session.user.roles.includes("admin")) {

--- a/assistant-ui/skills/cloud/references/custom-persistence.md
+++ b/assistant-ui/skills/cloud/references/custom-persistence.md
@@ -1,0 +1,375 @@
+# Custom Persistence
+
+Self-hosted message and thread persistence without AssistantCloud, backed by your own database through `RemoteThreadListAdapter` and `ThreadHistoryAdapter`.
+
+## Contents
+
+- [How the pieces fit](#how-the-pieces-fit)
+- [The two adapters](#the-two-adapters)
+- [withFormat, the variant useChatRuntime needs](#withformat-the-variant-usechatruntime-needs)
+- [Database schema (Postgres/Drizzle)](#database-schema-postgresdrizzle)
+- [Route handlers](#route-handlers)
+- [Thread adapter with history](#thread-adapter-with-history)
+- [Runtime provider](#runtime-provider)
+- [API names](#api-names)
+
+## How the pieces fit
+
+Two adapters split the work. `RemoteThreadListAdapter` owns thread metadata (create, list, rename, archive, delete, generate title). `ThreadHistoryAdapter` owns the messages of a single thread (load on switch, append on each new message). You wire them together with `useRemoteThreadListRuntime`, passing `useChatRuntime` as the per-thread runtime hook.
+
+The storage contract is four columns per message: `id`, `parent_id`, `format`, `content`. The `parent_id` chain is what preserves branching (edits and regenerations). The `format` column records which encoder produced `content` so it can be decoded back later.
+
+Note: with `useChatRuntime` (AI SDK), the runtime always goes through `withFormat`. The top-level `load`/`append` on `ThreadHistoryAdapter` are required by the type but unused on that code path.
+
+## The two adapters
+
+```ts
+import type {
+  RemoteThreadListAdapter,
+  ThreadHistoryAdapter,
+} from "@assistant-ui/react";
+```
+
+`ThreadHistoryAdapter` shape:
+
+```ts
+interface ThreadHistoryAdapter {
+  load: () => Promise<ExportedMessageRepository & { unstable_resume?: boolean }>;
+  append: (item: ExportedMessageRepositoryItem) => Promise<void>;
+  withFormat?: <TMessage, TStorageFormat extends Record<string, unknown>>(
+    formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>,
+  ) => GenericThreadHistoryAdapter<TMessage>;
+}
+```
+
+`RemoteThreadListAdapter` shape:
+
+```ts
+interface RemoteThreadListAdapter {
+  list: (params?: RemoteThreadListPageOptions) => Promise<RemoteThreadListResponse>;
+  initialize: (threadId: string) => Promise<RemoteThreadInitializeResponse>;
+  rename: (remoteId: string, newTitle: string) => Promise<void>;
+  archive: (remoteId: string) => Promise<void>;
+  unarchive: (remoteId: string) => Promise<void>;
+  delete: (remoteId: string) => Promise<void>;
+  fetch: (threadId: string) => Promise<RemoteThreadMetadata>;
+  generateTitle: (remoteId: string, unstable_messages: readonly ThreadMessage[]) => Promise<AssistantStream>;
+  unstable_Provider?: ComponentType<PropsWithChildren>;
+}
+```
+
+`unstable_Provider` is the seam where you mount the per-thread `ThreadHistoryAdapter`, because that adapter needs access to the active thread's `remoteId`.
+
+## withFormat, the variant useChatRuntime needs
+
+`withFormat` takes a `MessageFormatAdapter` and returns a history adapter whose `load`/`append` move through the format's encode and decode. The format adapter is the bridge between a `UIMessage` and your four stored columns.
+
+```ts
+interface MessageFormatAdapter<TMessage, TStorageFormat> {
+  format: string;
+  encode: (item: MessageFormatItem<TMessage>) => TStorageFormat;
+  decode: (stored: MessageStorageEntry<TStorageFormat>) => MessageFormatItem<TMessage>;
+  getId: (message: TMessage) => string;
+}
+```
+
+You do not construct this yourself; `withFormat` receives the active `fmt` and you call its methods:
+
+- `fmt.decode({ id, parent_id, format, content })` turns a stored row back into a `UIMessage`.
+- `fmt.encode(item)` turns the appended item into the `content` you store.
+- `fmt.getId(item.message)` extracts the message id for the `id` column.
+- `fmt.format` is the format string (for example `"ai-sdk/v6"`) you write to the `format` column.
+
+## Database schema (Postgres/Drizzle)
+
+`db/schema.ts`. The four message columns `id`, `parent_id`, `format`, `content` are the contract `withFormat` writes against.
+
+```ts
+import { pgTable, text, timestamp, jsonb, index } from "drizzle-orm/pg-core";
+
+export const threads = pgTable(
+  "threads",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id").notNull(),
+    title: text("title"),
+    status: text("status", { enum: ["regular", "archived"] }).notNull().default("regular"),
+    custom: jsonb("custom").$type<Record<string, unknown>>(),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (t) => [index("threads_user_idx").on(t.userId)],
+);
+
+export const messages = pgTable(
+  "messages",
+  {
+    id: text("id").primaryKey(),
+    threadId: text("thread_id").notNull().references(() => threads.id, { onDelete: "cascade" }),
+    parentId: text("parent_id"),
+    format: text("format").notNull(),
+    content: jsonb("content").notNull(),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+  },
+  (t) => [index("messages_thread_idx").on(t.threadId)],
+);
+```
+
+## Route handlers
+
+These back the `fetch` calls the adapters make. Every handler scopes by the authenticated user so a thread id from one user cannot read another's messages.
+
+`app/api/threads/route.ts`:
+
+```ts
+import { db } from "@/db";
+import { threads } from "@/db/schema";
+import { auth } from "@/auth";
+import { desc, eq } from "drizzle-orm";
+import { generateId } from "ai";
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user) return new Response(null, { status: 401 });
+  const rows = await db.select().from(threads)
+    .where(eq(threads.userId, session.user.id))
+    .orderBy(desc(threads.updatedAt));
+  return Response.json(rows);
+}
+
+export async function POST() {
+  const session = await auth();
+  if (!session?.user) return new Response(null, { status: 401 });
+  const id = generateId();
+  await db.insert(threads).values({ id, userId: session.user.id });
+  return Response.json({ id });
+}
+```
+
+`app/api/threads/[id]/route.ts`:
+
+```ts
+import { db } from "@/db";
+import { threads } from "@/db/schema";
+import { auth } from "@/auth";
+import { and, eq } from "drizzle-orm";
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const session = await auth();
+  if (!session?.user) return new Response(null, { status: 401 });
+  const patch = (await req.json()) as { title?: string; status?: "regular" | "archived" };
+  await db.update(threads)
+    .set({ ...patch, updatedAt: new Date() })
+    .where(and(eq(threads.id, id), eq(threads.userId, session.user.id)));
+  return new Response(null, { status: 204 });
+}
+```
+
+`app/api/threads/[id]/messages/route.ts`. The POST body is exactly the `{ id, parent_id, format, content }` contract:
+
+```ts
+import { db } from "@/db";
+import { threads, messages } from "@/db/schema";
+import { auth } from "@/auth";
+import { and, asc, eq } from "drizzle-orm";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const session = await auth();
+  if (!session?.user) return new Response(null, { status: 401 });
+  const [thread] = await db.select().from(threads)
+    .where(and(eq(threads.id, id), eq(threads.userId, session.user.id)));
+  if (!thread) return new Response(null, { status: 404 });
+  const rows = await db.select().from(messages)
+    .where(eq(messages.threadId, id))
+    .orderBy(asc(messages.createdAt));
+  return Response.json(rows);
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const session = await auth();
+  if (!session?.user) return new Response(null, { status: 401 });
+  const body = (await req.json()) as {
+    id: string;
+    parent_id: string | null;
+    format: string;
+    content: Record<string, unknown>;
+  };
+  await db.insert(messages).values({
+    id: body.id,
+    threadId: id,
+    parentId: body.parent_id,
+    format: body.format,
+    content: body.content,
+  });
+  return new Response(null, { status: 204 });
+}
+```
+
+## Thread adapter with history
+
+`app/runtime/thread-adapter.tsx`. The `RemoteThreadListAdapter` maps thread rows to and from the runtime, and its `unstable_Provider` mounts the per-thread `ThreadHistoryAdapter` through `RuntimeAdapterProvider`. The history's `withFormat` is where `fmt.encode` / `fmt.decode` run against the four columns.
+
+```tsx
+"use client";
+import {
+  RuntimeAdapterProvider,
+  useAui,
+  type RemoteThreadListAdapter,
+  type ThreadHistoryAdapter,
+} from "@assistant-ui/react";
+import { createAssistantStream } from "assistant-stream";
+import { useMemo } from "react";
+
+export const threadListAdapter: RemoteThreadListAdapter = {
+  async list() {
+    const rows = await fetch("/api/threads").then((r) => r.json());
+    return {
+      threads: rows.map((t: any) => ({
+        status: t.status,
+        remoteId: t.id,
+        title: t.title ?? undefined,
+      })),
+    };
+  },
+  async initialize() {
+    const { id } = await fetch("/api/threads", { method: "POST" }).then((r) => r.json());
+    return { remoteId: id };
+  },
+  async rename(remoteId, title) {
+    await fetch(`/api/threads/${remoteId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ title }),
+    });
+  },
+  async archive(remoteId) {
+    await fetch(`/api/threads/${remoteId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ status: "archived" }),
+    });
+  },
+  async unarchive(remoteId) {
+    await fetch(`/api/threads/${remoteId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ status: "regular" }),
+    });
+  },
+  async delete(remoteId) {
+    await fetch(`/api/threads/${remoteId}`, { method: "DELETE" });
+  },
+  async fetch(remoteId) {
+    const t = await fetch(`/api/threads/${remoteId}`).then((r) => r.json());
+    return { status: t.status, remoteId: t.id, title: t.title };
+  },
+  async generateTitle(remoteId, messages) {
+    return createAssistantStream(async (controller) => {
+      const { title } = await fetch(`/api/threads/${remoteId}/title`, {
+        method: "POST",
+        body: JSON.stringify({ messages }),
+      }).then((r) => r.json());
+      controller.appendText(title);
+    });
+  },
+  unstable_Provider({ children }) {
+    const aui = useAui();
+    const history = useMemo<ThreadHistoryAdapter>(
+      () => ({
+        async load() {
+          return { messages: [] };
+        },
+        async append() {},
+        withFormat: (fmt) => ({
+          async load() {
+            const { remoteId } = aui.threadListItem().getState();
+            if (!remoteId) return { messages: [] };
+            const rows = await fetch(`/api/threads/${remoteId}/messages`).then((r) => r.json());
+            return {
+              messages: rows.map((row: any) =>
+                fmt.decode({
+                  id: row.id,
+                  parent_id: row.parent_id,
+                  format: row.format,
+                  content: row.content,
+                }),
+              ),
+            };
+          },
+          async append(item) {
+            const { remoteId } = await aui.threadListItem().initialize();
+            await fetch(`/api/threads/${remoteId}/messages`, {
+              method: "POST",
+              body: JSON.stringify({
+                id: fmt.getId(item.message),
+                parent_id: item.parentId,
+                format: fmt.format,
+                content: fmt.encode(item),
+              }),
+            });
+          },
+        }),
+      }),
+      [aui],
+    );
+    return (
+      <RuntimeAdapterProvider adapters={{ history }}>
+        {children}
+      </RuntimeAdapterProvider>
+    );
+  },
+};
+```
+
+Note: `append` awaits `aui.threadListItem().initialize()` so the thread row exists before its first message is written; `load` uses `getState()` and bails out when there is no `remoteId` yet.
+
+## Runtime provider
+
+`app/runtime/MyProvider.tsx`. `useRemoteThreadListRuntime` drives the thread list, and `runtimeHook` supplies the per-thread runtime. Because the history adapter is mounted inside `unstable_Provider`, `useChatRuntime` needs no extra wiring here.
+
+```tsx
+"use client";
+import {
+  AssistantRuntimeProvider,
+  useRemoteThreadListRuntime,
+} from "@assistant-ui/react";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import { threadListAdapter } from "./thread-adapter";
+
+export function MyProvider({ children }: { children: React.ReactNode }) {
+  const runtime = useRemoteThreadListRuntime({
+    runtimeHook: () => useChatRuntime(),
+    adapter: threadListAdapter,
+  });
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      {children}
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+## API names
+
+| Name | Purpose |
+|------|---------|
+| `RemoteThreadListAdapter` | Thread metadata: list, initialize, rename, archive, unarchive, delete, fetch, generateTitle, unstable_Provider |
+| `ThreadHistoryAdapter` | Per-thread messages: load, append, withFormat |
+| `withFormat(fmt)` | Returns a history adapter whose load/append run through `fmt`; required by `useChatRuntime` |
+| `fmt.decode({ id, parent_id, format, content })` | Stored row to `UIMessage` |
+| `fmt.encode(item)` | `UIMessage` to stored `content` |
+| `fmt.getId(item.message)` | Extracts the message id |
+| `fmt.format` | Format string written to the `format` column (for example `"ai-sdk/v6"`) |
+| `aui.threadListItem().getState()` | Reads the active thread's `remoteId` for loading |
+| `aui.threadListItem().initialize()` | Awaited before appending to ensure the thread row exists |
+| `useRemoteThreadListRuntime` | Combines the thread list adapter with a per-thread `runtimeHook` |
+| `RuntimeAdapterProvider` | Mounts `{ history }` for the active thread |

--- a/assistant-ui/skills/cloud/references/persistence.md
+++ b/assistant-ui/skills/cloud/references/persistence.md
@@ -105,7 +105,7 @@ await cloud.threads.delete(threadId);
 
 ```tsx
 const messages = await cloud.threads.messages(threadId).list({
-  format: "aui/v0",  // Message format
+  format: "aui/v0",
 });
 
 // messages: Array<{
@@ -166,22 +166,21 @@ type MessagePart =
     };
 ```
 
-## Thread History Adapter
+## Custom Persistence Adapters
 
-For custom persistence with useLocalRuntime:
+The simplest persistence is passing `cloud` to the runtime (see Basic Setup above). For full control over storage, assistant-ui exposes adapter interfaces (from `@assistant-ui/react`):
+
+- `ThreadHistoryAdapter` owns the messages of a single thread.
+- `RemoteThreadListAdapter` owns the list of threads (create, rename, archive, delete).
+
+To back those adapters with assistant-cloud rather than your own database, use `CloudMessagePersistence` or `createFormattedPersistence` from `assistant-cloud`:
 
 ```tsx
-import { AssistantCloudThreadHistoryAdapter } from "assistant-cloud";
-
-const historyAdapter = new AssistantCloudThreadHistoryAdapter(cloud, threadId);
-
-const runtime = useLocalRuntime({
-  model: myModel,
-  adapters: {
-    threadHistory: historyAdapter,
-  },
-});
+import { CloudMessagePersistence, createFormattedPersistence } from "assistant-cloud";
 ```
+
+For a database-backed example, see the custom thread persistence guide at
+[assistant-ui.com/docs/integrations/persistence/custom-adapter](https://www.assistant-ui.com/docs/integrations/persistence/custom-adapter).
 
 ## Auto-Save Behavior
 
@@ -209,12 +208,10 @@ The cloud backend uses the conversation to generate a concise title.
 Link threads to your system:
 
 ```tsx
-// Create with external ID
 await cloud.threads.create({
   external_id: "your-system-id-123",
 });
 
-// Find by external ID
 const threads = await cloud.threads.list();
 const thread = threads.find(t => t.external_id === "your-system-id-123");
 ```
@@ -233,7 +230,6 @@ await cloud.threads.create({
   },
 });
 
-// Update metadata
 await cloud.threads.update(threadId, {
   metadata: { resolved: true },
 });

--- a/assistant-ui/skills/copilots/SKILL.md
+++ b/assistant-ui/skills/copilots/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: copilots
+description: "Grounding an assistant in your app with assistant-ui copilots (@assistant-ui/react). Use when steering assistant behavior with useAssistantInstructions, feeding lazy app-state context via useAssistantContext({ getContext }), exposing rendered components with makeAssistantVisible(Component, { clickable, editable }), building two-way interactable state with useAssistantInteractable and Interactables(), or registering instructions and tools imperatively through useAui().modelContext().register({ getModelContext }). Reach for this when the assistant should read the current page, click or edit UI, or read and update component state through auto-generated update_{name} tools. For LLM tools and tool-call UI use the tools skill; for runtime and thread state use the runtime skill."
+license: MIT
+---
+
+# assistant-ui Copilots
+
+**Always consult [assistant-ui.com/llms.txt](https://www.assistant-ui.com/llms.txt) for the latest API.**
+
+Copilots ground an assistant in your running app: steer it with instructions, feed it lazy app state, let it read rendered components, click and edit UI, and read or update persistent interactable state.
+
+## References
+
+- [./references/instructions.md](./references/instructions.md) -- useAssistantInstructions
+- [./references/model-context.md](./references/model-context.md) -- useAssistantContext and imperative modelContext().register
+- [./references/visible.md](./references/visible.md) -- makeAssistantVisible
+- [./references/interactables.md](./references/interactables.md) -- interactable components
+
+## Orientation
+
+All APIs ship from `@assistant-ui/react` and run inside `AssistantRuntimeProvider`. Pick the smallest tool for the job:
+
+```
+What do you need the assistant to know or do?
+├─ Steer behavior with a system prompt → useAssistantInstructions("...")
+├─ Feed read-only app state (page, selection, cart) → useAssistantContext({ getContext })
+├─ Let it read / click / edit a rendered component → makeAssistantVisible(Component, { clickable, editable })
+├─ Read AND write persistent component state via tools → useAssistantInteractable(name, config)
+└─ Register instructions + tools together imperatively → useAui().modelContext().register({ getModelContext })
+```
+
+Instructions and context are the lightweight starting point. Reach for `makeAssistantVisible` when the assistant needs to perceive or drive existing DOM, and for interactables when it needs structured two-way state it can mutate through auto-generated `update_{name}` tools.
+
+```tsx
+import { useAssistantInstructions, useAssistantContext } from "@assistant-ui/react";
+
+function CheckoutCopilot() {
+  useAssistantInstructions("You help users complete checkout. Be concise.");
+  useAssistantContext({ getContext: () => `Current page: ${window.location.href}` });
+  return null;
+}
+```
+
+`getContext` is evaluated fresh each time the model context is read, so it always reflects current state. Register imperatively when you need instructions and tools in one provider:
+
+```tsx
+import { useAui, tool } from "@assistant-ui/react";
+import { useEffect } from "react";
+
+function SearchCopilot() {
+  const aui = useAui();
+  useEffect(() => {
+    return aui.modelContext().register({
+      getModelContext: () => ({
+        system: "You are a helpful search assistant.",
+        tools: { search: mySearchTool },
+      }),
+    });
+  }, [aui]);
+  return null;
+}
+```
+
+`register` returns an unsubscribe function; returning it from `useEffect` cleans up the provider on unmount. Multiple providers compose: `system` strings concatenate and `tools` maps merge.
+
+## Common Gotchas
+
+**Assistant ignores instructions or context**
+- The hook or `register` call must run inside `AssistantRuntimeProvider`.
+- For `useAui().modelContext().register`, call it in `useEffect` and return the result so it unsubscribes; registering in render leaks providers.
+
+**Context is stale**
+- Use the `getContext` callback form, not a captured value. It is re-read at send time, so closures over fresh state work; a precomputed string will not update.
+
+**makeAssistantVisible does nothing**
+- Without options the component is read-only (exposes its `outerHTML`). Pass `{ clickable: true }` to allow clicks and `{ editable: true }` for `<input>` / `<textarea>` editing. Nested visible components expose only the outermost.
+
+**Interactable resets its state on every render**
+- Define `stateSchema` and `initialState` outside the component (or memoize). A new schema each render re-registers the interactable and wipes its state. Register the scope with `useAui({ interactables: Interactables() })`.
+
+**Partial updates drop fields**
+- The AI sends only the fields it changes and the merge is shallow (one level deep); nested objects are replaced, not deep-merged.
+
+## Related Skills
+
+- **tools** -- frontend and backend tools and custom tool-call UI (`makeAssistantTool`, `useAssistantTool`, `makeAssistantToolUI`).
+- **runtime** -- runtime creation, `AssistantRuntimeProvider`, and reading or mutating thread state (`useAui`, `useAuiState`, `useAuiEvent`).

--- a/assistant-ui/skills/copilots/references/instructions.md
+++ b/assistant-ui/skills/copilots/references/instructions.md
@@ -1,0 +1,146 @@
+# useAssistantInstructions
+
+Register system instructions that guide assistant behavior from any component inside the runtime.
+
+## Basic usage
+
+`useAssistantInstructions` accepts a plain string. Instructions register into the model context on mount, update when the string changes, and unregister on unmount.
+
+```tsx
+import { useAssistantInstructions } from "@assistant-ui/react";
+
+function SupportChat() {
+  useAssistantInstructions("You are a customer support assistant. Be concise and cite docs.");
+  return <Thread />;
+}
+```
+
+## Config object
+
+Pass an object to control registration. `disabled: true` skips registering without conditionally calling the hook.
+
+```tsx
+useAssistantInstructions({
+  instruction: "You are a helpful form assistant.",
+  disabled: false,
+});
+```
+
+## Conditional instructions
+
+Toggle instructions with `disabled` instead of wrapping the hook in a condition (hooks must run unconditionally).
+
+```tsx
+function ModeAwareChat({ adminMode }: { adminMode: boolean }) {
+  useAssistantInstructions({
+    instruction: "You may run destructive operations when the user confirms.",
+    disabled: !adminMode,
+  });
+  return <Thread />;
+}
+```
+
+## Multiline instructions
+
+Use a template literal for structured guidance.
+
+```tsx
+function SmartForm() {
+  useAssistantInstructions({
+    instruction: `You are a form assistant that:
+- Validates user input
+- Provides helpful suggestions
+- Never submits without confirmation`,
+  });
+  return <form></form>;
+}
+```
+
+## React state in instructions
+
+The string can interpolate component state; changing it re-registers automatically.
+
+```tsx
+function Assistant({ userName }: { userName: string }) {
+  useAssistantInstructions(`Address the user as ${userName}.`);
+  return <Thread />;
+}
+```
+
+## Dynamic context at send-time
+
+`useAssistantInstructions` re-registers whenever its value changes. For values that should be read fresh on every run without re-registration, use `useAssistantContext`, whose `getContext` callback is evaluated each time the model context is read and returns the system string directly.
+
+```tsx
+import { useAssistantContext } from "@assistant-ui/react";
+
+function CartContext({ cart }: { cart: Cart }) {
+  useAssistantContext({
+    getContext: () => `Cart total: ${cart.total}. Items: ${cart.items.length}.`,
+  });
+  return null;
+}
+```
+
+## Composition
+
+Instructions are additive. When several components register instructions, the system strings are concatenated and any registered tool sets are merged, so you can colocate guidance with the feature it describes.
+
+```tsx
+function App() {
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <GlobalInstructions />  {/* "You are a helpful assistant." */}
+      <CheckoutInstructions /> {/* "When checking out, confirm the address." */}
+      <Thread />
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+## With tools and visible components
+
+Instructions pair with `makeAssistantTool` (browser tools) and `makeAssistantVisible` (component context) to describe how the assistant should use them.
+
+```tsx
+import { makeAssistantTool, useAssistantInstructions, tool } from "@assistant-ui/react";
+import { z } from "zod";
+
+const SubmitFormTool = makeAssistantTool({
+  ...tool({
+    parameters: z.object({ email: z.string() }),
+    execute: async ({ email }) => submitForm(email),
+  }),
+  toolName: "submitForm",
+});
+
+function FormCopilot() {
+  useAssistantInstructions("Help the user fill the form, then call submitForm.");
+  return (
+    <>
+      <SubmitFormTool />
+      <Thread />
+    </>
+  );
+}
+```
+
+## Low-level registration
+
+`useAssistantInstructions` is a thin wrapper over the model context API. Register `system` directly via `useAui` when you need to combine instructions, tools, and cleanup yourself.
+
+```tsx
+import { useAui } from "@assistant-ui/react";
+
+function Provider() {
+  const aui = useAui();
+  useEffect(() => {
+    return aui.modelContext().register({
+      getModelContext: () => ({ system: "You are a search assistant." }),
+    });
+  }, [aui]);
+  return null;
+}
+```
+
+Note: the value returned from `register` is the cleanup function; call it (or return it from `useEffect`) to unregister.

--- a/assistant-ui/skills/copilots/references/interactables.md
+++ b/assistant-ui/skills/copilots/references/interactables.md
@@ -1,0 +1,314 @@
+# Interactables
+
+Persistent UI components whose state the AI can read and update through auto-generated tools.
+
+## Contents
+
+- [Overview](#overview)
+- [Register the scope](#register-the-scope)
+- [useAssistantInteractable](#useassistantinteractable)
+- [useInteractableState](#useinteractablestate)
+- [Auto-generated update tools](#auto-generated-update-tools)
+- [Multiple instances](#multiple-instances)
+- [Selection](#selection)
+- [Streaming updates](#streaming-updates)
+- [Persistence](#persistence)
+- [Export and import](#export-and-import)
+- [Schema evolution](#schema-evolution)
+
+## Overview
+
+An interactable is a React component with state that is shared between the user and the AI. State persists across messages, supports partial updates, and the framework auto-registers a tool so the model can change it. Unlike a tool UI (which only renders a tool call), an interactable lives anywhere in your app and stays mounted across turns.
+
+All APIs come from `@assistant-ui/react`.
+
+```tsx
+import {
+  useAui,
+  useAuiState,
+  Interactables,
+  AssistantRuntimeProvider,
+  useAssistantInteractable,
+  useInteractableState,
+} from "@assistant-ui/react";
+```
+
+## Register the scope
+
+Add the `Interactables()` scope to the runtime via `useAui`, then pass the result to `AssistantRuntimeProvider`.
+
+```tsx
+function MyRuntimeProvider({ children }: { children: React.ReactNode }) {
+  const aui = useAui({
+    interactables: Interactables(),
+  });
+
+  return (
+    <AssistantRuntimeProvider aui={aui} runtime={runtime}>
+      {children}
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+Combine with other scopes such as tools:
+
+```tsx
+const aui = useAui({
+  tools: Tools({ toolkit: myToolkit }),
+  interactables: Interactables(),
+});
+```
+
+The interactable component can live anywhere inside the provider, including outside the chat panel.
+
+```tsx
+function App() {
+  return (
+    <MyRuntimeProvider>
+      <div className="flex">
+        <Thread className="flex-1" />
+        <TaskBoard />
+      </div>
+    </MyRuntimeProvider>
+  );
+}
+```
+
+## useAssistantInteractable
+
+Registers an interactable and returns its instance `id`. Define `stateSchema` and `initialState` outside the component (or memoize them); new object identities on every render trigger re-registration and reset state.
+
+```tsx
+import { z } from "zod";
+
+const taskBoardSchema = z.object({
+  tasks: z.array(
+    z.object({ id: z.string(), title: z.string(), done: z.boolean() }),
+  ),
+});
+
+const taskBoardInitialState = { tasks: [] };
+
+function TaskBoard() {
+  const id = useAssistantInteractable("taskBoard", {
+    description: "A task board showing the user's tasks",
+    stateSchema: taskBoardSchema,
+    initialState: taskBoardInitialState,
+  });
+
+  // ...
+}
+```
+
+Config fields:
+
+```ts
+interface InteractableConfig {
+  description: string;                  // Shown to the AI
+  stateSchema: StandardSchemaV1;        // Zod schema or JSON Schema
+  initialState: unknown;
+  id?: string;                          // Auto-generated if omitted
+  selected?: boolean;                   // Mark as focused at registration time
+}
+```
+
+The first argument (`name`) feeds the auto-generated tool name and is referenced in the system prompt.
+
+## useInteractableState
+
+Reads and writes the state of a registered interactable. The setter behaves like `useState`, accepting a value or an updater function. Pass a `fallback` used before registration completes.
+
+```tsx
+function TaskBoard() {
+  const id = useAssistantInteractable("taskBoard", {
+    description: "A task board showing the user's tasks",
+    stateSchema: taskBoardSchema,
+    initialState: taskBoardInitialState,
+  });
+
+  const [state, { setState }] = useInteractableState(id, taskBoardInitialState);
+
+  return (
+    <ul>
+      {state.tasks.map((task) => (
+        <li key={task.id}>
+          <label>
+            <input
+              type="checkbox"
+              checked={task.done}
+              onChange={() =>
+                setState((prev) => ({
+                  tasks: prev.tasks.map((t) =>
+                    t.id === task.id ? { ...t, done: !t.done } : t,
+                  ),
+                }))
+              }
+            />
+            {task.title}
+          </label>
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+The second tuple element exposes the full control surface:
+
+```ts
+const [state, { setState, setSelected, isPending, error, flush }] =
+  useInteractableState(id, fallback);
+```
+
+- `setState(value | (prev) => next)`: update state; the new value is also sent to the model context for the next turn.
+- `setSelected(boolean)`: mark this interactable as the focused one.
+- `isPending`: `true` while a persistence save is in flight.
+- `error`: error from the last failed save.
+- `flush()`: force an immediate persistence save, returns a promise.
+
+User `setState` calls and AI tool calls write to the same state, so the UI and model stay in sync bidirectionally.
+
+## Auto-generated update tools
+
+For each registered interactable the framework generates a frontend tool the AI calls to mutate state.
+
+- One instance of a name: tool is `update_{name}` (for example `update_taskBoard`).
+- Multiple instances of a name: tools are `update_{name}_{id}` (for example `update_note_note-1`).
+
+The tool uses a partial version of `stateSchema`: every field becomes optional, so the model sends only what it changes.
+
+```ts
+// Current state: { title: "My Note", content: "Hello", color: "yellow" }
+// AI calls:
+update_note({ color: "blue" });
+// Result: { title: "My Note", content: "Hello", color: "blue" }
+```
+
+Note: the merge is shallow (one level). Nested objects are replaced, not deep-merged.
+
+## Multiple instances
+
+Reuse the same `name` with distinct `id`s. Each instance gets its own tool.
+
+```tsx
+const noteSchema = z.object({
+  title: z.string(),
+  content: z.string(),
+  color: z.enum(["yellow", "blue", "green", "pink"]),
+});
+
+const noteInitialState = {
+  title: "New Note",
+  content: "",
+  color: "yellow" as const,
+};
+
+function NoteCard({ noteId }: { noteId: string }) {
+  useAssistantInteractable("note", {
+    id: noteId,
+    description: "A sticky note",
+    stateSchema: noteSchema,
+    initialState: noteInitialState,
+  });
+
+  const [state] = useInteractableState(noteId, noteInitialState);
+  return <div>{state.title}</div>;
+}
+
+function Notes() {
+  return (
+    <>
+      <NoteCard noteId="note-1" /> {/* update_note_note-1 */}
+      <NoteCard noteId="note-2" /> {/* update_note_note-2 */}
+    </>
+  );
+}
+```
+
+When a component unmounts, its tool is removed from the AI's list but its state is preserved in the scope. Remounting with the same `name` and `id` restores the preserved state instead of resetting to `initialState`, which handles Strict Mode double-mounts and tab switches.
+
+## Selection
+
+Marking an interactable selected tells the model to prioritize it; the AI sees `(SELECTED)` next to it in the system prompt.
+
+```tsx
+function NoteCard({ noteId }: { noteId: string }) {
+  const [state, { setSelected }] = useInteractableState(noteId, noteInitialState);
+
+  return (
+    <div onClick={() => setSelected(true)}>
+      {state.title}
+    </div>
+  );
+}
+```
+
+Selection can also be set at registration with `config.selected: true`.
+
+## Streaming updates
+
+State updates progressively as the AI streams tool arguments, so fields appear one at a time. Detect an in-progress run with `useAuiState` to show skeleton UI.
+
+```tsx
+function TaskBoard() {
+  const id = useAssistantInteractable("taskBoard", {
+    description: "A task board",
+    stateSchema: taskBoardSchema,
+    initialState: taskBoardInitialState,
+  });
+  const [state] = useInteractableState(id, taskBoardInitialState);
+
+  const isRunning = useAuiState((s) => s.thread.isRunning);
+  const isLoading = isRunning && state.tasks.length === 0;
+
+  if (isLoading) return <Skeleton />;
+  return <TaskList tasks={state.tasks} />;
+}
+```
+
+## Persistence
+
+State is in-memory by default. Register a persistence adapter on the scope to save it; importing previously saved state rehydrates the interactables.
+
+```tsx
+function PersistenceSetup() {
+  const aui = useAui();
+
+  useEffect(() => {
+    aui.interactables().setPersistenceAdapter({
+      save: async (state) => {
+        localStorage.setItem("interactables", JSON.stringify(state));
+      },
+    });
+
+    const saved = localStorage.getItem("interactables");
+    if (saved) {
+      aui.interactables().importState(JSON.parse(saved));
+    }
+  }, [aui]);
+
+  return null;
+}
+```
+
+- State changes are debounced 500ms before `save` is called.
+- A pending save is flushed immediately when a component unregisters.
+- `isPending`, `error`, and `flush()` from `useInteractableState` expose sync status to the UI.
+
+## Export and import
+
+Read or replace the full snapshot directly through the scope.
+
+```tsx
+const aui = useAui();
+
+const snapshot = aui.interactables().exportState();
+// => { "note-1": { name: "note", state: { title: "Hello" } }, ... }
+
+aui.interactables().importState(snapshot);
+```
+
+## Schema evolution
+
+Changing a `stateSchema` after persisting state can cause silent mismatches when old data is imported. Mitigate by versioning the storage key (for example `taskBoard_v2`), namespacing by a schema hash on breaking changes, or running a migration step inside your `importState` call.

--- a/assistant-ui/skills/copilots/references/model-context.md
+++ b/assistant-ui/skills/copilots/references/model-context.md
@@ -1,0 +1,232 @@
+# Model Context
+
+Provide instructions, tools, and lazy app state to the assistant. Multiple providers compose: system strings concatenate, tool sets merge.
+
+## Contents
+
+- [useAssistantContext](#useassistantcontext) (lazy send-time string state)
+- [useAssistantInstructions](#useassistantinstructions) (static instructions)
+- [Imperative register](#imperative-register) (useAui().modelContext().register)
+- [Provider shape](#provider-shape) (getModelContext return)
+- [ModelContextRegistry](#modelcontextregistry) (standalone addTool / addInstruction / addProvider)
+- [Handles](#handles) (update() and remove())
+- [Composition](#composition) (how providers merge)
+
+## useAssistantContext
+
+`getContext` is a callback evaluated fresh each time the model context is read (at send-time), so frequently-changing app state never triggers a re-registration.
+
+```tsx
+import { useAssistantContext } from "@assistant-ui/react";
+
+function PageContext() {
+  useAssistantContext({
+    getContext: () => `Current page: ${window.location.href}`,
+  });
+  return null;
+}
+```
+
+Config shape:
+
+```ts
+interface AssistantContextConfig {
+  getContext: () => string;
+  disabled?: boolean; // gate registration dynamically
+}
+```
+
+## useAssistantInstructions
+
+Takes a static string (or config). Re-registers when the value changes, so prefer it for stable, explicit instructions.
+
+```tsx
+import { useAssistantInstructions } from "@assistant-ui/react";
+
+function Setup() {
+  useAssistantInstructions("You are a helpful assistant...");
+  return null;
+}
+```
+
+## Imperative register
+
+`useAui().modelContext().register(provider)` returns an unsubscribe function. Register inside `useEffect` and return the result so the provider is cleaned up on unmount.
+
+```tsx
+import { useAui, tool } from "@assistant-ui/react";
+import { useEffect } from "react";
+import { z } from "zod";
+
+// Define tool outside the component (no runtime dependencies)
+const myTool = tool({
+  parameters: z.object({ query: z.string() }),
+  execute: async ({ query }) => {
+    const result = await searchDatabase(query);
+    return { result };
+  },
+});
+
+function MyComponent() {
+  const aui = useAui();
+  useEffect(() => {
+    return aui.modelContext().register({
+      getModelContext: () => ({
+        system: "You are a helpful search assistant...",
+        tools: { myTool },
+      }),
+    });
+  }, [aui]);
+
+  return <div></div>;
+}
+```
+
+Because `getModelContext` runs at send-time, you can close over changing props or state. Re-register only when the closed-over identity must change.
+
+```tsx
+function SmartHistory({ userProfile }) {
+  const aui = useAui();
+  useEffect(() => {
+    return aui.modelContext().register({
+      getModelContext: () => ({
+        system: `User spending patterns:
+- Average transaction: ${userProfile.avgTransaction}
+- Common merchants: ${userProfile.frequentMerchants.join(", ")}`,
+      }),
+    });
+  }, [aui, userProfile]);
+  return null;
+}
+```
+
+## Provider shape
+
+A provider is `{ getModelContext, subscribe? }`. `getModelContext` returns a `ModelContext` (`system`, `tools`, `config`, ...). `subscribe` lets the runtime react to external changes without re-registering.
+
+```ts
+interface ModelContextProvider {
+  getModelContext: () => ModelContext;
+  subscribe?: (callback: () => void) => Unsubscribe;
+}
+```
+
+Minimal provider that injects model config:
+
+```tsx
+useEffect(() => {
+  const config = { config: { modelName } };
+  return aui.modelContext().register({
+    getModelContext: () => config,
+  });
+}, [aui, modelName]);
+```
+
+## ModelContextRegistry
+
+A standalone registry instance (not tied to React) that manages tools, instructions, and nested providers. Useful outside a component tree (for example, building context in an iframe to expose to a parent assistant).
+
+```ts
+import { ModelContextRegistry } from "@assistant-ui/react";
+
+const registry = new ModelContextRegistry();
+```
+
+Registry interface (all members optional on the type):
+
+```ts
+interface ModelContextRegistry {
+  getModelContext?: () => ModelContext;
+  subscribe?: (callback: () => void) => Unsubscribe;
+  addTool?: (tool: AssistantToolProps) => ModelContextRegistryToolHandle;
+  addInstruction?: (
+    config: string | AssistantInstructionsConfig,
+  ) => ModelContextRegistryInstructionHandle;
+  addProvider?: (
+    provider: ModelContextProvider,
+  ) => ModelContextRegistryProviderHandle;
+}
+```
+
+### addTool
+
+```ts
+import { z } from "zod";
+
+const handle = registry.addTool({
+  toolName: "searchProducts",
+  description: "Search for products in the catalog",
+  parameters: z.object({
+    query: z.string(),
+    category: z.string().optional(),
+  }),
+  execute: async ({ query, category }) => {
+    const results = await searchAPI(query, category);
+    return { products: results };
+  },
+});
+```
+
+### addInstruction
+
+```ts
+const instruction = registry.addInstruction("You are a helpful assistant.");
+```
+
+### addProvider
+
+Compose another provider (or registry's `getModelContext`/`subscribe`) into this one.
+
+```ts
+const providerHandle = registry.addProvider({
+  getModelContext: () => ({ system: "Be concise." }),
+});
+```
+
+## Handles
+
+`addTool` / `addInstruction` / `addProvider` each return a handle with `update(...)` and `remove()`. Use them to mutate or tear down a single contribution.
+
+```ts
+const toolHandle = registry.addTool({
+  toolName: "convertCurrency",
+  description: "Convert between currencies",
+  parameters: z.object({ amount: z.number(), from: z.string(), to: z.string() }),
+  execute: async ({ amount, from, to }) => {
+    const rate = await fetchExchangeRate(from, to);
+    return { result: amount * rate, currency: to };
+  },
+});
+
+toolHandle.update({
+  toolName: "convertCurrency",
+  description: "Convert between currencies with live rates",
+  parameters: z.object({ amount: z.number(), from: z.string(), to: z.string() }),
+  execute: async ({ amount, from, to }) => {
+    const rate = await fetchExchangeRate(from, to);
+    return { result: amount * rate, currency: to };
+  },
+});
+
+toolHandle.remove();
+```
+
+Instruction handles work the same way:
+
+```ts
+const instruction = registry.addInstruction("You are a helpful assistant.");
+instruction.update("You have access to a product catalog search tool.");
+instruction.remove();
+```
+
+Note: the React hooks (`useAssistantContext`, `useAssistantInstructions`) and `register()` clean up automatically. Call `handle.remove()` only when managing a `ModelContextRegistry` yourself.
+
+## Composition
+
+Registered providers compose rather than override:
+
+- System instructions are concatenated.
+- Tool sets are merged.
+- Nested readable components only contribute their context at the outermost level.
+
+Keep each provider focused on one component's purpose and register inside `useEffect` so removal happens on unmount.

--- a/assistant-ui/skills/copilots/references/visible.md
+++ b/assistant-ui/skills/copilots/references/visible.md
@@ -1,0 +1,141 @@
+# makeAssistantVisible
+
+Higher-order component that exposes a component's rendered HTML to the assistant and optionally lets it click or edit the component.
+
+## Contents
+
+- [makeAssistantVisible](#makeassistantvisible)
+- [Config](#config)
+- [Clickable](#clickable)
+- [Editable](#editable)
+- [Nesting](#nesting)
+- [Combining with instructions](#combining-with-instructions)
+- [Notes](#notes)
+
+## makeAssistantVisible
+
+Wrap a component to make its `outerHTML` available as system context. The assistant can read the live HTML structure of whatever the wrapped component renders.
+
+```tsx
+import { makeAssistantVisible } from "@assistant-ui/react";
+
+const Button = ({ onClick, children }) => (
+  <button onClick={onClick}>{children}</button>
+);
+
+const ReadableButton = makeAssistantVisible(Button);
+```
+
+The returned component forwards all props and refs, so it is a drop-in replacement for the original.
+
+## Config
+
+Second argument is an optional config object. Both flags default to false.
+
+```tsx
+makeAssistantVisible(Component, {
+  clickable?: boolean,  // register a `click` tool for this component
+  editable?:  boolean,  // register an `edit` tool for an input/textarea inside it
+});
+```
+
+```tsx
+const ClickableButton = makeAssistantVisible(Button, { clickable: true });
+
+const EditableInput = makeAssistantVisible(Input, { editable: true });
+```
+
+## Clickable
+
+`clickable: true` stamps a unique `data-click-id` on the wrapped component and registers a `click` tool. The tool resolves `[data-click-id='...']` via `querySelector` and calls `.click()` on the element.
+
+```tsx
+const SmartButton = makeAssistantVisible(
+  ({ onClick, children }) => <button onClick={onClick}>{children}</button>,
+  { clickable: true },
+);
+
+function TransactionHistory({ transactions }) {
+  return (
+    <div className="transaction-list">
+      {transactions.map((t) => (
+        <div key={t.id} className="transaction-item">
+          <span>${t.amount}</span>
+          <span>{t.merchant}</span>
+          <SmartButton onClick={() => handleRefund(t.id)}>
+            Request Refund
+          </SmartButton>
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+Note: the click tool waits 2 seconds after clicking before resolving, so the assistant observes any resulting DOM changes on its next read.
+
+## Editable
+
+`editable: true` stamps a `data-edit-id` and registers an `edit` tool taking `editId` and `value`. The tool finds an `<input>` or `<textarea>` inside the component, sets `.value`, then dispatches bubbling `input` and `change` events so React state updates.
+
+```tsx
+const Input = ({ label, ...props }) => (
+  <div>
+    <label>{label}</label>
+    <input {...props} />
+  </div>
+);
+
+const EditableInput = makeAssistantVisible(Input, { editable: true });
+
+function Form() {
+  return (
+    <EditableInput label="Email" type="email" placeholder="Enter your email" />
+  );
+}
+```
+
+If the element under `data-edit-id` is not an `<input>` or `<textarea>`, the tool returns `"Element not found"`.
+
+## Nesting
+
+Visible components can be nested. Only the outermost wrapper contributes its `outerHTML` to the system context; nested `makeAssistantVisible` wrappers suppress their own HTML to avoid duplication. Click and edit tools from nested components stay registered regardless.
+
+```tsx
+const VisibleCard = makeAssistantVisible(Card);
+const VisibleRow = makeAssistantVisible(Row, { clickable: true });
+
+// Only VisibleCard's HTML is sent; VisibleRow rows are still clickable
+<VisibleCard>
+  {rows.map((r) => (
+    <VisibleRow key={r.id} onClick={() => select(r.id)} />
+  ))}
+</VisibleCard>;
+```
+
+## Combining with instructions
+
+Visible HTML tells the assistant what is on screen; pair it with `useAssistantInstructions` so it knows how to act on what it sees.
+
+```tsx
+import {
+  makeAssistantVisible,
+  useAssistantInstructions,
+} from "@assistant-ui/react";
+
+const VisibleForm = makeAssistantVisible(CheckoutForm, { editable: true });
+
+function Checkout() {
+  useAssistantInstructions(
+    "Help the user fill out the checkout form. Read the form HTML, then use the edit tool to set field values.",
+  );
+
+  return <VisibleForm />;
+}
+```
+
+## Notes
+
+- Context registration runs in an effect, so HTML is captured from the mounted DOM (`componentRef.current?.outerHTML`); it reflects the current render, not stale markup.
+- The wrapped type is preserved (`displayName` is copied), so the result composes like the original component in JSX.
+- Clickable/editable rely on browser APIs (`document.querySelector`, `CSS.escape`, DOM events), so the tools only run client-side.

--- a/assistant-ui/skills/markdown/SKILL.md
+++ b/assistant-ui/skills/markdown/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: markdown
+description: "Render and customize assistant message text as markdown in assistant-ui. Use when displaying model output as formatted markdown with MarkdownTextPrimitive from @assistant-ui/react-markdown wired into the MessagePrimitive.Parts text branch, configuring remarkPlugins (remark-gfm, remark-math) and rehypePlugins (rehype-katex), or memoizing components with unstable_memoizeMarkdownComponents. Covers code-block syntax highlighting via react-shiki or react-syntax-highlighter registered as SyntaxHighlighter in components/componentsByLanguage, LaTeX math rendering with KaTeX, Mermaid diagrams gated on stream completion, custom math delimiters via preprocess, and the StreamdownTextPrimitive alternative from @assistant-ui/react-streamdown with built-in Shiki/KaTeX/Mermaid and block streaming. For general chat UI composition route to primitives."
+license: MIT
+---
+
+# assistant-ui Markdown
+
+**Always consult [assistant-ui.com/llms.txt](https://www.assistant-ui.com/llms.txt) for the latest API.**
+
+Render and customize assistant message text as markdown with `MarkdownTextPrimitive` from `@assistant-ui/react-markdown`, wired into the `MessagePrimitive.Parts` text branch.
+
+## References
+
+- [./references/markdown-text.md](./references/markdown-text.md) -- MarkdownTextPrimitive setup
+- [./references/syntax-highlighting.md](./references/syntax-highlighting.md) -- code highlighting (react-shiki / react-syntax-highlighter)
+- [./references/latex-mermaid.md](./references/latex-mermaid.md) -- LaTeX and Mermaid
+- [./references/streamdown.md](./references/streamdown.md) -- StreamdownTextPrimitive alternative
+
+## Orientation
+
+`MarkdownTextPrimitive` renders one text part as markdown. The registry component (`npx assistant-ui@latest add markdown-text`) generates `components/assistant-ui/markdown-text.tsx`, which exports a memoized `MarkdownText` built on the primitive plus a `defaultComponents` map from `unstable_memoizeMarkdownComponents`. Render `MarkdownText` from the `text` branch of `MessagePrimitive.Parts`.
+
+```tsx
+import "@assistant-ui/react-markdown/styles/dot.css";
+import { MarkdownTextPrimitive } from "@assistant-ui/react-markdown";
+import { MessagePrimitive } from "@assistant-ui/react";
+import remarkGfm from "remark-gfm";
+import { memo } from "react";
+
+const MarkdownTextImpl = () => (
+  <MarkdownTextPrimitive
+    remarkPlugins={[remarkGfm]}
+    className="aui-md"
+    components={defaultComponents}
+  />
+);
+
+export const MarkdownText = memo(MarkdownTextImpl);
+
+<MessagePrimitive.Parts>
+  {({ part }) => (part.type === "text" ? <MarkdownText /> : null)}
+</MessagePrimitive.Parts>;
+```
+
+Add highlighting, math, or diagrams by extending the same primitive: `rehypePlugins` for KaTeX, `componentsByLanguage` for a per-language `SyntaxHighlighter` (Mermaid, diff), and `preprocess` to normalize raw text before parsing. See the references for each. For a batteries-included alternative with built-in Shiki, KaTeX, Mermaid, and block streaming, swap in `StreamdownTextPrimitive` from `@assistant-ui/react-streamdown`.
+
+## Common Gotchas
+
+- **Nothing renders / plain text shows.** The `text` branch must return `MarkdownText`; returning `<p>{part.text}</p>` bypasses markdown entirely.
+- **No syntax highlighting.** Highlighting is not bundled. Register a `SyntaxHighlighter` in `defaultComponents` (react-shiki recommended) per the syntax-highlighting reference.
+- **KaTeX has no styling.** Import `katex/dist/katex.min.css` once at the app root; `rehypeKatex` only emits markup.
+- **Mermaid parses partial diagrams while streaming.** Gate rendering on stream completion (the reference uses `useAuiState` to detect the closing fence) instead of rendering every delta.
+- **Memoization export name.** The package exports `unstable_memoizeMarkdownComponents`; the generated file aliases it to `memoizeMarkdownComponents`.
+- **Unstyled by default.** The `aui-md` class and `styles/dot.css` provide base styling; add your own Tailwind/CSS otherwise.
+
+## Related Skills
+
+- **primitives** -- general UI composition (`ThreadPrimitive`, `ComposerPrimitive`, `MessagePrimitive.Parts`) for assembling the message and the rest of the chat surface around the markdown text branch.

--- a/assistant-ui/skills/markdown/references/latex-mermaid.md
+++ b/assistant-ui/skills/markdown/references/latex-mermaid.md
@@ -1,0 +1,169 @@
+# LaTeX and Mermaid
+
+Render math and diagrams inside the markdown message part by extending the generated `markdown-text.tsx`.
+
+## Contents
+
+- [Starting point](#starting-point)
+- [LaTeX with KaTeX](#latex-with-katex)
+- [Custom math delimiters](#custom-math-delimiters)
+- [Mermaid diagrams](#mermaid-diagrams)
+- [Wiring Mermaid in](#wiring-mermaid-in)
+- [Notes](#notes)
+
+## Starting point
+
+Both features build on the registry `markdown-text` component; add it first if the project does not already have it:
+
+```bash
+npx assistant-ui@latest add markdown-text
+```
+
+See [./markdown-text.md](./markdown-text.md) for the base `MarkdownText` setup. The sections below extend that generated `markdown-text.tsx`.
+
+## LaTeX with KaTeX
+
+Add a remark plugin to parse math and a rehype plugin to render it with KaTeX.
+
+```bash
+npm install remark-math rehype-katex katex
+```
+
+Import the KaTeX stylesheet once, at the app root (`app/layout.tsx`):
+
+```ts
+import "katex/dist/katex.min.css";
+```
+
+Pass `remarkMath` alongside `remarkGfm`, and `rehypeKatex` via `rehypePlugins`:
+
+```tsx
+import { MarkdownTextPrimitive } from "@assistant-ui/react-markdown";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
+
+const MarkdownTextImpl = () => {
+  return (
+    <MarkdownTextPrimitive
+      remarkPlugins={[remarkGfm, remarkMath]}
+      rehypePlugins={[rehypeKatex]}
+      className="aui-md"
+      components={defaultComponents}
+    />
+  );
+};
+```
+
+This renders `$...$` inline math, `$$...$$` display math, and fenced code blocks tagged with the `math` language identifier.
+
+## Custom math delimiters
+
+Models sometimes emit non-standard delimiters such as `\(...\)`, `\[...\]`, or `[math]...[/math]`. The `preprocess` prop normalizes the raw string before parsing, and it runs before `useSmooth`, so partial delimiters accumulate in the buffer instead of being parsed mid-stream.
+
+```tsx
+<MarkdownTextPrimitive
+  remarkPlugins={[remarkGfm, remarkMath]}
+  rehypePlugins={[rehypeKatex]}
+  preprocess={normalizeCustomMathTags}
+  className="aui-md"
+  components={defaultComponents}
+/>;
+
+function normalizeCustomMathTags(input: string): string {
+  return input
+    .replace(/\[math\]([\s\S]*?)\[\/math\]/g, (_, c) => `$$${c.trim()}$$`)
+    .replace(/\\{1,2}\(([\s\S]*?)\\{1,2}\)/g, (_, c) => `$${c.trim()}$`)
+    .replace(/\\{1,2}\[([\s\S]*?)\\{1,2}\]/g, (_, c) => `$$${c.trim()}$$`);
+}
+```
+
+## Mermaid diagrams
+
+Mermaid is wired through `componentsByLanguage`, which overrides the `SyntaxHighlighter` for a single fenced language (here `mermaid`).
+
+```bash
+npm install mermaid
+```
+
+Create `components/assistant-ui/mermaid-diagram.tsx`. The component receives `SyntaxHighlighterProps` (carrying `code`, `node`, `components`, and `language`) and uses `useAuiState` to detect when the code fence has finished streaming before rendering, so Mermaid never parses a partial diagram.
+
+```tsx
+"use client";
+import { useAuiState } from "@assistant-ui/react";
+import type { SyntaxHighlighterProps } from "@assistant-ui/react-markdown";
+import mermaid from "mermaid";
+import { type FC, useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export type MermaidDiagramProps = SyntaxHighlighterProps & {
+  className?: string;
+};
+
+mermaid.initialize({ theme: "default", startOnLoad: false });
+
+export const MermaidDiagram: FC<MermaidDiagramProps> = ({
+  code,
+  className,
+  node: _node,
+  components: _components,
+  language: _language,
+}) => {
+  const ref = useRef<HTMLPreElement>(null);
+
+  const isComplete = useAuiState((s) => {
+    if (s.part.type !== "text") return false;
+    const codeIndex = s.part.text.indexOf(code);
+    if (codeIndex === -1) return false;
+    const afterCode = s.part.text.substring(codeIndex + code.length);
+    return /^```|^\n```/.test(afterCode);
+  });
+
+  useEffect(() => {
+    if (!isComplete) return;
+    (async () => {
+      try {
+        const id = `mermaid-${Math.random().toString(36).slice(2)}`;
+        const result = await mermaid.render(id, code);
+        if (ref.current) {
+          ref.current.innerHTML = result.svg;
+          result.bindFunctions?.(ref.current);
+        }
+      } catch (e) {
+        console.warn("Failed to render Mermaid diagram:", e);
+      }
+    })();
+  }, [isComplete, code]);
+
+  return (
+    <pre ref={ref} className={cn("aui-mermaid-diagram", className)}>
+      Drawing diagram...
+    </pre>
+  );
+};
+
+MermaidDiagram.displayName = "MermaidDiagram";
+```
+
+## Wiring Mermaid in
+
+Map the `mermaid` language key to the component through `componentsByLanguage`. Every other language falls back to the default highlighter.
+
+```tsx
+import { MermaidDiagram } from "@/components/assistant-ui/mermaid-diagram";
+
+<MarkdownTextPrimitive
+  remarkPlugins={[remarkGfm]}
+  className="aui-md"
+  components={defaultComponents}
+  componentsByLanguage={{
+    mermaid: { SyntaxHighlighter: MermaidDiagram },
+  }}
+/>;
+```
+
+## Notes
+
+- `useAuiState` reads the current message part; the selector assumes the diagram lives in a `text` part, which is the markdown case.
+- `componentsByLanguage` composes with `remarkPlugins` and `rehypePlugins`, so a single `MarkdownTextPrimitive` can run KaTeX and Mermaid together.
+- `mermaid.initialize(...)` at module scope runs once per bundle; `startOnLoad: false` keeps Mermaid from scanning the DOM on its own.

--- a/assistant-ui/skills/markdown/references/markdown-text.md
+++ b/assistant-ui/skills/markdown/references/markdown-text.md
@@ -1,0 +1,126 @@
+# MarkdownText
+
+The `MarkdownText` component renders an assistant message's text part as markdown. It wraps `MarkdownTextPrimitive` from `@assistant-ui/react-markdown` with a memoized component map, a `CodeHeader`, and the package's CSS. You register it in the `MessagePrimitive.Parts` text branch so only `text` parts render as markdown.
+
+## Contents
+
+- [Package and CSS import](#package-and-css-import)
+- [The MarkdownText component](#the-markdowntext-component)
+- [remarkPlugins and rehypePlugins](#remarkplugins-and-rehypeplugins)
+- [unstable_memoizeMarkdownComponents and defaultComponents](#unstable_memoizemarkdowncomponents-and-defaultcomponents)
+- [CodeHeader](#codeheader)
+- [Wiring into MessagePrimitive.Parts](#wiring-into-messageprimitiveparts)
+
+## Package and CSS import
+
+Everything lives in `@assistant-ui/react-markdown`. Import the stylesheet once (the `dot.css` ships the default `aui-md-*` styles and the streaming cursor) and pull in the primitive plus the memoization helper.
+
+```ts
+import "@assistant-ui/react-markdown/styles/dot.css";
+import {
+  type CodeHeaderProps,
+  MarkdownTextPrimitive,
+  unstable_memoizeMarkdownComponents as memoizeMarkdownComponents,
+  useIsMarkdownCodeBlock,
+} from "@assistant-ui/react-markdown";
+import remarkGfm from "remark-gfm";
+```
+
+The helper is exported as `unstable_memoizeMarkdownComponents`; the generated `markdown-text.tsx` aliases it to `memoizeMarkdownComponents`.
+
+## The MarkdownText component
+
+`MarkdownTextPrimitive` reads the current text part from context, so it takes no `children`. Pass `remarkPlugins`, a `className`, and the memoized `components` map, then memoize the wrapper since the text part re-renders on every streamed token.
+
+```tsx
+const MarkdownTextImpl = () => {
+  return (
+    <MarkdownTextPrimitive
+      remarkPlugins={[remarkGfm]}
+      className="aui-md"
+      components={defaultComponents}
+    />
+  );
+};
+
+export const MarkdownText = memo(MarkdownTextImpl);
+```
+
+Other props worth knowing: `componentsByLanguage` (per-language `SyntaxHighlighter` / `CodeHeader` overrides, see `syntax-highlighting.md`), `smooth` (toggles the smooth streaming animation), and `preprocess` (transform the raw text before markdown parsing).
+
+## remarkPlugins and rehypePlugins
+
+`MarkdownTextPrimitiveProps` extends `react-markdown`'s `Options`, so both `remarkPlugins` and `rehypePlugins` are forwarded as-is. `remarkGfm` is the common default (tables, strikethrough, task lists). Add `rehypePlugins` for HTML-stage transforms; KaTeX and Mermaid wiring is covered in `latex-mermaid.md`.
+
+```tsx
+<MarkdownTextPrimitive
+  remarkPlugins={[remarkGfm]}
+  rehypePlugins={[]}
+  className="aui-md"
+  components={defaultComponents}
+/>
+```
+
+## unstable_memoizeMarkdownComponents and defaultComponents
+
+`memoizeMarkdownComponents` wraps a component map so each element only re-renders when its own subtree changes, which keeps streaming cheap. The map accepts every standard markdown HTML element plus the assistant-ui slots `CodeHeader`, `SyntaxHighlighter`, and `Pre`. Use `useIsMarkdownCodeBlock` inside `code` to distinguish inline code from fenced blocks.
+
+```tsx
+const defaultComponents = memoizeMarkdownComponents({
+  h1: ({ className, ...props }) => (
+    <h1 className={cn("aui-md-h1", className)} {...props} />
+  ),
+  p: ({ className, ...props }) => (
+    <p className={cn("aui-md-p", className)} {...props} />
+  ),
+  pre: ({ className, ...props }) => (
+    <pre className={cn("aui-md-pre", className)} {...props} />
+  ),
+  code: function Code({ className, ...props }) {
+    const isCodeBlock = useIsMarkdownCodeBlock();
+    return (
+      <code
+        className={cn(!isCodeBlock && "aui-md-inline-code", className)}
+        {...props}
+      />
+    );
+  },
+  CodeHeader,
+  // h2-h6, a, blockquote, ul, ol, hr, table, th, td, tr, li, sup
+});
+```
+
+## CodeHeader
+
+`CodeHeader` renders above each fenced code block and receives `language` and `code` typed by `CodeHeaderProps`. The default copies the block to the clipboard.
+
+```tsx
+const CodeHeader: FC<CodeHeaderProps> = ({ language, code }) => {
+  const { isCopied, copyToClipboard } = useCopyToClipboard();
+  const onCopy = () => {
+    if (!code || isCopied) return;
+    copyToClipboard(code);
+  };
+  return (
+    <div className="aui-code-header-root">
+      <span className="aui-code-header-language">{language}</span>
+      <TooltipIconButton tooltip="Copy" onClick={onCopy}>
+        {!isCopied && <CopyIcon />}
+        {isCopied && <CheckIcon />}
+      </TooltipIconButton>
+    </div>
+  );
+};
+```
+
+## Wiring into MessagePrimitive.Parts
+
+`MessagePrimitive.Parts` takes a render function that receives each `{ part }`. Render `MarkdownText` only for the `text` branch; other part types fall through to their own renderers.
+
+```tsx
+import { MarkdownText } from "@/components/assistant-ui/markdown-text";
+
+<MessagePrimitive.Parts>
+  {({ part }) => (part.type === "text" ? <MarkdownText /> : null)}
+</MessagePrimitive.Parts>;
+```

--- a/assistant-ui/skills/markdown/references/streamdown.md
+++ b/assistant-ui/skills/markdown/references/streamdown.md
@@ -1,0 +1,281 @@
+# StreamdownTextPrimitive
+
+`@assistant-ui/react-streamdown` is a feature-rich alternative to `MarkdownTextPrimitive` with built-in Shiki syntax highlighting, KaTeX math, and Mermaid diagrams, plus block-based streaming. Powered by Vercel Streamdown.
+
+## Contents
+
+- [Install](#install)
+- [Basic usage](#basic-usage)
+- [Plugins (Shiki, KaTeX, Mermaid, CJK)](#plugins-shiki-katex-mermaid-cjk)
+- [Props](#props)
+- [Streaming mode and caret](#streaming-mode-and-caret)
+- [Mermaid options](#mermaid-options)
+- [Incomplete markdown (remend)](#incomplete-markdown-remend)
+- [Security and link safety](#security-and-link-safety)
+- [Custom code components](#custom-code-components)
+- [Migrating from react-markdown](#migrating-from-react-markdown)
+- [CSS setup](#css-setup)
+- [Exports](#exports)
+
+## Install
+
+```bash
+npm install @assistant-ui/react-streamdown streamdown
+```
+
+Plugins ship as separate optional packages: `@streamdown/code`, `@streamdown/math`, `@streamdown/mermaid`, `@streamdown/cjk`.
+
+## Basic usage
+
+`StreamdownTextPrimitive` replaces the text part renderer. Define a wrapper and render it from `MessagePrimitive.Parts`.
+
+```tsx
+import { StreamdownTextPrimitive } from "@assistant-ui/react-streamdown";
+
+const StreamdownText = () => <StreamdownTextPrimitive />;
+
+<MessagePrimitive.Parts>
+  {({ part }) => (part.type === "text" ? <StreamdownText {...part} /> : null)}
+</MessagePrimitive.Parts>;
+```
+
+## Plugins (Shiki, KaTeX, Mermaid, CJK)
+
+Pass plugins through the `plugins` prop. Each is imported from its own package; math also needs the KaTeX stylesheet.
+
+```tsx
+import { StreamdownTextPrimitive } from "@assistant-ui/react-streamdown";
+import { code } from "@streamdown/code";
+import { math } from "@streamdown/math";
+import { mermaid } from "@streamdown/mermaid";
+import "katex/dist/katex.min.css";
+
+const StreamdownText = () => (
+  <StreamdownTextPrimitive
+    plugins={{ code, math, mermaid }}
+    shikiTheme={["github-light", "github-dark"]}
+  />
+);
+```
+
+`@streamdown/cjk` adds CJK rendering optimizations via `import { cjk } from "@streamdown/cjk"` and `plugins={{ cjk }}`. `shikiTheme` is a `[light, dark]` tuple and defaults to `["github-light", "github-dark"]`.
+
+## Props
+
+| Prop | Type | Default | Notes |
+|------|------|---------|-------|
+| `mode` | `"streaming" \| "static"` | `"streaming"` | Block-based streaming vs static render |
+| `plugins` | `PluginConfig` | | `code`, `math`, `mermaid`, `cjk` |
+| `shikiTheme` | `[string, string]` | `["github-light", "github-dark"]` | Light/dark themes |
+| `components` | `object` | | Override `SyntaxHighlighter`, `CodeHeader` |
+| `componentsByLanguage` | `object` | | Per-language component overrides |
+| `preprocess` | `(text: string) => string` | | Text preprocessor |
+| `controls` | `boolean \| ControlsConfig` | `true` | Copy/download/fullscreen UI |
+| `caret` | `"block" \| "circle"` | | Streaming caret style |
+| `mermaid` | `MermaidOptions` | | Mermaid config and error handling |
+| `linkSafety` | `LinkSafetyConfig` | | External link confirmation |
+| `remend` | `RemendConfig` | | Incomplete markdown handling |
+| `allowedTags` | `Record<string, string[]>` | | HTML tag whitelist |
+| `security` | `SecurityConfig` | | URL/image restrictions |
+| `containerProps` | `object` | | Props for the container div |
+| `containerClassName` | `string` | | Container class name |
+| `remarkRehypeOptions` | `object` | | remark-rehype options |
+| `BlockComponent` | `ComponentType<BlockProps>` | | Custom block renderer |
+| `parseMarkdownIntoBlocksFn` | `(md: string) => string[]` | | Custom block parser |
+| `parseIncompleteMarkdown` | `boolean` | `false` | Toggle remend processing |
+
+## Streaming mode and caret
+
+`mode="streaming"` (the default) parses markdown into blocks so completed blocks stay stable while the last block grows. The `caret` prop renders a typing indicator at the stream tail.
+
+```tsx
+<StreamdownTextPrimitive caret="block" />   // ▋
+<StreamdownTextPrimitive caret="circle" />  // ●
+```
+
+## Mermaid options
+
+Configure the underlying Mermaid instance and supply a custom error renderer.
+
+```tsx
+<StreamdownTextPrimitive
+  plugins={{ mermaid }}
+  mermaid={{
+    config: { theme: "dark" },
+    errorComponent: ({ error, chart, retry }) => (
+      <div>
+        <p>Failed to render diagram: {error}</p>
+        <button onClick={retry}>Retry</button>
+      </div>
+    ),
+  }}
+/>
+```
+
+## Incomplete markdown (remend)
+
+During streaming, markdown is often syntactically incomplete (an unclosed `**`, a half-typed link). The `remend` config controls which constructs get auto-completed for display.
+
+```tsx
+<StreamdownTextPrimitive
+  remend={{
+    links: true,
+    images: true,
+    linkMode: "protocol",
+    bold: true,
+    italic: true,
+    boldItalic: true,
+    inlineCode: true,
+    strikethrough: true,
+    katex: true,
+    setextHeadings: true,
+    handlers: [],
+  }}
+/>
+```
+
+## Security and link safety
+
+`security` restricts which URLs and images are allowed to render; `linkSafety` adds a confirmation step before navigating external links.
+
+```tsx
+<StreamdownTextPrimitive
+  security={{
+    allowedLinkPrefixes: ["https://example.com", "https://docs.example.com"],
+    allowedImagePrefixes: ["https://cdn.example.com"],
+    allowedProtocols: ["https", "mailto"],
+    allowDataImages: false,
+    defaultOrigin: "https://example.com",
+    blockedLinkClass: "blocked-link",
+    blockedImageClass: "blocked-image",
+  }}
+  linkSafety={{
+    enabled: true,
+    onLinkCheck: (url) => url.startsWith("https://trusted.com"),
+  }}
+/>
+```
+
+`allowedTags` whitelists raw HTML tags and their attributes:
+
+```tsx
+<StreamdownTextPrimitive
+  allowedTags={{
+    div: ["class", "id"],
+    span: ["class", "style"],
+    iframe: ["src", "width", "height"],
+  }}
+/>
+```
+
+## Custom code components
+
+Override the highlighter and code header per language, or build a custom code component using the provided hooks.
+
+```tsx
+<StreamdownTextPrimitive
+  components={{
+    SyntaxHighlighter: MySyntaxHighlighter,
+    CodeHeader: MyCodeHeader,
+  }}
+  componentsByLanguage={{
+    mermaid: { SyntaxHighlighter: MermaidRenderer },
+  }}
+/>
+```
+
+`useIsStreamdownCodeBlock` distinguishes block code from inline code; `useStreamdownPreProps` exposes the `<pre>` props for the current block.
+
+```tsx
+import {
+  useIsStreamdownCodeBlock,
+  useStreamdownPreProps,
+} from "@assistant-ui/react-streamdown";
+
+function MyCodeComponent({ children, ...props }) {
+  const isCodeBlock = useIsStreamdownCodeBlock();
+  const preProps = useStreamdownPreProps();
+  if (!isCodeBlock) {
+    return (
+      <code className="inline-code" {...props}>
+        {children}
+      </code>
+    );
+  }
+  return (
+    <pre className={preProps?.className}>
+      <code {...props}>{children}</code>
+    </pre>
+  );
+}
+```
+
+## Migrating from react-markdown
+
+Existing custom renderers map onto the `components` and `componentsByLanguage` props, so a `react-markdown` based `MarkdownText` can be ported without rewriting the highlighter or header.
+
+```tsx
+const StreamdownText = () => (
+  <StreamdownTextPrimitive
+    components={{
+      SyntaxHighlighter: MySyntaxHighlighter,
+      CodeHeader: MyCodeHeader,
+    }}
+    componentsByLanguage={{
+      mermaid: { SyntaxHighlighter: MermaidRenderer },
+    }}
+  />
+);
+```
+
+## CSS setup
+
+Streamdown assumes shadcn/ui design tokens (`--background`, `--muted-foreground`, `--border`, etc.). With Tailwind v4, add an `@source` directive for each installed package so its classes are not purged.
+
+```css
+@import "tailwindcss";
+@source "../node_modules/streamdown/dist/*.js";
+@source "../node_modules/@streamdown/code/dist/*.js";
+@source "../node_modules/@streamdown/math/dist/*.js";
+@source "../node_modules/@streamdown/mermaid/dist/*.js";
+@source "../node_modules/@streamdown/cjk/dist/*.js";
+```
+
+For the word-level fade-in animation, also import the stylesheet at the app entry:
+
+```ts
+import "streamdown/styles.css";
+```
+
+Note: without these directives the copy/download/fullscreen controls render with no padding or cursor styling and the `caret` indicator stays invisible.
+
+## Exports
+
+```ts
+import {
+  StreamdownTextPrimitive,
+  StreamdownContext,
+  parseMarkdownIntoBlocks,
+  useIsStreamdownCodeBlock,
+  useStreamdownPreProps,
+  memoCompareNodes,
+  DEFAULT_SHIKI_THEME,
+} from "@assistant-ui/react-streamdown";
+
+import type {
+  StreamdownTextPrimitiveProps,
+  SyntaxHighlighterProps,
+  CodeHeaderProps,
+  ComponentsByLanguage,
+  StreamdownTextComponents,
+  PluginConfig,
+  CaretStyle,
+  ControlsConfig,
+  MermaidOptions,
+  MermaidErrorComponentProps,
+  LinkSafetyConfig,
+  RemendConfig,
+  SecurityConfig,
+  BlockProps,
+} from "@assistant-ui/react-streamdown";
+```

--- a/assistant-ui/skills/markdown/references/syntax-highlighting.md
+++ b/assistant-ui/skills/markdown/references/syntax-highlighting.md
@@ -1,0 +1,234 @@
+# Syntax Highlighting
+
+Code block highlighting for the markdown renderer. Two options: `react-shiki` (recommended) and `@assistant-ui/react-syntax-highlighter` (legacy, may be removed). Both plug in as a `SyntaxHighlighter` component, either globally via `defaultComponents` or per language via `componentsByLanguage`.
+
+## Contents
+
+- [How it plugs in](#how-it-plugs-in)
+- [react-shiki (recommended)](#react-shiki-recommended)
+- [Dual / multi theme](#dual--multi-theme)
+- [Bundle optimization (shiki)](#bundle-optimization-shiki)
+- [react-syntax-highlighter (legacy)](#react-syntax-highlighter-legacy)
+- [Full language bundle](#full-language-bundle)
+- [Per-language overrides (componentsByLanguage)](#per-language-overrides-componentsbylanguage)
+- [SyntaxHighlighterProps](#syntaxhighlighterprops)
+
+## How it plugs in
+
+`MarkdownTextPrimitive` renders code blocks with the `SyntaxHighlighter` you register. A global one goes in `defaultComponents` (built with `memoizeMarkdownComponents`); language specific ones go in `componentsByLanguage`.
+
+```tsx
+import { MarkdownTextPrimitive } from "@assistant-ui/react-markdown";
+
+<MarkdownTextPrimitive
+  remarkPlugins={[remarkGfm]}
+  className="aui-md"
+  components={defaultComponents}
+  componentsByLanguage={{
+    mermaid: { SyntaxHighlighter: MermaidDiagram },
+  }}
+/>;
+```
+
+Note: the package exports the memoization helper as `unstable_memoizeMarkdownComponents`; the generated `markdown-text.tsx` aliases it to `memoizeMarkdownComponents`.
+
+## react-shiki (recommended)
+
+Install via the registry (`https://r.assistant-ui.com/shiki-highlighter.json`), which adds the `react-shiki` package and `/components/assistant-ui/shiki-highlighter.tsx`.
+
+```tsx
+"use client";
+import type { FC } from "react";
+import ShikiHighlighter, { type ShikiHighlighterProps } from "react-shiki";
+import type { SyntaxHighlighterProps as AUIProps } from "@assistant-ui/react-markdown";
+import { cn } from "@/lib/utils";
+
+export type HighlighterProps = Omit<ShikiHighlighterProps, "children" | "theme"> & {
+  theme?: ShikiHighlighterProps["theme"];
+} & Pick<AUIProps, "language" | "code"> &
+  Partial<Pick<AUIProps, "node" | "components">>;
+
+export const SyntaxHighlighter: FC<HighlighterProps> = ({
+  code,
+  language,
+  theme = { dark: "kanagawa-wave", light: "kanagawa-lotus" },
+  className,
+  addDefaultStyles = false,
+  showLanguage = false,
+  node: _node,
+  components: _components,
+  ...props
+}) => {
+  return (
+    <ShikiHighlighter
+      {...props}
+      language={language}
+      theme={theme}
+      addDefaultStyles={addDefaultStyles}
+      showLanguage={showLanguage}
+      defaultColor="light-dark()"
+      className={cn(
+        "aui-shiki-base [&_pre]:bg-muted/75! [&_pre]:overflow-x-auto [&_pre]:rounded-b-lg [&_pre]:p-4",
+        className,
+      )}
+    >
+      {code.trim()}
+    </ShikiHighlighter>
+  );
+};
+SyntaxHighlighter.displayName = "SyntaxHighlighter";
+```
+
+Register it in `defaultComponents` (file `markdown-text.tsx`):
+
+```tsx
+import { SyntaxHighlighter } from "./shiki-highlighter";
+
+export const defaultComponents = memoizeMarkdownComponents({
+  SyntaxHighlighter: SyntaxHighlighter,
+  h1: /* ... */,
+  // ...other elements...
+});
+```
+
+`ShikiHighlighter` props worth knowing: `theme` (a single theme or a multi-theme object), `language` (default `"text"`), `defaultColor` (`string | false`), `delay` (highlight throttle for streaming, default `0`), `customLanguages`, and `codeToHastOptions`.
+
+## Dual / multi theme
+
+Pass a `{ light, dark }` object plus `defaultColor="light-dark()"`.
+
+```tsx
+<ShikiHighlighter
+  theme={{ light: "github-light", dark: "github-dark" }}
+  defaultColor="light-dark()"
+>
+  {code.trim()}
+</ShikiHighlighter>
+```
+
+Wire up `color-scheme` in `globals.css`. System based:
+
+```css
+:root { color-scheme: light dark; }
+```
+
+Class based:
+
+```css
+:root { color-scheme: light; }
+:root.dark { color-scheme: dark; }
+```
+
+## Bundle optimization (shiki)
+
+Use the web bundle (smaller, web-focused languages):
+
+```tsx
+import ShikiHighlighter, { type ShikiHighlighterProps } from "react-shiki/web";
+```
+
+Or build a custom core highlighter with only the themes and languages you need, then pass it via the `highlighter` prop:
+
+```tsx
+import { createHighlighterCore, createOnigurumaEngine } from "react-shiki/core";
+
+const customHighlighter = await createHighlighterCore({
+  themes: [import("@shikijs/themes/nord")],
+  langs: [
+    import("@shikijs/langs/javascript"),
+    import("@shikijs/langs/typescript"),
+  ],
+  engine: createOnigurumaEngine(import("shiki/wasm")),
+});
+
+<SyntaxHighlighter {...props} language={language} theme={theme} highlighter={customHighlighter} />;
+```
+
+## react-syntax-highlighter (legacy)
+
+Install via the registry (`https://r.assistant-ui.com/syntax-highlighter.json`), which adds `@assistant-ui/react-syntax-highlighter`, `react-syntax-highlighter`, `@types/react-syntax-highlighter`, and `/components/assistant-ui/syntax-highlighter.tsx`. The light build only ships the languages you register.
+
+```tsx
+import { PrismAsyncLight } from "react-syntax-highlighter";
+import { makePrismAsyncLightSyntaxHighlighter } from "@assistant-ui/react-syntax-highlighter";
+import tsx from "react-syntax-highlighter/dist/esm/languages/prism/tsx";
+import python from "react-syntax-highlighter/dist/esm/languages/prism/python";
+import { coldarkDark } from "react-syntax-highlighter/dist/cjs/styles/prism";
+
+PrismAsyncLight.registerLanguage("js", tsx);
+PrismAsyncLight.registerLanguage("jsx", tsx);
+PrismAsyncLight.registerLanguage("ts", tsx);
+PrismAsyncLight.registerLanguage("tsx", tsx);
+PrismAsyncLight.registerLanguage("python", python);
+
+export const SyntaxHighlighter = makePrismAsyncLightSyntaxHighlighter({
+  style: coldarkDark,
+  customStyle: {
+    margin: 0,
+    width: "100%",
+    background: "black",
+    padding: "1.5rem 1rem",
+  },
+});
+```
+
+Register it the same way:
+
+```tsx
+import { SyntaxHighlighter } from "./syntax-highlighter";
+
+export const defaultComponents = memoizeMarkdownComponents({
+  SyntaxHighlighter: SyntaxHighlighter,
+  h1: /* ... */,
+  // ...other elements...
+});
+```
+
+## Full language bundle
+
+For all languages without registering each one, use the `/full` subpath and `makePrismAsyncSyntaxHighlighter` instead of the light builder.
+
+```tsx
+import { makePrismAsyncSyntaxHighlighter } from "@assistant-ui/react-syntax-highlighter/full";
+```
+
+## Per-language overrides (componentsByLanguage)
+
+`componentsByLanguage` maps a language id to its own `SyntaxHighlighter` (and optional `CodeHeader`). It takes precedence over the global `SyntaxHighlighter` in `components` for that language; other languages fall back to the global one. This is how Mermaid and diff renderers are wired.
+
+```tsx
+const MarkdownTextImpl = () => {
+  return (
+    <MarkdownTextPrimitive
+      remarkPlugins={[remarkGfm]}
+      className="aui-md"
+      components={defaultComponents}
+      componentsByLanguage={{
+        mermaid: {
+          SyntaxHighlighter: MermaidDiagram,
+        },
+      }}
+    />
+  );
+};
+
+export const MarkdownText = memo(MarkdownTextImpl);
+```
+
+## SyntaxHighlighterProps
+
+Every `SyntaxHighlighter` (global or per language) receives this from `@assistant-ui/react-markdown`:
+
+```ts
+export type SyntaxHighlighterProps = {
+  node?: Element | undefined;
+  components: {
+    Pre: PreComponent;
+    Code: CodeComponent;
+  };
+  language: string;
+  code: string;
+};
+```
+
+`language` falls back to `"unknown"` when the fence has no language; `code` is the raw block text. The shiki and prism components destructure `node` and `components` out and forward the rest, since `react-shiki` and `react-syntax-highlighter` render their own `pre`/`code`.

--- a/assistant-ui/skills/observability/SKILL.md
+++ b/assistant-ui/skills/observability/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: observability
+description: "Adds tracing, telemetry, and observability to an assistant-ui backend. Use when wiring an AI SDK route handler (streamText/generateText, toUIMessageStreamResponse) to a tracing backend: Langfuse via OpenTelemetry (LangfuseSpanProcessor and NodeSDK in instrumentation.ts, experimental_telemetry isEnabled, propagateAttributes with traceName/userId/sessionId, langfuseSpanProcessor.forceFlush on serverless), LangSmith via wrapAISDK(ai) from langsmith/experimental/vercel (createLangSmithProviderOptions, awaitPendingTraceBatches), or Helicone via createOpenAI baseURL https://oai.helicone.ai/v1 with the Helicone-Auth header. Also covers rendering collected spans with @assistant-ui/react-o11y headless primitives (SpanResource, SpanPrimitive Root/Indent/CollapseToggle/StatusIndicator/TypeBadge/Name/Children, SpanByIndexProvider, SpanData/SpanState) mounted via useAui/AuiProvider from @assistant-ui/store. Use for missing or empty traces, edge vs nodejs runtime telemetry, serverless flush issues, or trace waterfalls."
+license: MIT
+---
+
+# assistant-ui Observability
+
+**Always consult [assistant-ui.com/llms.txt](https://www.assistant-ui.com/llms.txt) for the latest API.**
+
+Tracing and telemetry for an assistant-ui backend. Most of this is generic AI SDK telemetry; the assistant-ui specific part is the route handler and the `@assistant-ui/react-o11y` client primitives for rendering spans.
+
+## Contents
+
+- [References](#references)
+- [Where it plugs in](#where-it-plugs-in)
+- [Provider routing](#provider-routing)
+- [AI SDK telemetry (shared)](#ai-sdk-telemetry-shared)
+- [Helicone (proxy, no OTel)](#helicone-proxy-no-otel)
+- [Visualizing spans with react-o11y](#visualizing-spans-with-react-o11y)
+- [Common Gotchas](#common-gotchas)
+- [Related Skills](#related-skills)
+
+## References
+
+- [./references/langfuse.md](./references/langfuse.md) -- Langfuse tracing
+- [./references/langsmith.md](./references/langsmith.md) -- LangSmith tracing
+- [./references/helicone.md](./references/helicone.md) -- Helicone proxy
+- [./references/react-o11y.md](./references/react-o11y.md) -- @assistant-ui/react-o11y client primitives
+
+## Where it plugs in
+
+Telemetry attaches to the **server route** that calls `streamText`/`generateText`, not to the React runtime. The frontend (`useChatRuntime`, `Thread`) is unchanged. `react-o11y` is a separate, optional client layer for drawing the trace waterfall in your own UI.
+
+```
+Thread (frontend) ──> /api/chat (streamText) ──> tracing backend
+                                              └─> react-o11y (optional UI)
+```
+
+## Provider routing
+
+```
+Langfuse   → OTel span processor + experimental_telemetry, propagateAttributes
+LangSmith  → wrapAISDK(ai) wrapper, no OTel setup
+Helicone   → proxy baseURL on the provider, no telemetry flag
+react-o11y → client primitives to render spans you collected
+```
+
+## AI SDK telemetry (shared)
+
+Langfuse and any OTel backend reuse the AI SDK `experimental_telemetry` flag. Enable it per call:
+
+```ts
+import { openai } from "@ai-sdk/openai";
+import { streamText, convertToModelMessages } from "ai";
+import type { UIMessage } from "ai";
+
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json();
+  const result = streamText({
+    model: openai("gpt-5.4-nano"),
+    messages: await convertToModelMessages(messages),
+    experimental_telemetry: { isEnabled: true },
+  });
+  return result.toUIMessageStreamResponse();
+}
+```
+
+For Langfuse, register an OTel span processor in `instrumentation.ts` and wrap the call so traces carry `userId`/`sessionId`:
+
+```ts
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { LangfuseSpanProcessor } from "@langfuse/otel";
+
+export const langfuseSpanProcessor = new LangfuseSpanProcessor();
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+  const sdk = new NodeSDK({ spanProcessors: [langfuseSpanProcessor] });
+  sdk.start();
+}
+```
+
+```ts
+import { propagateAttributes } from "@langfuse/tracing";
+
+const result = await propagateAttributes(
+  { traceName: "chat-completion", userId, sessionId },
+  async () =>
+    streamText({
+      model: openai("gpt-5.4-nano"),
+      messages: await convertToModelMessages(messages),
+      experimental_telemetry: { isEnabled: true },
+    }),
+);
+```
+
+LangSmith skips OTel entirely; wrap the `ai` module instead. `convertToModelMessages` is not wrapped, so import it from `ai` directly:
+
+```ts
+import * as ai from "ai";
+import { wrapAISDK } from "langsmith/experimental/vercel";
+import { openai } from "@ai-sdk/openai";
+
+const { streamText } = wrapAISDK(ai);
+
+const result = streamText({
+  model: openai("gpt-5.4-nano"),
+  messages: await ai.convertToModelMessages(messages),
+});
+return result.toUIMessageStreamResponse();
+```
+
+See the per provider reference files for env vars, metadata tagging, and serverless flushing.
+
+## Helicone (proxy, no OTel)
+
+Helicone needs no telemetry flag. Point the provider at the proxy `baseURL` and pass the auth header:
+
+```ts
+import { createOpenAI } from "@ai-sdk/openai";
+
+const openai = createOpenAI({
+  baseURL: "https://oai.helicone.ai/v1",
+  headers: { "Helicone-Auth": `Bearer ${process.env.HELICONE_API_KEY}` },
+});
+```
+
+Use this `openai` instance with `streamText` as usual; streaming, tools, and attachments are unchanged.
+
+## Visualizing spans with react-o11y
+
+`@assistant-ui/react-o11y` gives headless primitives to render collected spans as a trace waterfall. Feed it `SpanData[]` (id, parentSpanId, name, type, status, startedAt, endedAt, latencyMs) via `SpanResource`, mount with `useAui`, and render `SpanPrimitive` parts.
+
+```bash
+npm install @assistant-ui/react-o11y
+```
+
+```tsx
+import {
+  SpanResource,
+  SpanPrimitive,
+  type SpanData,
+} from "@assistant-ui/react-o11y";
+import { AuiProvider, useAui } from "@assistant-ui/store";
+
+function SpanRow() {
+  return (
+    <SpanPrimitive.Root>
+      <SpanPrimitive.Indent />
+      <SpanPrimitive.CollapseToggle />
+      <SpanPrimitive.StatusIndicator />
+      <SpanPrimitive.TypeBadge />
+      <SpanPrimitive.Name />
+    </SpanPrimitive.Root>
+  );
+}
+
+export function TraceView({ spans }: { spans: SpanData[] }) {
+  const aui = useAui({ resource: SpanResource({ spans }) });
+  return (
+    <AuiProvider value={aui}>
+      <SpanPrimitive.Children components={{ Span: SpanRow }} />
+    </AuiProvider>
+  );
+}
+```
+
+`SpanPrimitive.Children` flattens the tree to a visible list and wraps each item in `SpanByIndexProvider`. `Root` exposes `data-span-status`, `data-span-type`, `data-span-depth`, and `data-collapsed` for styling. See [react-o11y.md](./references/react-o11y.md) for the full part list and `SpanState` shape.
+
+## Common Gotchas
+
+**No traces on Vercel/Lambda**
+- The function exits before OTel flushes its buffer. Langfuse: `await langfuseSpanProcessor.forceFlush()` before responding. LangSmith: `await new Client().awaitPendingTraceBatches()`.
+
+**Langfuse traces empty**
+- `experimental_telemetry: { isEnabled: true }` must be set on each `streamText`/`generateText` call.
+- The span processor only registers when `process.env.NEXT_RUNTIME === "nodejs"`; OTel does not run on the edge runtime.
+
+**LangSmith not tracing**
+- Use the destructured methods from `wrapAISDK(ai)`, not the originals from `ai`. `LANGSMITH_TRACING=true` must be set.
+
+**Helicone requests still hit OpenAI directly**
+- Confirm requests go to `oai.helicone.ai`, not `api.openai.com`, and carry both `Helicone-Auth` and `Authorization` headers.
+
+**react-o11y renders nothing**
+- Primitives must render inside `AuiProvider`; the resource mounts through `useAui({ resource: SpanResource({ spans }) })`.
+
+## Related Skills
+
+- `/streaming` - The route handler and stream response telemetry attaches to
+- `/setup` - Backend wiring (`ai-sdk`, `custom-backend`) where the route lives
+- `/cloud` - Persistence; pair `userId`/`sessionId`/`threadId` with trace attributes

--- a/assistant-ui/skills/observability/references/helicone.md
+++ b/assistant-ui/skills/observability/references/helicone.md
@@ -1,0 +1,90 @@
+# Helicone
+
+Log and monitor LLM calls by routing them through the Helicone proxy. No SDK or wrapper is needed; you only change the provider's `baseURL` and add an auth header.
+
+## How It Works
+
+Helicone is a proxy. Point your OpenAI provider at Helicone's gateway instead of `api.openai.com`, and every request is logged (cost, latency, prompts, completions) before being forwarded to OpenAI. Streaming, tools, and attachments keep working unchanged because the request shape is identical.
+
+## Environment Variables
+
+```
+HELICONE_API_KEY=sk-helicone-...
+OPENAI_API_KEY=sk-...
+```
+
+Server-side only. Never set the Helicone key in client code.
+
+## Route Setup (AI SDK)
+
+Create the provider with `createOpenAI` from `@ai-sdk/openai`, override `baseURL`, and attach the `Helicone-Auth` header. Use the provider exactly as you would the default `openai` export.
+
+```ts
+import { createOpenAI } from "@ai-sdk/openai";
+import { streamText, convertToModelMessages } from "ai";
+import type { UIMessage } from "ai";
+
+const openai = createOpenAI({
+  baseURL: "https://oai.helicone.ai/v1",
+  headers: {
+    "Helicone-Auth": `Bearer ${process.env.HELICONE_API_KEY}`,
+  },
+});
+
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json();
+  const result = streamText({
+    model: openai("gpt-5.4-mini"),
+    messages: await convertToModelMessages(messages),
+  });
+  return result.toUIMessageStreamResponse();
+}
+```
+
+The `OPENAI_API_KEY` env var is still read by `createOpenAI`; Helicone forwards it to OpenAI.
+
+## Route Setup (OpenAI SDK)
+
+If you call the OpenAI SDK directly instead of the AI SDK, set `baseURL` and `defaultHeaders` on the client.
+
+```ts
+import OpenAI from "openai";
+
+const openai = new OpenAI({
+  baseURL: "https://oai.helicone.ai/v1",
+  defaultHeaders: {
+    "Helicone-Auth": `Bearer ${process.env.HELICONE_API_KEY}`,
+  },
+});
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+  const stream = await openai.chat.completions.create({
+    model: "gpt-5.4-mini",
+    messages,
+    stream: true,
+  });
+  return new Response(stream.toReadableStream());
+}
+```
+
+## Custom Metadata
+
+Add per request headers to tag and filter sessions in the Helicone dashboard. Pass them alongside `Helicone-Auth` in the `headers` (AI SDK) or `defaultHeaders` (OpenAI SDK) object.
+
+```ts
+const openai = createOpenAI({
+  baseURL: "https://oai.helicone.ai/v1",
+  headers: {
+    "Helicone-Auth": `Bearer ${process.env.HELICONE_API_KEY}`,
+    "Helicone-User-Id": "user_123",
+    "Helicone-Property-App": "support-bot",
+  },
+});
+```
+
+`Helicone-User-Id` groups requests by end user; any `Helicone-Property-*` header becomes a custom filterable dimension.
+
+## Other Providers
+
+For Anthropic, Gemini, and others, swap the base URL to the matching Helicone gateway. See Helicone's provider docs for the exact host per provider; the auth header stays the same.

--- a/assistant-ui/skills/observability/references/langfuse.md
+++ b/assistant-ui/skills/observability/references/langfuse.md
@@ -1,0 +1,135 @@
+# Langfuse
+
+Trace AI SDK calls into Langfuse via OpenTelemetry for tracing, evals, and prompt management.
+
+## Contents
+
+- [How it works](#how-it-works)
+- [Environment variables](#environment-variables)
+- [Packages](#packages)
+- [instrumentation.ts](#instrumentationts)
+- [Next.js 14 config](#nextjs-14-config)
+- [Route handler](#route-handler)
+- [Trace metadata](#trace-metadata)
+- [Serverless: forceFlush](#serverless-forceflush)
+
+## How it works
+
+There is no proxy and no client wrapping. `streamText` (or `generateText`) emits OpenTelemetry spans when `experimental_telemetry` is enabled. A `LangfuseSpanProcessor` registered on the OTel `NodeSDK` ships those spans to Langfuse, which renders them as traces.
+
+`@langfuse/tracing` provides the helpers that label traces (user, session, trace name). `@langfuse/otel` provides the span processor.
+
+## Environment variables
+
+```bash
+LANGFUSE_PUBLIC_KEY=pk-lf-...
+LANGFUSE_SECRET_KEY=sk-lf-...
+LANGFUSE_BASE_URL=https://cloud.langfuse.com
+```
+
+`LANGFUSE_BASE_URL` selects the region: EU is `https://cloud.langfuse.com`, US is `https://us.cloud.langfuse.com`, or point it at a self-hosted instance.
+
+## Packages
+
+```bash
+npm install @langfuse/tracing @langfuse/otel @opentelemetry/sdk-node
+```
+
+## instrumentation.ts
+
+Create `instrumentation.ts` at the project root. Export the processor so route handlers can flush it later (see [Serverless: forceFlush](#serverless-forceflush)).
+
+```ts
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { LangfuseSpanProcessor } from "@langfuse/otel";
+
+export const langfuseSpanProcessor = new LangfuseSpanProcessor();
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+
+  const sdk = new NodeSDK({
+    spanProcessors: [langfuseSpanProcessor],
+  });
+  sdk.start();
+}
+```
+
+Note: the `NEXT_RUNTIME` guard skips the edge runtime, where OTel does not run.
+
+## Next.js 14 config
+
+Next.js 15 calls `register()` automatically. On Next.js 14 and earlier, opt in via `next.config.mjs`:
+
+```js
+const nextConfig = {
+  experimental: {
+    instrumentationHook: true,
+  },
+};
+
+export default nextConfig;
+```
+
+## Route handler
+
+Enable telemetry by setting `experimental_telemetry` directly on `streamText`. The same flag works on `generateText`.
+
+```ts
+import { openai } from "@ai-sdk/openai";
+import { streamText, convertToModelMessages } from "ai";
+import type { UIMessage } from "ai";
+
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json();
+
+  const result = streamText({
+    model: openai("gpt-4o"),
+    messages: convertToModelMessages(messages),
+    experimental_telemetry: { isEnabled: true },
+  });
+
+  return result.toUIMessageStreamResponse();
+}
+```
+
+## Trace metadata
+
+Wrap the call in `propagateAttributes` from `@langfuse/tracing` to attach a trace name, user, and session so Langfuse can group and filter runs.
+
+```ts
+import { openai } from "@ai-sdk/openai";
+import { streamText, convertToModelMessages } from "ai";
+import type { UIMessage } from "ai";
+import { propagateAttributes } from "@langfuse/tracing";
+
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json();
+  const userId = "<resolve from your session>";
+  const sessionId = "<resolve from your thread state>";
+
+  const result = await propagateAttributes(
+    { traceName: "chat-completion", userId, sessionId },
+    async () =>
+      streamText({
+        model: openai("gpt-4o"),
+        messages: convertToModelMessages(messages),
+        experimental_telemetry: { isEnabled: true },
+      }),
+  );
+
+  return result.toUIMessageStreamResponse();
+}
+```
+
+## Serverless: forceFlush
+
+On serverless platforms the function can exit before OTel flushes its buffer, dropping traces. Import the processor exported from `instrumentation.ts` and flush it before responding, or hand the flush to the runtime's `waitUntil`.
+
+```ts
+import { langfuseSpanProcessor } from "@/instrumentation";
+
+await langfuseSpanProcessor.forceFlush();
+```
+
+Langfuse's own docs cover the deployment-specific flush patterns (for example `waitUntil`) and OTel sampling configuration on `NodeSDK`.

--- a/assistant-ui/skills/observability/references/langsmith.md
+++ b/assistant-ui/skills/observability/references/langsmith.md
@@ -1,0 +1,90 @@
+# LangSmith
+
+Trace AI SDK route handlers into LangSmith with `wrapAISDK`. Use this when your route talks to AI SDK directly; with `@assistant-ui/react-langgraph`, tracing flows through LangGraph Cloud automatically.
+
+## How it works
+
+LangSmith wraps the `ai` namespace. Call `wrapAISDK(ai)`, get back the same exports (`generateText`, `streamText`, `generateObject`, `streamObject`), and use those in place of the originals. Every call is then traced: your route calls the wrapped `streamText`, which routes through the LangSmith client to LangSmith.
+
+## Setup
+
+Get an API key from [smith.langchain.com](https://smith.langchain.com/), then set environment variables. `LANGSMITH_PROJECT` controls which project receives traces; the default project applies if you omit it.
+
+```bash
+# .env.local
+LANGSMITH_TRACING=true
+LANGSMITH_API_KEY=lsv2_pt_...
+LANGSMITH_PROJECT=assistant-ui
+```
+
+Install the LangSmith SDK.
+
+```bash
+npm install langsmith
+```
+
+## Wrap the AI SDK
+
+Destructure the wrapped exports from `wrapAISDK(ai)` and use them in your route.
+
+```ts
+import * as ai from "ai";
+import { wrapAISDK } from "langsmith/experimental/vercel";
+import { openai } from "@ai-sdk/openai";
+import type { UIMessage } from "ai";
+
+const { streamText } = wrapAISDK(ai);
+
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json();
+  const result = streamText({
+    model: openai("gpt-5.4-nano"),
+    messages: await ai.convertToModelMessages(messages),
+  });
+  return result.toUIMessageStreamResponse();
+}
+```
+
+Note: `convertToModelMessages` is not part of the wrapper, so import it from `ai` directly.
+
+## Metadata for grouping (optional)
+
+Pass a `langsmith` provider option to tag traces with user, session, or run identifiers. Build the value with `createLangSmithProviderOptions`.
+
+```ts
+import { createLangSmithProviderOptions } from "langsmith/experimental/vercel";
+
+const result = streamText({
+  model: openai("gpt-5.4-nano"),
+  messages: await ai.convertToModelMessages(messages),
+  providerOptions: {
+    langsmith: createLangSmithProviderOptions({
+      name: "chat-completion",
+      metadata: { userId, threadId },
+    }),
+  },
+});
+```
+
+`name` becomes the run name in LangSmith. Traces filter by the metadata fields you pass; resolve `userId` and `threadId` from your auth and thread state, don't ship literal strings.
+
+## Serverless flush
+
+Serverless functions exit before LangSmith flushes batched traces. Before returning, force the flush with the `Client` from `langsmith`; without it you lose traces on Vercel, AWS Lambda, and similar platforms.
+
+```ts
+import { Client } from "langsmith";
+
+const client = new Client();
+await client.awaitPendingTraceBatches();
+```
+
+## Verify
+
+Send a message; the trace should appear in your LangSmith project within seconds. Confirm a new run named according to `name` (or the default `streamText`), that inputs, outputs, token usage, and latency are populated, and that metadata fields show up as filters.
+
+## Notes
+
+- `experimental_telemetry` vs `wrapAISDK`: the AI SDK's generic `experimental_telemetry` flag emits OpenTelemetry spans (the path Langfuse uses). `wrapAISDK` is LangSmith's own path; you do not need to set `experimental_telemetry` when using it.
+- LangGraph users: if your backend is LangGraph Cloud, prefer the LangGraph runtime; tracing is built in. Use `wrapAISDK` only when calling AI SDK directly.
+- Version requirements: LangSmith documents AI SDK v5 as the minimum and `langsmith >= 0.3.63`. The wrapper continues to work against v6 in practice; if you hit an incompatibility, check LangSmith's release notes.

--- a/assistant-ui/skills/observability/references/react-o11y.md
+++ b/assistant-ui/skills/observability/references/react-o11y.md
@@ -1,0 +1,140 @@
+# react-o11y
+
+Headless primitives for visualizing observability spans (traces, waterfalls) from any span source.
+
+The primitives and `SpanResource` ship from `@assistant-ui/react-o11y` (experimental). Spans are mounted as a Tap resource with `useAui` and read with `useAuiState` from `@assistant-ui/store`. Feed it any data that matches the `SpanData` shape; the resource computes depth, `hasChildren`, `timeRange`, and collapse state for you.
+
+## Contents
+
+- [Imports](#imports)
+- [SpanData input](#spandata-input)
+- [SpanResource](#spanresource)
+- [SpanState](#spanstate)
+- [SpanPrimitive components](#spanprimitive-components)
+- [SpanByIndexProvider](#spanbyindexprovider)
+- [Full trace view](#full-trace-view)
+
+## Imports
+
+```tsx
+import {
+  SpanPrimitive,
+  SpanResource,
+  SpanByIndexProvider,
+  type SpanData,
+} from "@assistant-ui/react-o11y";
+import { useAui, AuiProvider, useAuiState } from "@assistant-ui/store";
+```
+
+## SpanData input
+
+Raw spans you pass in. `parentSpanId` is `null` for roots, `endedAt`/`latencyMs` are `null` while running.
+
+```ts
+type SpanData = {
+  id: string;
+  parentSpanId: string | null;
+  name: string;
+  type: string; // category, e.g. "llm" or "tool"
+  status: "running" | "completed" | "failed" | "skipped";
+  startedAt: number; // ms
+  endedAt: number | null;
+  latencyMs: number | null;
+};
+```
+
+## SpanResource
+
+A Tap resource that ingests raw spans and produces reactive, tree-aware state. Mount it with `useAui`, then provide the result through `AuiProvider`.
+
+```tsx
+const aui = useAui({ resource: SpanResource({ spans }) });
+```
+
+## SpanState
+
+The computed state for a span, available via `useAuiState((s) => s.span)` inside any span-scoped subtree. Extends `SpanData` with `depth`, `hasChildren`, `isCollapsed`, `children`, and `timeRange`.
+
+```ts
+type SpanState = SpanData & {
+  depth: number;
+  hasChildren: boolean;
+  isCollapsed: boolean;
+  children: SpanItemState[];
+  timeRange: { min: number; max: number };
+};
+```
+
+## SpanPrimitive components
+
+All components forward refs and accept `className`, `style`, and standard DOM props. State is exposed through data attributes for styling.
+
+- `SpanPrimitive.Root`: container `<div>` exposing `data-span-id`, `data-span-status`, `data-span-type`, `data-span-depth`, and `data-collapsed`.
+- `SpanPrimitive.Indent`: `<div>` whose left padding is `baseIndent + depth * indentPerLevel`. Props `baseIndent` (default `8`) and `indentPerLevel` (default `12`), both px.
+- `SpanPrimitive.CollapseToggle`: `<button>` that toggles collapse, rendered only when the span has children. Exposes `data-collapsed` and stops click propagation.
+- `SpanPrimitive.StatusIndicator`: `<span>` exposing `data-span-status`, with no built-in glyph.
+- `SpanPrimitive.TypeBadge`: `<span>` defaulting its children to `span.type`; override by passing custom children.
+- `SpanPrimitive.Name`: `<span>` defaulting its children to `span.name`; override by passing custom children.
+- `SpanPrimitive.Children`: iterates visible (non-collapsed) spans, wrapping each in `SpanByIndexProvider`.
+- `SpanPrimitive.ChildByIndex`: renders a single child by `index`, useful for virtualization.
+
+```tsx
+<SpanPrimitive.StatusIndicator
+  className="size-2 rounded-full
+    data-[span-status=running]:bg-yellow-500
+    data-[span-status=completed]:bg-green-500
+    data-[span-status=failed]:bg-red-500
+    data-[span-status=skipped]:bg-gray-400"
+/>
+```
+
+`SpanPrimitive.Children` and `SpanPrimitive.ChildByIndex` take either a render prop or a memoized `components.Span`. Prefer the component form.
+
+```tsx
+<SpanPrimitive.Children components={{ Span: SpanRow }} />
+<SpanPrimitive.ChildByIndex index={0} components={{ Span: SpanRow }} />
+```
+
+## SpanByIndexProvider
+
+Lower-level provider that scopes a subtree to the span at `index`. `SpanPrimitive.Children` wires this up for you, so reach for it directly only when rendering rows manually.
+
+```tsx
+<SpanByIndexProvider index={0}>
+  <SpanPrimitive.Root>{/* reads the span at index 0 */}</SpanPrimitive.Root>
+</SpanByIndexProvider>
+```
+
+## Full trace view
+
+A recursive `SpanRow` renders one span and its children; `TraceView` mounts the resource and renders the roots.
+
+```tsx
+"use client";
+import { SpanPrimitive, SpanResource, type SpanData } from "@assistant-ui/react-o11y";
+import { useAui, AuiProvider } from "@assistant-ui/store";
+
+function SpanRow() {
+  return (
+    <SpanPrimitive.Root className="flex items-center gap-2 py-1">
+      <SpanPrimitive.Indent />
+      <SpanPrimitive.CollapseToggle className="size-4 cursor-pointer">
+        ▸
+      </SpanPrimitive.CollapseToggle>
+      <SpanPrimitive.StatusIndicator className="size-2 rounded-full" />
+      <SpanPrimitive.TypeBadge className="rounded bg-muted px-1.5 text-xs" />
+      <SpanPrimitive.Name className="text-sm" />
+      <SpanPrimitive.Children components={{ Span: SpanRow }} />
+    </SpanPrimitive.Root>
+  );
+}
+
+export function TraceView({ spans }: { spans: SpanData[] }) {
+  const aui = useAui({ resource: SpanResource({ spans }) });
+  return (
+    <AuiProvider value={aui}>
+      <SpanPrimitive.Children components={{ Span: SpanRow }} />
+    </AuiProvider>
+  );
+}
+```

--- a/assistant-ui/skills/primitives/SKILL.md
+++ b/assistant-ui/skills/primitives/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: primitives
-description: Guide for assistant-ui UI primitives - ThreadPrimitive, ComposerPrimitive, MessagePrimitive. Use when customizing chat UI components.
-version: 0.0.1
+description: "Builds and customizes assistant-ui chat UI from composable, unstyled @assistant-ui/react primitives that follow Radix-style part composition. Use when assembling or styling a custom Thread, Composer, message rendering, action bar, or branch picker from building blocks: ThreadPrimitive (.Root, .Viewport, .Messages, .Empty, .ScrollToBottom), ComposerPrimitive (.Input, .Send, .Cancel, .Attachments), MessagePrimitive (.Parts/.Content, .Error), ActionBarPrimitive (.Copy, .Edit, .Reload, .Speak, feedback, .ExportMarkdown), BranchPickerPrimitive, AttachmentPrimitive, ThreadListPrimitive, ThreadListItemPrimitive. Covers MessagePrimitive.Parts children render functions for text, image, reasoning, and tool-call parts; conditional rendering with AuiIf (deprecated .If); and gotchas like wrapping in AssistantRuntimeProvider and adding className since primitives ship unstyled. For prebuilt drop-in UI and scaffolding use setup; for multi-thread sidebar behavior use thread-list."
 license: MIT
 ---
 
 # assistant-ui Primitives
 
-**Always consult [assistant-ui.com/llms.txt](https://assistant-ui.com/llms.txt) for latest API.**
+**Always consult [assistant-ui.com/llms.txt](https://www.assistant-ui.com/llms.txt) for the latest API.**
 
 Composable, unstyled components following Radix UI patterns.
 
@@ -17,6 +16,8 @@ Composable, unstyled components following Radix UI patterns.
 - [./references/composer.md](./references/composer.md) -- ComposerPrimitive deep dive
 - [./references/message.md](./references/message.md) -- MessagePrimitive deep dive
 - [./references/action-bar.md](./references/action-bar.md) -- ActionBarPrimitive deep dive
+- [./references/part-grouping.md](./references/part-grouping.md) -- Part grouping and chain-of-thought UI
+- [./references/mentions.md](./references/mentions.md) -- Composer mentions and slash commands
 
 ## Import
 
@@ -57,10 +58,15 @@ function CustomThread() {
       </ThreadPrimitive.Empty>
 
       <ThreadPrimitive.Viewport className="flex-1 overflow-y-auto p-4">
-        <ThreadPrimitive.Messages components={{
-          UserMessage: CustomUserMessage,
-          AssistantMessage: CustomAssistantMessage,
-        }} />
+        <ThreadPrimitive.Messages>
+          {({ message }) =>
+            message.role === "user" ? (
+              <CustomUserMessage />
+            ) : (
+              <CustomAssistantMessage />
+            )
+          }
+        </ThreadPrimitive.Messages>
       </ThreadPrimitive.Viewport>
 
       <ComposerPrimitive.Root className="border-t p-4 flex gap-2">
@@ -96,27 +102,48 @@ Prefer `AuiIf` for new code. Primitive `.If` components still exist but are depr
 <AuiIf condition={({ thread }) => thread.isEmpty}>No messages</AuiIf>
 ```
 
-## Content Parts
+## Message Parts (children render function)
+
+As of 0.14, primitives that render lists (`ThreadPrimitive.Messages`, `MessagePrimitive.Parts`, `ThreadPrimitive.Suggestions`, `ThreadListPrimitive.Items`, `ComposerPrimitive.Attachments`) take a children render function instead of a `components` prop. The `components` prop still works but is deprecated.
+
+`MessagePrimitive.Parts` is the canonical name (`MessagePrimitive.Content` is a deprecated alias).
 
 ```tsx
-<MessagePrimitive.Content components={{
-  Text: ({ part }) => <p>{part.text}</p>,
-  Image: ({ part }) => <img src={part.image} alt="" />,
-  ToolCall: ({ part }) => <div>Tool: {part.toolName}</div>,
-  Reasoning: ({ part }) => <details><summary>Thinking</summary>{part.text}</details>,
-}} />
+<MessagePrimitive.Parts>
+  {({ part }) => {
+    switch (part.type) {
+      case "text":
+        return <p>{part.text}</p>;
+      case "image":
+        return <img src={part.image} alt="" />;
+      case "reasoning":
+        return (
+          <details>
+            <summary>Thinking</summary>
+            {part.text}
+          </details>
+        );
+      case "tool-call":
+        return part.toolUI ?? <div>Tool: {part.toolName}</div>;
+      default:
+        return null; // registered tool/data UIs still render
+    }
+  }}
+</MessagePrimitive.Parts>
 ```
+
+Returning `null` from the render function lets registered tool and data UIs render via the registry; return `<></>` to explicitly render nothing.
 
 ## Branch Picker
 
 ```tsx
-<MessagePrimitive.If hasBranches>
+<AuiIf condition={({ message }) => message.branchCount > 1}>
   <BranchPickerPrimitive.Root className="flex items-center gap-1">
     <BranchPickerPrimitive.Previous>←</BranchPickerPrimitive.Previous>
     <span><BranchPickerPrimitive.Number /> / <BranchPickerPrimitive.Count /></span>
     <BranchPickerPrimitive.Next>→</BranchPickerPrimitive.Next>
   </BranchPickerPrimitive.Root>
-</MessagePrimitive.If>
+</AuiIf>
 ```
 
 ## Common Gotchas

--- a/assistant-ui/skills/primitives/references/action-bar.md
+++ b/assistant-ui/skills/primitives/references/action-bar.md
@@ -56,7 +56,6 @@ Copy message content to clipboard.
   className="p-1 rounded hover:bg-gray-100"
   copiedDuration={2000}  // Duration of "copied" state
 >
-  {/* Default content */}
   <CopyIcon className="w-4 h-4" />
 </ActionBarPrimitive.Copy>
 
@@ -160,7 +159,6 @@ function MessageActionBar() {
       className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity"
       hideWhenRunning
     >
-      {/* Copy */}
       <ActionBarPrimitive.Copy
         className="p-1.5 rounded text-gray-500 hover:text-gray-700 hover:bg-gray-100"
         copiedDuration={2000}
@@ -173,21 +171,18 @@ function MessageActionBar() {
         </AuiIf>
       </ActionBarPrimitive.Copy>
 
-      {/* Regenerate (assistant only) */}
       <AuiIf condition={({ message }) => message.role === "assistant"}>
         <ActionBarPrimitive.Reload className="p-1.5 rounded text-gray-500 hover:text-gray-700 hover:bg-gray-100">
           <RefreshIcon className="w-4 h-4" />
         </ActionBarPrimitive.Reload>
       </AuiIf>
 
-      {/* Edit (user only) */}
       <AuiIf condition={({ message }) => message.role === "user"}>
         <ActionBarPrimitive.Edit className="p-1.5 rounded text-gray-500 hover:text-gray-700 hover:bg-gray-100">
           <EditIcon className="w-4 h-4" />
         </ActionBarPrimitive.Edit>
       </AuiIf>
 
-      {/* Text-to-speech */}
       <AuiIf condition={({ message }) => message.speech == null}>
         <ActionBarPrimitive.Speak className="p-1.5 rounded text-gray-500 hover:text-gray-700 hover:bg-gray-100">
           <SpeakerIcon className="w-4 h-4" />
@@ -199,7 +194,6 @@ function MessageActionBar() {
         </ActionBarPrimitive.StopSpeaking>
       </AuiIf>
 
-      {/* Feedback */}
       <div className="border-l pl-1 ml-1">
         <ActionBarPrimitive.FeedbackPositive
           className="p-1.5 rounded text-gray-500 hover:text-green-600 hover:bg-green-50"
@@ -225,7 +219,7 @@ function AssistantMessage() {
     <MessagePrimitive.Root className="group flex mb-4">
       <Avatar fallback="AI" />
       <div className="flex-1">
-        <MessagePrimitive.Content />
+        <MessagePrimitive.Parts />
         <MessageActionBar />
       </div>
     </MessagePrimitive.Root>

--- a/assistant-ui/skills/primitives/references/composer.md
+++ b/assistant-ui/skills/primitives/references/composer.md
@@ -168,12 +168,10 @@ Prefer `AuiIf` for richer state checks (`thread`, `composer`, etc.).
 function CustomComposer() {
   return (
     <ComposerPrimitive.Root className="border-t p-4">
-      {/* Drag-drop overlay */}
       <ComposerPrimitive.AttachmentDropzone className="absolute inset-0 flex items-center justify-center bg-blue-50/80 border-2 border-dashed border-blue-300 rounded-lg opacity-0 pointer-events-none data-[dragging]:opacity-100 data-[dragging]:pointer-events-auto">
         <p className="text-blue-500">Drop files to attach</p>
       </ComposerPrimitive.AttachmentDropzone>
 
-      {/* Attached files */}
       <AuiIf condition={({ composer }) => composer.attachments.length > 0}>
         <ComposerPrimitive.Attachments className="flex flex-wrap gap-2 mb-2">
           <AttachmentPrimitive.Root className="group flex items-center gap-2 bg-gray-100 rounded-lg px-3 py-1.5">
@@ -185,7 +183,6 @@ function CustomComposer() {
         </ComposerPrimitive.Attachments>
       </AuiIf>
 
-      {/* Input row */}
       <div className="flex items-end gap-2">
         <ComposerPrimitive.AddAttachment className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded">
           <PaperclipIcon className="w-5 h-5" />
@@ -228,23 +225,4 @@ function CustomComposer() {
 
 ## Accessing Composer State
 
-```tsx
-import { useComposer, useComposerRuntime } from "@assistant-ui/react";
-
-function ComposerInfo() {
-  // Reactive state
-  const { text, attachments, isSubmitting } = useComposer();
-
-  // Runtime API
-  const runtime = useComposerRuntime();
-  const handleClear = () => runtime.setText("");
-
-  return (
-    <div>
-      <p>Characters: {text.length}</p>
-      <p>Attachments: {attachments.length}</p>
-      <button onClick={handleClear}>Clear</button>
-    </div>
-  );
-}
-```
+Read composer state with `useAuiState((s) => s.composer...)` (e.g. `s.composer.text`, `s.composer.attachments`) and act via `useAui().composer()` (e.g. `.setText("")`). See the `/runtime` skill for the full state API.

--- a/assistant-ui/skills/primitives/references/mentions.md
+++ b/assistant-ui/skills/primitives/references/mentions.md
@@ -1,0 +1,487 @@
+# Composer Mentions and Slash Commands
+
+Type-ahead popovers in the composer: `@` mentions insert directive chips, `/` slash commands insert a chip and fire an action. Both are built on `ComposerPrimitive.Unstable_TriggerPopover` (unstable, under active development).
+
+## Contents
+
+- [Imports](#imports)
+- [Quick start: slash commands](#quick-start-slash-commands)
+- [Quick start: mentions](#quick-start-mentions)
+- [unstable_useMentionAdapter](#unstable_usementionadapter)
+- [unstable_useSlashCommandAdapter](#unstable_useslashcommandadapter)
+- [Unstable_TriggerAdapter](#unstable_triggeradapter)
+- [TriggerPopover components](#triggerpopover-components)
+- [Behavior sub-primitives: Directive vs Action](#behavior-sub-primitives-directive-vs-action)
+- [Categories and drill-down](#categories-and-drill-down)
+- [Combining mentions and slash commands](#combining-mentions-and-slash-commands)
+- [Commands with arguments](#commands-with-arguments)
+- [Async adapters](#async-adapters)
+- [Lexical input](#lexical-input)
+- [Directive format and backend parsing](#directive-format-and-backend-parsing)
+- [Scope context hook](#scope-context-hook)
+
+## Imports
+
+```ts
+import {
+  ComposerPrimitive,
+  unstable_useMentionAdapter,
+  unstable_useSlashCommandAdapter,
+  unstable_defaultDirectiveFormatter,
+  unstable_useTriggerPopoverScopeContext,
+  unstable_useTriggerPopoverTriggers,
+  type Unstable_DirectiveFormatter,
+  type Unstable_Mention,
+  type Unstable_SlashCommand,
+} from "@assistant-ui/react";
+import type { Unstable_TriggerAdapter } from "@assistant-ui/core";
+import { LexicalComposerInput } from "@assistant-ui/react-lexical";
+```
+
+## Quick start: slash commands
+
+`unstable_useSlashCommandAdapter` builds the adapter from a list of commands and returns a spreadable bundle `{ adapter, action }`.
+
+```tsx
+const SLASH_COMMANDS: readonly Unstable_SlashCommand[] = [
+  { id: "summarize", description: "Summarize the conversation", execute: () => console.log("Summarize!") },
+  { id: "translate", description: "Translate text to another language", execute: () => console.log("Translate!") },
+  { id: "help", description: "List all available commands", execute: () => console.log("Help!") },
+];
+
+function MyComposer() {
+  const slash = unstable_useSlashCommandAdapter({ commands: SLASH_COMMANDS });
+  return (
+    <ComposerPrimitive.Unstable_TriggerPopoverRoot>
+      <ComposerPrimitive.Root>
+        <ComposerPrimitive.Input placeholder="Type / for commands..." />
+        <ComposerPrimitive.Send>Send</ComposerPrimitive.Send>
+        <ComposerPrimitive.Unstable_TriggerPopover char="/" adapter={slash.adapter} className="popover">
+          <ComposerPrimitive.Unstable_TriggerPopover.Action {...slash.action} />
+          <ComposerPrimitive.Unstable_TriggerPopoverItems>
+            {(items) =>
+              items.map((item, index) => (
+                <ComposerPrimitive.Unstable_TriggerPopoverItem
+                  key={item.id}
+                  item={item}
+                  index={index}
+                  className="popover-item"
+                >
+                  <strong>{item.label}</strong>
+                  {item.description && <span>{item.description}</span>}
+                </ComposerPrimitive.Unstable_TriggerPopoverItem>
+              ))
+            }
+          </ComposerPrimitive.Unstable_TriggerPopoverItems>
+        </ComposerPrimitive.Unstable_TriggerPopover>
+      </ComposerPrimitive.Root>
+    </ComposerPrimitive.Unstable_TriggerPopoverRoot>
+  );
+}
+```
+
+Note: `Unstable_TriggerPopoverRoot` must be the outermost primitive, wrapping `ComposerPrimitive.Root`.
+
+## Quick start: mentions
+
+`unstable_useMentionAdapter` returns `{ adapter, directive, iconMap?, fallbackIcon? }`. With no options it sources items from the model context tools.
+
+```tsx
+function MyComposer() {
+  const mention = unstable_useMentionAdapter();
+  return (
+    <ComposerPrimitive.Unstable_TriggerPopoverRoot>
+      <ComposerPrimitive.Root>
+        <ComposerPrimitive.Input placeholder="Type @ to mention..." />
+        <ComposerPrimitive.Send>Send</ComposerPrimitive.Send>
+        <ComposerPrimitive.Unstable_TriggerPopover char="@" adapter={mention.adapter}>
+          <ComposerPrimitive.Unstable_TriggerPopover.Directive {...mention.directive} />
+          <ComposerPrimitive.Unstable_TriggerPopoverItems>
+            {(items) =>
+              items.map((item) => (
+                <ComposerPrimitive.Unstable_TriggerPopoverItem key={item.id} item={item}>
+                  {item.label}
+                </ComposerPrimitive.Unstable_TriggerPopoverItem>
+              ))
+            }
+          </ComposerPrimitive.Unstable_TriggerPopoverItems>
+        </ComposerPrimitive.Unstable_TriggerPopover>
+      </ComposerPrimitive.Root>
+    </ComposerPrimitive.Unstable_TriggerPopoverRoot>
+  );
+}
+```
+
+## unstable_useMentionAdapter
+
+| Option | Type | Behavior |
+|---|---|---|
+| `items` | `Unstable_Mention[]` | Flat list (ignored when `categories` is set) |
+| `categories` | `{ id, label, items }[]` | Drill-down groups |
+| `includeModelContextTools` | `boolean \| object` | Default: `true` only when neither `items` nor `categories` is given |
+| `formatter` | `Unstable_DirectiveFormatter` | Override directive serialization |
+| `onInserted` | `(item) => void` | Fires after the directive is inserted |
+| `iconMap` | `Record<string, IconComponent>` | Maps `icon` strings to React components |
+| `fallbackIcon` | `IconComponent` | Used when no `iconMap` entry matches |
+
+Custom items only:
+
+```ts
+const mention = unstable_useMentionAdapter({
+  items: [
+    { id: "alice", type: "user", label: "Alice", icon: "User" },
+    { id: "bob", type: "user", label: "Bob", icon: "User" },
+  ],
+});
+```
+
+Mix custom items with model context tools (flat):
+
+```ts
+const mention = unstable_useMentionAdapter({
+  items: [{ id: "kb", type: "doc", label: "Knowledge Base", icon: "Book" }],
+  includeModelContextTools: true,
+});
+```
+
+Override the tool category, label formatting, and icon:
+
+```ts
+const mention = unstable_useMentionAdapter({
+  categories: [{ id: "users", label: "Users", items: [/* ... */] }],
+  includeModelContextTools: {
+    category: { id: "integrations", label: "Integrations" },
+    formatLabel: (name) =>
+      name.replaceAll("_", " ").replace(/\b\w/g, (c) => c.toUpperCase()),
+    icon: "Wrench",
+  },
+});
+```
+
+## unstable_useSlashCommandAdapter
+
+`Unstable_SlashCommand` fields: `id: string` (required), `label?: string` (defaults to `/${id}`), `description?: string`, `icon?: string`, `execute: () => void` (required).
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `commands` | `Unstable_SlashCommand[]` | none | Command definitions |
+| `removeOnExecute` | `boolean` | `false` | Strips the trigger text after execution |
+| `iconMap` | `Record<string, IconComponent>` | none | Maps `icon` strings to React components |
+| `fallbackIcon` | `IconComponent` | none | Fallback icon component |
+
+Returns `{ adapter, action, iconMap?, fallbackIcon? }`. The hook re-runs on every render, so passing a freshly computed `commands` list always reflects the latest state.
+
+Selecting a command inserts a directive chip (`:command[/summarize]{name=summarize}`) and fires the command's action at the moment of selection. Set `removeOnExecute` for purely transient commands that should leave no chip behind:
+
+```ts
+const slash = unstable_useSlashCommandAdapter({
+  commands: SLASH_COMMANDS,
+  removeOnExecute: true,
+});
+```
+
+Wrap the action callback to add custom dispatch (logging, analytics) while keeping default behavior:
+
+```tsx
+<ComposerPrimitive.Unstable_TriggerPopover.Action
+  onExecute={(item) => {
+    logCommandUsed(item.id);
+    slash.action.onExecute(item);
+  }}
+/>
+```
+
+## Unstable_TriggerAdapter
+
+Both hooks produce an `Unstable_TriggerAdapter`. Implement it directly for full control. All methods are synchronous; back them with external state (React Query, SWR, local state) for async data.
+
+```ts
+const adapter: Unstable_TriggerAdapter = {
+  categories() {
+    return [
+      { id: "tools", label: "Tools" },
+      { id: "users", label: "Users" },
+    ];
+  },
+  categoryItems(categoryId) {
+    if (categoryId === "tools") {
+      return [
+        { id: "search", type: "tool", label: "Search" },
+        { id: "calculator", type: "tool", label: "Calculator" },
+      ];
+    }
+    if (categoryId === "users") {
+      return [
+        { id: "alice", type: "user", label: "Alice" },
+        { id: "bob", type: "user", label: "Bob" },
+      ];
+    }
+    return [];
+  },
+  // Optional: enables global (cross-category) search mode
+  search(query) {
+    const lower = query.toLowerCase();
+    const all = [...this.categoryItems("tools"), ...this.categoryItems("users")];
+    return all.filter(
+      (item) =>
+        item.label.toLowerCase().includes(lower) ||
+        item.id.toLowerCase().includes(lower),
+    );
+  },
+};
+```
+
+## TriggerPopover components
+
+| Component | Description |
+|---|---|
+| `.Unstable_TriggerPopoverRoot` | Outermost wrapper around the whole composer |
+| `.Unstable_TriggerPopover` | One trigger; props `char`, `adapter`, optional `className` |
+| `.Unstable_TriggerPopover.Directive` | Insert-only behavior (mentions); prop `formatter` |
+| `.Unstable_TriggerPopover.Action` | Insert plus action callback (slash commands); props `formatter`, `onExecute` |
+| `.Unstable_TriggerPopoverItems` | Render-prop child receiving the filtered item list |
+| `.Unstable_TriggerPopoverItem` | One item; props `item`, optional `index`, `className` |
+| `.Unstable_TriggerPopoverCategories` | Render-prop child receiving the filtered category list |
+| `.Unstable_TriggerPopoverCategoryItem` | One category row; prop `categoryId` |
+| `.Unstable_TriggerPopoverBack` | Navigation back button for drill-down |
+
+## Behavior sub-primitives: Directive vs Action
+
+Each `Unstable_TriggerPopover` allows exactly one behavior sub-primitive. Spread the bundle returned by the matching hook into it.
+
+- `Directive` only inserts a directive chip into the composer text. Use it for mentions: `<ComposerPrimitive.Unstable_TriggerPopover.Directive {...mention.directive} />`.
+- `Action` inserts a chip and additionally fires `onExecute` at selection. Use it for slash commands: `<ComposerPrimitive.Unstable_TriggerPopover.Action {...slash.action} />`.
+
+Both accept a `formatter` prop. Pass `unstable_defaultDirectiveFormatter` for the standard `:type[label]{name=id}` serialization, or a custom `Unstable_DirectiveFormatter`.
+
+## Categories and drill-down
+
+Provide `categories` to the hook (or implement `categories()` / `categoryItems()` on a manual adapter), then render both `Categories` and `Items`. The popover shows categories first; selecting one drills into its items, and `Back` returns.
+
+```ts
+const mention = unstable_useMentionAdapter({
+  categories: [
+    {
+      id: "users",
+      label: "Users",
+      items: [
+        { id: "alice", type: "user", label: "Alice", icon: "User" },
+        { id: "bob", type: "user", label: "Bob", icon: "User" },
+      ],
+    },
+    {
+      id: "files",
+      label: "Files",
+      items: [{ id: "readme", type: "file", label: "README.md", icon: "FileText" }],
+    },
+  ],
+  includeModelContextTools: true,
+});
+```
+
+```tsx
+<ComposerPrimitive.Unstable_TriggerPopover char="@" adapter={mention.adapter}>
+  <ComposerPrimitive.Unstable_TriggerPopover.Directive {...mention.directive} />
+  <ComposerPrimitive.Unstable_TriggerPopoverBack>← Back</ComposerPrimitive.Unstable_TriggerPopoverBack>
+  <ComposerPrimitive.Unstable_TriggerPopoverCategories>
+    {(categories) =>
+      categories.map((cat) => (
+        <ComposerPrimitive.Unstable_TriggerPopoverCategoryItem key={cat.id} categoryId={cat.id}>
+          {cat.label}
+        </ComposerPrimitive.Unstable_TriggerPopoverCategoryItem>
+      ))
+    }
+  </ComposerPrimitive.Unstable_TriggerPopoverCategories>
+  <ComposerPrimitive.Unstable_TriggerPopoverItems>
+    {(items) =>
+      items.map((item, index) => (
+        <ComposerPrimitive.Unstable_TriggerPopoverItem key={item.id} item={item} index={index}>
+          {item.label}
+        </ComposerPrimitive.Unstable_TriggerPopoverItem>
+      ))
+    }
+  </ComposerPrimitive.Unstable_TriggerPopoverItems>
+</ComposerPrimitive.Unstable_TriggerPopover>
+```
+
+## Combining mentions and slash commands
+
+Share one `TriggerPopoverRoot`; give each trigger its own `TriggerPopover` with its own behavior sub-primitive. Keyboard events route to whichever trigger is currently active.
+
+```tsx
+<ComposerPrimitive.Unstable_TriggerPopoverRoot>
+  <ComposerPrimitive.Root>
+    <ComposerPrimitive.Input placeholder="Type @ to mention, / for commands..." />
+    <ComposerPrimitive.Send>Send</ComposerPrimitive.Send>
+
+    <ComposerPrimitive.Unstable_TriggerPopover char="@" adapter={mention.adapter}>
+      <ComposerPrimitive.Unstable_TriggerPopover.Directive {...mention.directive} />
+      <ComposerPrimitive.Unstable_TriggerPopoverItems>
+        {(items) =>
+          items.map((item) => (
+            <ComposerPrimitive.Unstable_TriggerPopoverItem key={item.id} item={item}>
+              {item.label}
+            </ComposerPrimitive.Unstable_TriggerPopoverItem>
+          ))
+        }
+      </ComposerPrimitive.Unstable_TriggerPopoverItems>
+    </ComposerPrimitive.Unstable_TriggerPopover>
+
+    <ComposerPrimitive.Unstable_TriggerPopover char="/" adapter={slash.adapter}>
+      <ComposerPrimitive.Unstable_TriggerPopover.Action {...slash.action} />
+      <ComposerPrimitive.Unstable_TriggerPopoverItems>
+        {(items) =>
+          items.map((item, index) => (
+            <ComposerPrimitive.Unstable_TriggerPopoverItem key={item.id} item={item} index={index}>
+              {item.label}
+            </ComposerPrimitive.Unstable_TriggerPopoverItem>
+          ))
+        }
+      </ComposerPrimitive.Unstable_TriggerPopoverItems>
+    </ComposerPrimitive.Unstable_TriggerPopover>
+  </ComposerPrimitive.Root>
+</ComposerPrimitive.Unstable_TriggerPopoverRoot>
+```
+
+## Commands with arguments
+
+Read the raw composer value inside `execute` to parse arguments after the command. Pair with `removeOnExecute` to clear the input.
+
+```tsx
+function MyComposer() {
+  const composerRef = useRef<HTMLTextAreaElement>(null);
+  const slash = unstable_useSlashCommandAdapter({
+    commands: SLASH_COMMANDS.map((cmd) => ({
+      ...cmd,
+      execute: () => {
+        const raw = composerRef.current?.value ?? "";
+        const match = raw.match(new RegExp(`^/${cmd.id}\\s+(.*)`));
+        const args = match?.[1]?.trim() ?? "";
+        handleCommand(cmd.id, args);
+      },
+    })),
+    removeOnExecute: true,
+  });
+  return (
+    <ComposerPrimitive.Unstable_TriggerPopoverRoot>
+      <ComposerPrimitive.Root>
+        <ComposerPrimitive.Input ref={composerRef} placeholder="Type / for commands..." />
+        <ComposerPrimitive.Unstable_TriggerPopover char="/" adapter={slash.adapter}>
+          <ComposerPrimitive.Unstable_TriggerPopover.Action {...slash.action} />
+          <ComposerPrimitive.Unstable_TriggerPopoverItems>
+            {(items) =>
+              items.map((item, i) => (
+                <ComposerPrimitive.Unstable_TriggerPopoverItem key={item.id} item={item} index={i}>
+                  <strong>{item.label}</strong>
+                  {item.description && <span>{item.description}</span>}
+                </ComposerPrimitive.Unstable_TriggerPopoverItem>
+              ))
+            }
+          </ComposerPrimitive.Unstable_TriggerPopoverItems>
+        </ComposerPrimitive.Unstable_TriggerPopover>
+        <ComposerPrimitive.Send>Send</ComposerPrimitive.Send>
+      </ComposerPrimitive.Root>
+    </ComposerPrimitive.Unstable_TriggerPopoverRoot>
+  );
+}
+```
+
+## Async adapters
+
+Adapter methods are synchronous, so drive them from external async state. Slash commands and mentions can both swap their source list on every render.
+
+```tsx
+// Slash commands from a query
+function MyComposer() {
+  const { data: commands = [] } = useQuery({
+    queryKey: ["slash-commands"],
+    queryFn: fetchAvailableCommands,
+  });
+  const slash = unstable_useSlashCommandAdapter({ commands });
+  return (/* ... */);
+}
+```
+
+```ts
+// Mention search backed by React Query
+function useMentionAdapter(query: string): Unstable_TriggerAdapter {
+  const { data = [] } = useQuery({
+    queryKey: ["mention-search", query],
+    queryFn: () => fetchUsers(query),
+    enabled: query.length > 0,
+  });
+
+  return useMemo(() => ({
+    categories: () => [],
+    categoryItems: () => [],
+    search: () => data.map((u) => ({ id: u.id, type: "user", label: u.name })),
+  }), [data]);
+}
+```
+
+## Lexical input
+
+`LexicalComposerInput` renders inserted directives as inline chips. It auto-discovers every `Directive` trigger under `TriggerPopoverRoot`, so the structure is otherwise the same as the textarea version.
+
+```tsx
+<ComposerPrimitive.Unstable_TriggerPopoverRoot>
+  <ComposerPrimitive.Root>
+    <LexicalComposerInput placeholder="Type @ to mention..." />
+    <ComposerPrimitive.Send />
+    <ComposerPrimitive.Unstable_TriggerPopover char="@" adapter={mention.adapter}>
+      <ComposerPrimitive.Unstable_TriggerPopover.Directive {...mention.directive} />
+      {/* categories / items render props same as above */}
+    </ComposerPrimitive.Unstable_TriggerPopover>
+  </ComposerPrimitive.Root>
+</ComposerPrimitive.Unstable_TriggerPopoverRoot>
+```
+
+## Directive format and backend parsing
+
+Default serialization is `:type[label]{name=id}`, for example `:tool[Get Weather]{name=get_weather}`. When `id === label`, the attribute is omitted: `:tool[search]`.
+
+Parse directives out of the message text on the backend:
+
+```ts
+const DIRECTIVE_RE = /:([\w-]+)\[([^\]]+)\](?:\{name=([^}]+)\})?/g;
+
+function parseMentions(text: string) {
+  const mentions = [];
+  let match;
+  while ((match = DIRECTIVE_RE.exec(text)) !== null) {
+    mentions.push({
+      type: match[1],
+      label: match[2],
+      id: match[3] ?? match[2],
+    });
+  }
+  return mentions;
+}
+```
+
+Supply a custom `Unstable_DirectiveFormatter` to change serialization (for example, render `/id` instead of the default form), and pass it as the `formatter` prop on `Directive` or `Action`. `createDirectiveText(formatter)` returns a component you can wire into message rendering so directives display as chips on sent messages:
+
+```tsx
+const SlashDirectiveText = createDirectiveText(slashFormatter);
+
+<MessagePrimitive.Parts components={{ Text: SlashDirectiveText }} />
+```
+
+## Scope context hook
+
+`unstable_useTriggerPopoverScopeContext` exposes the live popover state. Must be called inside a `ComposerPrimitive.Unstable_TriggerPopover`.
+
+```ts
+function MyPopoverContent() {
+  const scope = unstable_useTriggerPopoverScopeContext();
+  // scope.open              popover visibility
+  // scope.query             text after the trigger character
+  // scope.categories        filtered category list
+  // scope.items             filtered item list
+  // scope.highlightedIndex  keyboard-navigated index
+  // scope.isSearchMode      true when global search is active
+  // scope.selectItem(item)  programmatic selection
+  // scope.close()           close the popover
+  return null;
+}
+```

--- a/assistant-ui/skills/primitives/references/message.md
+++ b/assistant-ui/skills/primitives/references/message.md
@@ -20,7 +20,7 @@ Individual message display.
 ```tsx
 <MessagePrimitive.Root>
   <Avatar src="/user-avatar.png" />
-  <MessagePrimitive.Content />
+  <MessagePrimitive.Parts />
 </MessagePrimitive.Root>
 ```
 
@@ -37,50 +37,56 @@ Container for a single message.
 </MessagePrimitive.Root>
 ```
 
-## MessagePrimitive.Content
+## MessagePrimitive.Parts
 
-Renders message content parts (text, images, tool calls, etc.).
+Renders message content parts (text, images, tool calls, etc.). `MessagePrimitive.Parts` is canonical; `MessagePrimitive.Content` is a deprecated alias. As of 0.14 it takes a children render function that receives `{ part }`; the `components` prop still works but is deprecated.
 
 ```tsx
-// Simple usage - uses default rendering
-<MessagePrimitive.Content />
+<MessagePrimitive.Parts />
 
-// Custom part rendering
-<MessagePrimitive.Content
-  components={{
-    Text: ({ part }) => (
-      <p className="whitespace-pre-wrap">{part.text}</p>
-    ),
-    Image: ({ part }) => (
-      <img src={part.image} alt="" className="max-w-full rounded" />
-    ),
-    ToolCall: ({ part }) => (
-      <div className="bg-gray-100 rounded p-2">
-        <strong>{part.toolName}</strong>
-        {part.result && <pre>{JSON.stringify(part.result, null, 2)}</pre>}
-      </div>
-    ),
-    Reasoning: ({ part }) => (
-      <details className="text-gray-500">
-        <summary>Thinking...</summary>
-        <p>{part.text}</p>
-      </details>
-    ),
-    Source: ({ part }) => (
-      <a href={part.url} className="text-blue-500">
-        {part.title}
-      </a>
-    ),
-    File: ({ part }) => (
-      <a
-        href={`data:${part.mimeType};base64,${part.data}`}
-        download={part.filename ?? "file"}
-      >
-        📄 {part.filename ?? "file"}
-      </a>
-    ),
+<MessagePrimitive.Parts>
+  {({ part }) => {
+    switch (part.type) {
+      case "text":
+        return <p className="whitespace-pre-wrap">{part.text}</p>;
+      case "image":
+        return <img src={part.image} alt="" className="max-w-full rounded" />;
+      case "tool-call":
+        return (
+          part.toolUI ?? (
+            <div className="bg-gray-100 rounded p-2">
+              <strong>{part.toolName}</strong>
+              {part.result && <pre>{JSON.stringify(part.result, null, 2)}</pre>}
+            </div>
+          )
+        );
+      case "reasoning":
+        return (
+          <details className="text-gray-500">
+            <summary>Thinking...</summary>
+            <p>{part.text}</p>
+          </details>
+        );
+      case "source":
+        return (
+          <a href={part.url} className="text-blue-500">
+            {part.title}
+          </a>
+        );
+      case "file":
+        return (
+          <a
+            href={`data:${part.mimeType};base64,${part.data}`}
+            download={part.filename ?? "file"}
+          >
+            📄 {part.filename ?? "file"}
+          </a>
+        );
+      default:
+        return null; // registered tool/data UIs still render
+    }
   }}
-/>
+</MessagePrimitive.Parts>
 ```
 
 ### Part Types
@@ -135,7 +141,7 @@ function CustomUserMessage() {
       />
       <div className="max-w-[80%]">
         <div className="bg-blue-500 text-white rounded-2xl rounded-tr-sm px-4 py-2">
-          <MessagePrimitive.Content />
+          <MessagePrimitive.Parts />
         </div>
       </div>
     </MessagePrimitive.Root>
@@ -153,7 +159,7 @@ function CustomAssistantMessage() {
 
       <div className="max-w-[80%]">
         <div className="bg-gray-100 rounded-2xl rounded-tl-sm px-4 py-2">
-          <MessagePrimitive.Content />
+          <MessagePrimitive.Parts />
         </div>
       </div>
 
@@ -187,25 +193,4 @@ Use `MessagePrimitive.Error` to render a fallback UI only when the message has a
 
 ## Accessing Message State
 
-```tsx
-import { useMessage, useMessageRuntime } from "@assistant-ui/react";
-
-function MessageInfo() {
-  // Reactive state
-  const { role, content, status, createdAt } = useMessage();
-
-  // Runtime API
-  const runtime = useMessageRuntime();
-  const handleEdit = () => runtime.edit({
-    role: "user",
-    content: [{ type: "text", text: "New content" }],
-  });
-
-  return (
-    <div>
-      <p>Role: {role}</p>
-      <p>Status: {status}</p>
-    </div>
-  );
-}
-```
+Read message state with `useAuiState((s) => s.message...)` and act via `useAui().message()` (e.g. `.reload()`). On assistant messages `s.message.status` is an object; branch on `status.type`. See the `/runtime` skill for the full state API.

--- a/assistant-ui/skills/primitives/references/part-grouping.md
+++ b/assistant-ui/skills/primitives/references/part-grouping.md
@@ -1,0 +1,373 @@
+# Message Part Grouping
+
+Organize adjacent message parts into custom groups, and build chain-of-thought UI (reasoning + tools collapsed into a "thinking" accordion).
+
+## Contents
+
+- [Imports](#imports)
+- [MessagePrimitive.GroupedParts](#messageprimitivegroupedparts)
+- [groupPartByType](#grouppartbytype)
+- [Group keys and synthetic parts](#group-keys-and-synthetic-parts)
+- [Chain of thought](#chain-of-thought)
+- [Reasoning UI](#reasoning-ui)
+- [Sources UI](#sources-ui)
+- [Grouping by parentId or tool name](#grouping-by-parentid-or-tool-name)
+- [Standalone tool display](#standalone-tool-display)
+- [Legacy: Unstable_PartsGrouped](#legacy-unstable_partsgrouped)
+- [Legacy: ChainOfThoughtPrimitive](#legacy-chainofthoughtprimitive)
+- [Notes](#notes)
+
+## Imports
+
+```ts
+import { MessagePrimitive, groupPartByType } from "@assistant-ui/react";
+```
+
+Group-related types from `@assistant-ui/react`: `GroupPart`, `MessagePartGroup`, `ReasoningMessagePartComponent`, `SourceMessagePartComponent`.
+
+## MessagePrimitive.GroupedParts
+
+Renders parts through a `groupBy` function that maps each part to a group-key path. Adjacent parts that resolve to the same key are wrapped together. The children render function receives `{ part, children }` and is called once per group node and once per leaf part.
+
+```tsx
+<MessagePrimitive.GroupedParts
+  groupBy={groupPartByType({
+    "tool-call": ["group-tool"],
+  })}
+>
+  {({ part, children }) => {
+    switch (part.type) {
+      case "group-tool":
+        return <div className="group">{children}</div>;
+      case "tool-call":
+        return part.toolUI ?? <ToolFallback {...part} />;
+      case "text":
+        return <MarkdownText />;
+      default:
+        return null;
+    }
+  }}
+</MessagePrimitive.GroupedParts>
+```
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `groupBy` | `(part) => readonly \`group-${string}\`[]` | Maps a part to a group-key path. Return `[]` to leave it ungrouped. |
+| `children` | `({ part, children }) => ReactNode` | Render function for group nodes and leaf parts. |
+
+Render `children` only for group cases. Leaf cases (`text`, `tool-call`, `reasoning`, etc.) render the part itself; rendering `children` from a leaf case throws.
+
+## groupPartByType
+
+Builds a `groupBy` from a `part.type` to group-key-path map. Part types not listed are left ungrouped. Each value is a nested path: the first key is the outer group, later keys are inner groups.
+
+```ts
+groupPartByType({
+  reasoning: ["group-chainOfThought", "group-reasoning"],
+  "tool-call": ["group-chainOfThought", "group-tool"],
+});
+```
+
+`reasoning` parts land in `group-chainOfThought > group-reasoning`; `tool-call` parts in `group-chainOfThought > group-tool`. Both share the outer `group-chainOfThought`, so adjacent reasoning and tool parts collapse into one chain-of-thought block.
+
+## Group keys and synthetic parts
+
+Group keys must start with `group-`. This lets the render function distinguish synthetic group nodes from real part types like `text` or `tool-call`.
+
+A group node passed to `children` has the `GroupPart` shape:
+
+```ts
+type GroupPart<TKey extends `group-${string}` = `group-${string}`> = {
+  readonly type: TKey;
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+  readonly indices: readonly number[];
+};
+```
+
+Use `part.indices.length` for a count and `part.status.type` for streaming state (for example `"running"`).
+
+## Chain of thought
+
+Group consecutive reasoning tokens and tool calls into a collapsible thinking accordion. This is the canonical chain-of-thought API; render reasoning and tool groups with the Reasoning and tool-group UI components.
+
+```tsx
+import { MessagePrimitive, groupPartByType } from "@assistant-ui/react";
+import { MarkdownText } from "@/components/assistant-ui/markdown-text";
+import {
+  Reasoning,
+  ReasoningContent,
+  ReasoningRoot,
+  ReasoningText,
+  ReasoningTrigger,
+} from "@/components/assistant-ui/reasoning";
+import { ToolFallback } from "@/components/assistant-ui/tool-fallback";
+import {
+  ToolGroupContent,
+  ToolGroupRoot,
+  ToolGroupTrigger,
+} from "@/components/assistant-ui/tool-group";
+import type { FC } from "react";
+
+const AssistantMessage: FC = () => {
+  return (
+    <MessagePrimitive.Root>
+      <MessagePrimitive.GroupedParts
+        groupBy={groupPartByType({
+          reasoning: ["group-chainOfThought", "group-reasoning"],
+          "tool-call": ["group-chainOfThought", "group-tool"],
+        })}
+      >
+        {({ part, children }) => {
+          switch (part.type) {
+            case "group-chainOfThought":
+              return <div className="my-2">{children}</div>;
+            case "group-reasoning": {
+              const running = part.status.type === "running";
+              return (
+                <ReasoningRoot defaultOpen={running}>
+                  <ReasoningTrigger active={running} />
+                  <ReasoningContent aria-busy={running}>
+                    <ReasoningText>{children}</ReasoningText>
+                  </ReasoningContent>
+                </ReasoningRoot>
+              );
+            }
+            case "group-tool":
+              return (
+                <ToolGroupRoot>
+                  <ToolGroupTrigger
+                    count={part.indices.length}
+                    active={part.status.type === "running"}
+                  />
+                  <ToolGroupContent>{children}</ToolGroupContent>
+                </ToolGroupRoot>
+              );
+            case "text":
+              return <MarkdownText />;
+            case "reasoning":
+              return <Reasoning {...part} />;
+            case "tool-call":
+              return part.toolUI ?? <ToolFallback {...part} />;
+            default:
+              return null;
+          }
+        }}
+      </MessagePrimitive.GroupedParts>
+    </MessagePrimitive.Root>
+  );
+};
+```
+
+Note: LangGraph does not emit reasoning in the AI SDK reasoning stream format. To show LangGraph reasoning, emit it as a custom data part and render it via `makeAssistantDataUI`.
+
+## Reasoning UI
+
+The `reasoning` registry component (`https://r.assistant-ui.com/reasoning.json`) provides a collapsible thinking accordion. Exports from `@/components/assistant-ui/reasoning`: `Reasoning`, `ReasoningRoot`, `ReasoningTrigger`, `ReasoningContent`, `ReasoningText`, `ReasoningFade`, `reasoningVariants`. `ReasoningGroup` is deprecated.
+
+```tsx
+<MessagePrimitive.GroupedParts
+  groupBy={groupPartByType({ reasoning: ["group-reasoning"] })}
+>
+  {({ part, children }) => {
+    switch (part.type) {
+      case "group-reasoning": {
+        const running = part.status.type === "running";
+        return (
+          <ReasoningRoot defaultOpen={running}>
+            <ReasoningTrigger active={running} />
+            <ReasoningContent aria-busy={running}>
+              <ReasoningText>{children}</ReasoningText>
+            </ReasoningContent>
+          </ReasoningRoot>
+        );
+      }
+      case "text":
+        return <MarkdownText />;
+      case "reasoning":
+        return <Reasoning {...part} />;
+      case "tool-call":
+        return part.toolUI ?? <ToolFallback {...part} />;
+      default:
+        return null;
+    }
+  }}
+</MessagePrimitive.GroupedParts>
+```
+
+Wire `part.status.type === "running"` into `defaultOpen` so the accordion opens automatically while reasoning streams and stays closed once done. The `group-reasoning` case must render `{children}`; the leaf `reasoning` case must not.
+
+| Component | Notable props |
+|-----------|---------------|
+| `ReasoningRoot` | `defaultOpen?`, `open?`, `onOpenChange?`, `variant?` (`"outline"` default, `"ghost"`, `"muted"`) |
+| `ReasoningTrigger` | `active?` (shimmer while streaming), `duration?` (appends `(Ns)`) |
+| `ReasoningContent` | wraps `CollapsibleContent`; includes `ReasoningFade` |
+| `ReasoningText` | scrollable text container (`max-h-64`) |
+| `Reasoning` | leaf `ReasoningMessagePartComponent`, renders the part via markdown |
+
+## Sources UI
+
+The `sources` registry component (`https://r.assistant-ui.com/sources.json`) renders URL and document citations. `Sources` is a `SourceMessagePartComponent`; render it from a leaf `source` case.
+
+```tsx
+import { Sources } from "@/components/assistant-ui/sources";
+
+<MessagePrimitive.Parts>
+  {({ part }) => {
+    if (part.type === "source") return <Sources {...part} />;
+    return null;
+  }}
+</MessagePrimitive.Parts>
+```
+
+`Sources` branches on `part.sourceType`: `"url"` renders a linked badge with favicon and title (falling back to the domain), `"document"` renders a non-linked badge with a file icon and `part.title`. Compound sub-components `Sources.Root` (`Source`), `Sources.Icon` (`SourceIcon`), `Sources.Title` (`SourceTitle`) allow custom composition.
+
+```tsx
+<Sources.Root href="https://example.com">
+  <Sources.Icon
+    url="https://example.com"
+    faviconUrl={(domain) => `https://my-proxy.example.com/${domain}.ico`}
+  />
+  <Sources.Title>Example</Sources.Title>
+</Sources.Root>
+```
+
+To group sources by their `parentId` (for example all citations under one tool result), use `GroupedParts` with a `group-parent-` key (see below).
+
+## Grouping by parentId or tool name
+
+`groupBy` is arbitrary, so you can group on any part field. Return a key starting with `group-`, and branch on `part.type.startsWith(...)` in the render function.
+
+```tsx
+<MessagePrimitive.GroupedParts
+  groupBy={(part) => {
+    if (!part.parentId) return [];
+    return [`group-parent-${part.parentId}`];
+  }}
+>
+  {({ part, children }) => {
+    if (part.type.startsWith("group-parent-")) {
+      const id = part.type.replace("group-parent-", "");
+      return (
+        <ParentGroup id={id} count={part.indices.length}>
+          {children}
+        </ParentGroup>
+      );
+    }
+    if (part.type === "text") return <MarkdownText />;
+    if (part.type === "source") return <Sources {...part} />;
+    if (part.type === "tool-call") return part.toolUI ?? <ToolFallback {...part} />;
+    return null;
+  }}
+</MessagePrimitive.GroupedParts>
+```
+
+Group by tool name the same way, keying on `part.toolName`:
+
+```tsx
+groupBy={(part) => {
+  if (part.type !== "tool-call") return [];
+  return [`group-tool-${part.toolName}`];
+}}
+```
+
+## Standalone tool display
+
+`groupPartByType` understands the synthetic `"standalone-tool-call"` key, which matches tools marked `display: "standalone"`, MCP-app calls, and `human`-type tools. Map it to `[]` to keep those tools out of the chain-of-thought group and render them inline.
+
+```ts
+const toolkit = {
+  ask_user: { type: "human", render: AskUI },           // standalone (forced)
+  search_web: { type: "frontend", render: SearchUI },   // inline trace (default)
+  checkout: { type: "frontend", render: CheckoutUI, display: "standalone" },
+} satisfies Toolkit;
+```
+
+```tsx
+<MessagePrimitive.GroupedParts
+  groupBy={groupPartByType({
+    reasoning: ["group-chainOfThought", "group-reasoning"],
+    "tool-call": ["group-chainOfThought", "group-tool"],
+    "standalone-tool-call": [],
+  })}
+>
+  {({ part, children }) => {
+    switch (part.type) {
+      case "group-chainOfThought":
+        return <div className="chain-of-thought">{children}</div>;
+      case "tool-call":
+        return part.toolUI ?? <ToolFallback {...part} />;
+      default:
+        return null;
+    }
+  }}
+</MessagePrimitive.GroupedParts>
+```
+
+Note: `"mcp-app"` is a deprecated key superseded by `"standalone-tool-call"`.
+
+## Legacy: Unstable_PartsGrouped
+
+`MessagePrimitive.Unstable_PartsGrouped` predates `GroupedParts`. It accepts a `groupingFunction` that returns `MessagePartGroup[]` (not adjacency-limited) and a `components` map. Prefer `GroupedParts` in new code.
+
+```ts
+type MessagePartGroup = {
+  groupKey: string | undefined;
+  indices: number[];
+};
+```
+
+```tsx
+<MessagePrimitive.Unstable_PartsGrouped
+  groupingFunction={(parts) => {
+    const groups = new Map<string, number[]>();
+    parts.forEach((part, index) => {
+      const key = part.parentId ?? `__ungrouped_${index}`;
+      const indices = groups.get(key) ?? [];
+      indices.push(index);
+      groups.set(key, indices);
+    });
+    return Array.from(groups.entries()).map(([key, indices]) => ({
+      groupKey: key.startsWith("__ungrouped_") ? undefined : key,
+      indices,
+    }));
+  }}
+  components={{
+    Text: MarkdownText,
+    tools: { Fallback: ToolFallback },
+    Group: ({ groupKey, children }) => {
+      if (!groupKey) return <>{children}</>;
+      return <div className="rounded-lg border p-3">{children}</div>;
+    },
+  }}
+/>
+```
+
+The `components` map supports `Empty`, `Text`, `Reasoning`, `Source`, `Image`, `File`, `Unstable_Audio`, `tools`, and `Group`.
+
+## Legacy: ChainOfThoughtPrimitive
+
+`ChainOfThoughtPrimitive` and the `components.ChainOfThought` prop on `MessagePrimitive.Parts` are older chain-of-thought APIs. They still function but should not be used in new code; reach for `GroupedParts` instead. The collapsed state can be read with `AuiIf`:
+
+```tsx
+import { AuiIf, ChainOfThoughtPrimitive } from "@assistant-ui/react";
+import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
+
+const ChainOfThoughtAccordionTrigger = () => (
+  <ChainOfThoughtPrimitive.AccordionTrigger className="flex w-full cursor-pointer items-center gap-2 px-4 py-2 text-sm">
+    <AuiIf condition={(s) => s.chainOfThought.collapsed}>
+      <ChevronRightIcon className="size-4" />
+    </AuiIf>
+    <AuiIf condition={(s) => !s.chainOfThought.collapsed}>
+      <ChevronDownIcon className="size-4" />
+    </AuiIf>
+    Thinking
+  </ChainOfThoughtPrimitive.AccordionTrigger>
+);
+```
+
+## Notes
+
+- `GroupedParts` groups adjacent runs only: the same key appearing again after a gap starts a new group.
+- Always handle every renderable leaf part type, or those parts render nothing.
+- Group keys must begin with `group-`; the render function relies on that prefix.
+- Use `part.status.type === "running"` to drive `defaultOpen` and streaming indicators.

--- a/assistant-ui/skills/primitives/references/thread.md
+++ b/assistant-ui/skills/primitives/references/thread.md
@@ -19,12 +19,11 @@ Container for the entire chat thread.
 ```tsx
 <ThreadPrimitive.Root>
   <ThreadPrimitive.Viewport>
-    <ThreadPrimitive.Messages
-      components={{
-        UserMessage: MyUserMessage,
-        AssistantMessage: MyAssistantMessage,
-      }}
-    />
+    <ThreadPrimitive.Messages>
+      {({ message }) =>
+        message.role === "user" ? <MyUserMessage /> : <MyAssistantMessage />
+      }
+    </ThreadPrimitive.Messages>
   </ThreadPrimitive.Viewport>
 </ThreadPrimitive.Root>
 ```
@@ -57,22 +56,17 @@ Scrollable area containing messages. Handles auto-scroll on new messages.
 
 ## ThreadPrimitive.Messages
 
-Renders the message list.
+Renders the message list. As of 0.14 it takes a children render function that receives `{ message }` (with `role` and `composer.isEditing`). The `components` prop still works but is deprecated.
 
 ```tsx
-<ThreadPrimitive.Messages
-  components={{
-    // Required: Message components
-    UserMessage: () => <MessagePrimitive.Root>...</MessagePrimitive.Root>,
-    AssistantMessage: () => <MessagePrimitive.Root>...</MessagePrimitive.Root>,
-
-    // Optional: System message
-    SystemMessage: ({ message }) => <div>{message.content}</div>,
-
-    // Optional: Edit composer for message editing
-    EditComposer: () => <ComposerPrimitive.Root>...</ComposerPrimitive.Root>,
+<ThreadPrimitive.Messages>
+  {({ message }) => {
+    if (message.composer.isEditing) return <EditComposer />;
+    if (message.role === "user") return <UserMessage />;
+    if (message.role === "system") return <SystemMessage />;
+    return <AssistantMessage />;
   }}
-/>
+</ThreadPrimitive.Messages>
 ```
 
 ## ThreadPrimitive.Empty
@@ -102,18 +96,14 @@ Button that appears when scrolled up, scrolls to bottom on click.
 
 ## ThreadPrimitive.Suggestions
 
-Renders suggested quick replies.
+Renders suggested quick replies. The children render function receives `{ suggestion }`.
 
 ```tsx
-<ThreadPrimitive.Suggestions
-  components={{
-    Suggestion: ({ suggestion }) => (
-      <button onClick={() => suggestion.onClick()}>
-        {suggestion.text}
-      </button>
-    ),
-  }}
-/>
+<ThreadPrimitive.Suggestions>
+  {({ suggestion }) => (
+    <button onClick={() => suggestion.onClick()}>{suggestion.text}</button>
+  )}
+</ThreadPrimitive.Suggestions>
 ```
 
 ## Conditional Rendering (`AuiIf`)
@@ -149,48 +139,45 @@ Renders suggested quick replies.
 function CustomThread() {
   return (
     <ThreadPrimitive.Root className="relative flex flex-col h-full bg-white">
-      {/* Empty state */}
       <AuiIf condition={({ thread }) => thread.isEmpty}>
         <div className="flex-1 flex items-center justify-center">
           <div className="text-center p-8">
             <h1 className="text-2xl font-bold mb-2">AI Assistant</h1>
             <p className="text-gray-500 mb-4">How can I help you today?</p>
-            <ThreadPrimitive.Suggestions
-              components={{
-                Suggestion: ({ suggestion }) => (
-                  <button
-                    className="m-1 px-4 py-2 bg-gray-100 rounded-full"
-                    onClick={suggestion.onClick}
-                  >
-                    {suggestion.text}
-                  </button>
-                ),
-              }}
-            />
+            <ThreadPrimitive.Suggestions>
+              {({ suggestion }) => (
+                <button
+                  className="m-1 px-4 py-2 bg-gray-100 rounded-full"
+                  onClick={suggestion.onClick}
+                >
+                  {suggestion.text}
+                </button>
+              )}
+            </ThreadPrimitive.Suggestions>
           </div>
         </div>
       </AuiIf>
 
-      {/* Messages */}
       <AuiIf condition={({ thread }) => !thread.isEmpty}>
         <ThreadPrimitive.Viewport className="flex-1 overflow-y-auto">
           <div className="max-w-3xl mx-auto p-4">
-            <ThreadPrimitive.Messages
-              components={{
-                UserMessage: CustomUserMessage,
-                AssistantMessage: CustomAssistantMessage,
-              }}
-            />
+            <ThreadPrimitive.Messages>
+              {({ message }) =>
+                message.role === "user" ? (
+                  <CustomUserMessage />
+                ) : (
+                  <CustomAssistantMessage />
+                )
+              }
+            </ThreadPrimitive.Messages>
           </div>
         </ThreadPrimitive.Viewport>
       </AuiIf>
 
-      {/* Scroll to bottom */}
       <ThreadPrimitive.ScrollToBottom className="absolute bottom-24 right-4 p-2 rounded-full bg-white shadow-lg hover:bg-gray-50">
         <ChevronDownIcon className="w-5 h-5" />
       </ThreadPrimitive.ScrollToBottom>
 
-      {/* Composer */}
       <div className="border-t bg-white">
         <CustomComposer />
       </div>
@@ -201,22 +188,4 @@ function CustomThread() {
 
 ## Accessing Thread State
 
-```tsx
-import { useThread, useThreadRuntime } from "@assistant-ui/react";
-
-function ThreadInfo() {
-  // Reactive state
-  const { messages, isRunning } = useThread();
-
-  // Runtime API
-  const runtime = useThreadRuntime();
-  const handleClear = () => runtime.startRun();
-
-  return (
-    <div>
-      <p>{messages.length} messages</p>
-      {isRunning && <p>Generating...</p>}
-    </div>
-  );
-}
-```
+Read thread state with `useAuiState((s) => s.thread...)` (e.g. `s.thread.messages`, `s.thread.isRunning`) and act via `useAui().thread()`. See the `/runtime` skill for the full state API.

--- a/assistant-ui/skills/react-mcp/SKILL.md
+++ b/assistant-ui/skills/react-mcp/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: react-mcp
+description: "Lets end users add, authenticate, and manage MCP servers from the browser in assistant-ui apps with @assistant-ui/react-mcp. Use when building user-managed MCP server UIs: mounting McpManagerResource via useAui({ mcp }), declaring presets with defineConnector, dropping in McpConfigDialog, or composing McpManagerPrimitive (Root, Connectors, CustomServers, AddCustomTrigger), McpServerPrimitive (Root, Name, Icon, Status, ConnectButton, DisconnectButton, OAuthLink, RemoveButton, Error), and McpAddFormPrimitive (NameField, UrlField, AuthSelect, AuthFields, Submit, Cancel). Covers auth modes none/bearer/oauth, the OAuth flow with McpOAuthCallback, connection states, storage via McpLocalStorage/McpMemoryStorage/McpCustomStorage, reading state with useAuiState (s.mcp, s.mcpServer), and imperative addCustomServer/connect/callTool. Distinct from developer-defined backend @ai-sdk/mcp tools in the tools skill. Reach for this when connected-server tools are missing, OAuth never completes, or servers do not persist."
+license: MIT
+---
+
+# assistant-ui React MCP
+
+**Always consult [assistant-ui.com/llms.txt](https://www.assistant-ui.com/llms.txt) for the latest API.**
+
+Let end users add, authenticate, and manage MCP servers from the browser with `@assistant-ui/react-mcp`. The connected servers' tools are merged into the chat runtime automatically.
+
+## Contents
+
+- [References](#references) | [Routes vs tools](#routes-vs-tools) | [Mount the manager](#mount-the-manager) | [Drop-in dialog](#drop-in-dialog) | [Compose from primitives](#compose-from-primitives) | [OAuth connect flow](#oauth-connect-flow) | [Custom storage](#custom-storage) | [Imperative API](#imperative-api) | [Common Gotchas](#common-gotchas) | [Related Skills](#related-skills)
+
+## References
+
+- [./references/setup.md](./references/setup.md) -- McpManagerResource, defineConnector, storage, useAui({ mcp })
+- [./references/ui.md](./references/ui.md) -- McpManagerPrimitive / McpServerPrimitive / McpConfigDialog
+- [./references/oauth.md](./references/oauth.md) -- OAuth connect flow and auth modes
+
+## Routes vs tools
+
+This skill is for **user-managed** MCP servers: the end user picks and authenticates servers at runtime in the browser. Each server's tools are namespaced as `serverId__toolName` and exposed to the chat runtime with no extra wiring.
+
+For **developer-defined** tools (frontend `makeAssistantTool`, backend AI SDK `tool()`, custom tool-call UI), use the [tools](../tools/SKILL.md) skill instead. The two compose: a chat built with `useChatRuntime` can use both app tools and user-connected MCP tools at once.
+
+## Mount the manager
+
+`McpManagerResource({ connectors })` builds the `mcp` scope; pass it to `useAui` and wrap the app in `AuiProvider`. Connectors are presets declared with `defineConnector`.
+
+```tsx
+"use client";
+import { AuiProvider, useAui } from "@assistant-ui/react";
+import { McpManagerResource, defineConnector } from "@assistant-ui/react-mcp";
+
+const connectors = [
+  defineConnector({
+    id: "linear",
+    name: "Linear",
+    url: "https://mcp.linear.app",
+    auth: { type: "oauth", scopes: ["read"] },
+    icon: "/icons/linear.svg",
+  }),
+  defineConnector({
+    id: "weather",
+    name: "Weather",
+    url: "https://mcp.example.com/weather",
+    auth: { type: "none" },
+  }),
+];
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const aui = useAui({ mcp: McpManagerResource({ connectors }) });
+  return <AuiProvider value={aui}>{children}</AuiProvider>;
+}
+```
+
+Defaults: `storage` is `McpLocalStorage()`, `oauthRedirectUri` is `${window.location.origin}/mcp/callback`, and `autoConnect` is `true`.
+
+## Drop-in dialog
+
+`McpConfigDialog` is the shadcn dialog that lists connectors and custom servers with inline auth controls and an add form. Drop it anywhere under the provider.
+
+```tsx
+import { McpConfigDialog } from "@/components/assistant-ui/mcp-config";
+
+export default function Page() {
+  return (
+    <header className="flex items-center justify-between">
+      <h1>My app</h1>
+      <McpConfigDialog />
+    </header>
+  );
+}
+```
+
+Pass `children` to override the default trigger: `<McpConfigDialog><Button>Servers</Button></McpConfigDialog>`.
+
+## Compose from primitives
+
+`McpManagerPrimitive` iterates servers; nested `McpServerPrimitive.*` reads each item's scope automatically. Conditional buttons render only when the connection state matches.
+
+```tsx
+"use client";
+import { McpManagerPrimitive, McpServerPrimitive } from "@assistant-ui/react-mcp";
+
+const ServerCard = () => (
+  <McpServerPrimitive.Root>
+    <McpServerPrimitive.Icon />
+    <McpServerPrimitive.Name />
+    <McpServerPrimitive.Status />
+    <McpServerPrimitive.ConnectButton>Connect</McpServerPrimitive.ConnectButton>
+    <McpServerPrimitive.DisconnectButton>Disconnect</McpServerPrimitive.DisconnectButton>
+    <McpServerPrimitive.OAuthLink>Authorize</McpServerPrimitive.OAuthLink>
+    <McpServerPrimitive.RemoveButton>Remove</McpServerPrimitive.RemoveButton>
+    <McpServerPrimitive.Error />
+  </McpServerPrimitive.Root>
+);
+
+export default function McpPage() {
+  return (
+    <McpManagerPrimitive.Root>
+      <h2>Connectors</h2>
+      <McpManagerPrimitive.Connectors>{() => <ServerCard />}</McpManagerPrimitive.Connectors>
+      <h2>Your servers</h2>
+      <McpManagerPrimitive.CustomServers>{() => <ServerCard />}</McpManagerPrimitive.CustomServers>
+      <McpManagerPrimitive.AddCustomTrigger>Add custom server</McpManagerPrimitive.AddCustomTrigger>
+    </McpManagerPrimitive.Root>
+  );
+}
+```
+
+`RemoveButton` is hidden on connectors (presets cannot be removed). Omit `AddCustomTrigger` and `CustomServers` to disable user-added servers. Build the add form with `McpAddFormPrimitive` (`Root`, `NameField`, `UrlField`, `AuthSelect`, `AuthFields`, `Error`, `Submit`, `Cancel`); see [ui.md](./references/ui.md).
+
+## OAuth connect flow
+
+`auth` is one of `{ type: "none" }`, `{ type: "bearer", token? }`, or `{ type: "oauth", scopes?, ... }`. For OAuth, add a callback route at the configured `oauthRedirectUri` and render `McpOAuthCallback` inside the same provider so it can finish the handshake.
+
+```tsx
+"use client";
+import { McpOAuthCallback } from "@assistant-ui/react-mcp";
+import { useRouter } from "next/navigation";
+import { Providers } from "../../providers";
+
+export default function Callback() {
+  const router = useRouter();
+  return (
+    <Providers>
+      <McpOAuthCallback onComplete={() => router.replace("/mcp")} />
+    </Providers>
+  );
+}
+```
+
+See [oauth.md](./references/oauth.md) for the full auth-mode shapes and connection-state values (`connected`, `connecting`, `authRequired`, `authPending`, `error`, `disconnected`).
+
+## Custom storage
+
+Replace the default `McpLocalStorage()` to persist custom servers and auth state on a backend (use `McpMemoryStorage()` for SSR/tests).
+
+```ts
+import { McpManagerResource, McpCustomStorage } from "@assistant-ui/react-mcp";
+
+const aui = useAui({
+  mcp: McpManagerResource({
+    connectors,
+    storage: McpCustomStorage({
+      loadCustomServers: async () => fetch("/api/mcp/servers").then((r) => r.json()),
+      saveCustomServers: async (records) =>
+        fetch("/api/mcp/servers", { method: "PUT", body: JSON.stringify(records) }),
+      loadAuthState: async (id) =>
+        fetch(`/api/mcp/auth/${id}`).then((r) => (r.ok ? r.json() : null)),
+      saveAuthState: async (id, state) =>
+        fetch(`/api/mcp/auth/${id}`, { method: "PUT", body: JSON.stringify(state) }),
+      clearAuthState: async (id) => fetch(`/api/mcp/auth/${id}`, { method: "DELETE" }),
+    }),
+  }),
+});
+```
+
+## Imperative API
+
+Inside event handlers, drive the manager through `useAui().mcp()`.
+
+```ts
+const aui = useAui();
+await aui.mcp().addCustomServer({ name, url, auth: { type: "bearer", token } });
+await aui.mcp().server({ id }).connect();
+await aui.mcp().server({ id }).callTool("echo", { text: "hi" });
+```
+
+Read reactive state with `useAuiState`, scoped under `s.mcp` (manager) and `s.mcpServer` (current item inside a `McpServerPrimitive` subtree):
+
+```ts
+const isHydrated = useAuiState((s) => s.mcp.isHydrated);
+const connectionState = useAuiState((s) => s.mcpServer.connectionState);
+```
+
+## Common Gotchas
+
+**Tools not appearing in chat**
+- The server must reach the `connected` state; check `McpServerPrimitive.Status` or `s.mcpServer.connectionState`.
+- Tool names are prefixed `serverId__toolName`; reference that exact name in tool UI.
+
+**OAuth never completes**
+- The callback route path must match `oauthRedirectUri` (default `/mcp/callback`).
+- `McpOAuthCallback` must be rendered inside the same provider as the manager.
+
+**Servers not persisting / SSR errors**
+- Default `McpLocalStorage()` needs the browser; use `McpMemoryStorage()` or `McpCustomStorage(...)` on the server.
+
+**Custom server cannot be removed**
+- `RemoveButton` hides on connector presets by design; only user-added servers are removable.
+
+**Transport**
+- Only StreamableHTTP is supported; resources, prompts, sampling, and auto-reconnect are not yet wired.
+
+## Related Skills
+
+- [tools](../tools/SKILL.md) -- developer-defined frontend/backend tools and custom tool-call UI (`makeAssistantTool`, AI SDK `tool()`, `makeAssistantToolUI`); the complement to user-managed MCP servers.
+- [setup](../setup/SKILL.md) -- scaffold with the `mcp` template (`npx assistant-ui@latest create -t mcp`) and pick a runtime.
+- [runtime](../runtime/SKILL.md) -- the chat runtime (`useChatRuntime`) that MCP tools are merged into.

--- a/assistant-ui/skills/react-mcp/references/oauth.md
+++ b/assistant-ui/skills/react-mcp/references/oauth.md
@@ -1,0 +1,147 @@
+# MCP OAuth and Auth Modes
+
+Let end users connect and authenticate MCP servers from the browser with `@assistant-ui/react-mcp`. Auth modes are `none`, `bearer`, and `oauth` (PKCE + DCR).
+
+## Contents
+
+- [Auth modes](#auth-modes)
+- [Connectors and the manager resource](#connectors-and-the-manager-resource)
+- [OAuth connect flow](#oauth-connect-flow)
+- [OAuth callback route](#oauth-callback-route)
+- [Server connect UI](#server-connect-ui)
+- [Imperative connect and auth](#imperative-connect-and-auth)
+- [Reading connection state](#reading-connection-state)
+- [Token storage](#token-storage)
+
+## Auth modes
+
+Each connector or custom server carries an `auth` config. Three shapes:
+
+```ts
+// no auth header
+{ type: "none" }
+
+// Authorization: Bearer …
+{ type: "bearer", token: "…" }
+
+// PKCE + DCR + refresh; every field below the type is optional
+{
+  type: "oauth",
+  scopes: ["read"],
+  authorizationEndpoint: "…", // overrides RFC 8414 discovery
+  tokenEndpoint: "…",
+  registrationEndpoint: "…",
+  clientId: "…",              // skip DCR with a static client
+  clientSecret: "…",
+}
+```
+
+With `oauth` and no endpoint overrides, the client discovers metadata (RFC 8414), dynamically registers (DCR, RFC 7591), runs PKCE, exchanges the code, and refreshes tokens on 401. Set `clientId` (and `clientSecret`) to skip DCR with a pre-registered client.
+
+## Connectors and the manager resource
+
+OAuth connectors are declared with `defineConnector({ ..., auth: { type: "oauth", scopes } })` and mounted via `McpManagerResource` on the `aui` instance. The `oauthRedirectUri` option defaults to `"${window.location.origin}/mcp/callback"`. See [./setup.md](./setup.md) for the full `defineConnector` / `McpManagerResource` / provider setup.
+
+## OAuth connect flow
+
+1. The user triggers a connect on an `oauth` server (button or imperative call).
+2. The client runs discovery/DCR/PKCE and opens the authorization URL.
+3. The provider redirects back to `oauthRedirectUri` with `?state=…&code=…`. The server id is encoded in the OAuth `state` param, so one callback route resolves any server.
+4. The callback route completes the exchange; `autoConnect` then connects the server.
+
+Set the redirect URI explicitly when not using the default route:
+
+```ts
+McpManagerResource({
+  connectors,
+  oauthRedirectUri: `${window.location.origin}/auth/mcp`,
+});
+```
+
+## OAuth callback route
+
+Render `McpOAuthCallback` at the redirect path. It reads `code` and `state` from the URL and calls `completeAuth` on the right server. Wrap it in the same `Providers` so the manager resource is in scope.
+
+```tsx
+// app/mcp/callback/page.tsx
+"use client";
+import { McpOAuthCallback } from "@assistant-ui/react-mcp";
+import { useRouter } from "next/navigation";
+import { Providers } from "../../providers";
+
+export default function Callback() {
+  const router = useRouter();
+  return (
+    <Providers>
+      <McpOAuthCallback onComplete={() => router.replace("/mcp")} />
+    </Providers>
+  );
+}
+```
+
+`McpOAuthCallback` takes `onComplete: () => void`, fired after the token exchange resolves.
+
+## Server connect UI
+
+`McpServerPrimitive` action buttons render only when the server's state matches, so no manual gating is needed: `ConnectButton` when connectable, `OAuthLink` when authorization is required, `DisconnectButton` when connected.
+
+```tsx
+"use client";
+import {
+  McpManagerPrimitive,
+  McpServerPrimitive,
+} from "@assistant-ui/react-mcp";
+
+const ServerCard = () => (
+  <McpServerPrimitive.Root>
+    <McpServerPrimitive.Icon />
+    <McpServerPrimitive.Name />
+    <McpServerPrimitive.Status />
+    <McpServerPrimitive.ConnectButton>Connect</McpServerPrimitive.ConnectButton>
+    <McpServerPrimitive.DisconnectButton>Disconnect</McpServerPrimitive.DisconnectButton>
+    <McpServerPrimitive.OAuthLink>Authorize ↗</McpServerPrimitive.OAuthLink>
+    <McpServerPrimitive.RemoveButton>Remove</McpServerPrimitive.RemoveButton>
+    <McpServerPrimitive.Error />
+  </McpServerPrimitive.Root>
+);
+
+export default function McpPage() {
+  return (
+    <McpManagerPrimitive.Root>
+      <h2>Connectors</h2>
+      <McpManagerPrimitive.Connectors>
+        {() => <ServerCard />}
+      </McpManagerPrimitive.Connectors>
+      <h2>Your servers</h2>
+      <McpManagerPrimitive.CustomServers>
+        {() => <ServerCard />}
+      </McpManagerPrimitive.CustomServers>
+      <McpManagerPrimitive.AddCustomTrigger>
+        Add custom server
+      </McpManagerPrimitive.AddCustomTrigger>
+    </McpManagerPrimitive.Root>
+  );
+}
+```
+
+## Imperative connect and auth
+
+`aui.mcp().server({ id }).connect()`, called from an event handler, triggers the OAuth flow when the server needs it. See [./setup.md](./setup.md) for the full imperative API (`addCustomServer`, `connect`, `callTool`).
+
+## Reading connection state
+
+Read state with `useAuiState` from `@assistant-ui/store`. The `mcpServer.*` selectors require an `McpServerByIdProvider` in scope, which the manager iteration primitives supply automatically.
+
+```ts
+import { useAuiState } from "@assistant-ui/store";
+
+const isHydrated = useAuiState((s) => s.mcp.isHydrated);
+const connectionState = useAuiState((s) => s.mcpServer.connectionState);
+const name = useAuiState((s) => s.mcpServer.name);
+const icon = useAuiState((s) => s.mcpServer.icon ?? null);
+const error = useAuiState((s) => s.mcpServer.lastError?.message ?? null);
+```
+
+## Token storage
+
+OAuth tokens persist through the manager's `storage`. `McpLocalStorage` (the default) keeps them in plain text and is XSS-exposed; for anything beyond local prototyping use `McpCustomStorage` against an HTTP-only-cookie-backed endpoint. See [./setup.md](./setup.md) for the storage backends and a full `McpCustomStorage` example.

--- a/assistant-ui/skills/react-mcp/references/setup.md
+++ b/assistant-ui/skills/react-mcp/references/setup.md
@@ -1,0 +1,155 @@
+# MCP manager setup
+
+Mount user-managed MCP servers on the `aui` instance with `@assistant-ui/react-mcp`. Connectors are presets, storage persists servers and tokens, and `aui.mcp()` drives the manager imperatively.
+
+## Contents
+
+- [Imports](#imports)
+- [defineConnector](#defineconnector)
+- [McpManagerResource](#mcpmanagerresource)
+- [Mount on the provider](#mount-on-the-provider)
+- [Storage](#storage)
+- [McpCustomStorage](#mcpcustomstorage)
+- [Imperative API](#imperative-api)
+
+## Imports
+
+```ts
+import { AuiProvider, useAui } from "@assistant-ui/react";
+import {
+  McpManagerResource,
+  defineConnector,
+  McpLocalStorage,
+  McpMemoryStorage,
+  McpCustomStorage,
+} from "@assistant-ui/react-mcp";
+```
+
+## defineConnector
+
+A connector is an app-declared preset the end user can connect to. `id`, `name`, `url`, and `auth` are required; `icon` is optional. Auth is one of `{ type: "none" }`, `{ type: "bearer", token? }`, or `{ type: "oauth", scopes?, ... }` (see [oauth.md](./oauth.md) for the full shapes).
+
+```ts
+const connectors = [
+  defineConnector({
+    id: "linear",
+    name: "Linear",
+    url: "https://mcp.linear.app",
+    auth: { type: "oauth", scopes: ["read"] },
+    icon: "/icons/linear.svg",
+  }),
+  defineConnector({
+    id: "weather",
+    name: "Weather",
+    url: "https://mcp.example.com/weather",
+    auth: { type: "none" },
+  }),
+];
+```
+
+## McpManagerResource
+
+`McpManagerResource(options)` builds the `mcp` scope you pass to `useAui`. Options and their defaults:
+
+- `connectors`: the array from `defineConnector(...)`.
+- `storage`: `McpLocalStorage()` by default; persists under the `aui-mcp:` prefix in `window.localStorage`.
+- `oauthRedirectUri`: `"${window.location.origin}/mcp/callback"` by default.
+- `autoConnect`: `true` by default; connects on mount when usable auth is already persisted.
+
+```ts
+McpManagerResource({
+  connectors,
+  storage: McpLocalStorage(),
+  oauthRedirectUri: `${window.location.origin}/auth/mcp`,
+  autoConnect: true,
+});
+```
+
+## Mount on the provider
+
+Pass the resource to `useAui({ mcp })` and wrap the app in `AuiProvider`. Connected servers' tools merge into the chat runtime automatically, namespaced `serverId__toolName`.
+
+```tsx
+"use client";
+import { AuiProvider, useAui } from "@assistant-ui/react";
+import { McpManagerResource, defineConnector } from "@assistant-ui/react-mcp";
+
+const connectors = [
+  defineConnector({
+    id: "linear",
+    name: "Linear",
+    url: "https://mcp.linear.app",
+    auth: { type: "oauth", scopes: ["read"] },
+  }),
+];
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const aui = useAui({ mcp: McpManagerResource({ connectors }) });
+  return <AuiProvider value={aui}>{children}</AuiProvider>;
+}
+```
+
+## Storage
+
+Three built-in storage backends control where custom servers and OAuth tokens persist:
+
+- `McpLocalStorage()`: default; `window.localStorage` under the `aui-mcp:` prefix. Browser only.
+- `McpMemoryStorage()`: in-process Map; use for SSR or tests where `localStorage` is absent.
+- `McpCustomStorage({...})`: bring your own load/save handlers (for example a backend endpoint).
+
+`McpLocalStorage` keeps tokens in plain text and is XSS-exposed; for anything past local prototyping, back `McpCustomStorage` with an HTTP-only-cookie endpoint.
+
+```ts
+McpManagerResource({ connectors, storage: McpMemoryStorage() });
+```
+
+## McpCustomStorage
+
+Supply async handlers for custom-server records and per-server auth state. `loadAuthState` returns the stored state or `null`; `saveAuthState` and `clearAuthState` are keyed by server id.
+
+```ts
+const aui = useAui({
+  mcp: McpManagerResource({
+    connectors,
+    storage: McpCustomStorage({
+      loadCustomServers: async () =>
+        fetch("/api/mcp/servers").then((r) => r.json()),
+      saveCustomServers: async (records) =>
+        fetch("/api/mcp/servers", {
+          method: "PUT",
+          body: JSON.stringify(records),
+        }),
+      loadAuthState: async (id) =>
+        fetch(`/api/mcp/auth/${id}`).then((r) => (r.ok ? r.json() : null)),
+      saveAuthState: async (id, state) =>
+        fetch(`/api/mcp/auth/${id}`, {
+          method: "PUT",
+          body: JSON.stringify(state),
+        }),
+      clearAuthState: async (id) =>
+        fetch(`/api/mcp/auth/${id}`, { method: "DELETE" }),
+    }),
+  }),
+});
+```
+
+## Imperative API
+
+Drive the manager through `useAui().mcp()` from inside event handlers, never during render. `addCustomServer` registers a user server with its own auth; `server({ id })` scopes to one server for `connect` and `callTool`.
+
+```ts
+const aui = useAui();
+// inside an event handler:
+await aui.mcp().addCustomServer({ name, url, auth: { type: "bearer", token } });
+await aui.mcp().server({ id }).connect();
+const result = await aui.mcp().server({ id }).callTool("echo", { text: "hi" });
+```
+
+Read reactive state with `useAuiState` from `@assistant-ui/store`, scoped under `s.mcp` (manager) and `s.mcpServer` (current item inside a `McpServerPrimitive` subtree).
+
+```ts
+import { useAuiState } from "@assistant-ui/store";
+
+const isHydrated = useAuiState((s) => s.mcp.isHydrated);
+const connectionState = useAuiState((s) => s.mcpServer.connectionState);
+```

--- a/assistant-ui/skills/react-mcp/references/ui.md
+++ b/assistant-ui/skills/react-mcp/references/ui.md
@@ -1,0 +1,184 @@
+# MCP config UI
+
+Headless primitives for letting end users add and authenticate MCP servers from the browser, plus the `McpConfigDialog` shadcn registry component built on them.
+
+The primitives ship from `@assistant-ui/react-mcp`. Per-server card and form state is read with `useAuiState` from `@assistant-ui/store`. Install the prebuilt dialog with the CLI (`https://r.assistant-ui.com/mcp-config.json`) to get a ready styled version under `@/components/assistant-ui/mcp-config` that you can edit.
+
+## Contents
+
+- [Imports](#imports)
+- [McpManagerPrimitive](#mcpmanagerprimitive)
+- [McpServerPrimitive](#mcpserverprimitive)
+- [McpAddFormPrimitive](#mcpaddformprimitive)
+- [MCPConnectionState](#mcpconnectionstate)
+- [Reading server state](#reading-server-state)
+- [McpConfigDialog](#mcpconfigdialog)
+
+## Imports
+
+```tsx
+import { useAuiState } from "@assistant-ui/store";
+import {
+  McpAddFormPrimitive,
+  McpManagerPrimitive,
+  McpServerPrimitive,
+  type MCPConnectionState,
+} from "@assistant-ui/react-mcp";
+```
+
+## McpManagerPrimitive
+
+Wraps the manager state and iterates over the two server collections. The iteration parts take a render-prop child `() => <ServerCard />`; each rendered card reads its own server from context.
+
+| Part | Props | Description |
+|------|-------|-------------|
+| `.Root` | | Manager context provider; wrap the whole UI |
+| `.Connectors` | | App-defined connectors; child is `() => ReactNode` |
+| `.CustomServers` | | User-added servers; child is `() => ReactNode` |
+| `.AddCustomTrigger` | `asChild` | Reveals the add form |
+
+```tsx
+<McpManagerPrimitive.Root>
+  <section>
+    <h3>Connectors</h3>
+    <McpManagerPrimitive.Connectors>
+      {() => <ServerCard />}
+    </McpManagerPrimitive.Connectors>
+  </section>
+
+  <section>
+    <h3>Custom servers</h3>
+    <McpManagerPrimitive.CustomServers>
+      {() => <ServerCard />}
+    </McpManagerPrimitive.CustomServers>
+
+    <McpManagerPrimitive.AddCustomTrigger asChild>
+      <Button>Add server</Button>
+    </McpManagerPrimitive.AddCustomTrigger>
+  </section>
+</McpManagerPrimitive.Root>
+```
+
+## McpServerPrimitive
+
+Renders a single server (the one provided by the surrounding `.Connectors` / `.CustomServers` iteration). The connect, authorize, and disconnect actions render conditionally based on the server's connection state, so include all three and let the primitive decide which is active.
+
+| Part | Props | Description |
+|------|-------|-------------|
+| `.Root` | `className` | Card container; exposes `data-connection-state` (e.g. `data-[connection-state=error]`) |
+| `.Name` | | Renders the server name |
+| `.ConnectButton` | `asChild` | Connects a server that uses no OAuth |
+| `.OAuthLink` | `className` | Starts the OAuth flow (renders as a link) |
+| `.DisconnectButton` | `asChild` | Disconnects a connected server |
+| `.RemoveButton` | `asChild` | Removes the server from the manager |
+
+```tsx
+const ServerCard: FC = () => (
+  <McpServerPrimitive.Root
+    className={cn(
+      "rounded-lg border p-3",
+      "data-[connection-state=error]:border-destructive/40",
+    )}
+  >
+    <McpServerPrimitive.Name />
+    <McpServerPrimitive.ConnectButton asChild>
+      <Button size="sm">Connect</Button>
+    </McpServerPrimitive.ConnectButton>
+    <McpServerPrimitive.OAuthLink className={cn(buttonVariants({ size: "sm" }))}>
+      Authorize
+    </McpServerPrimitive.OAuthLink>
+    <McpServerPrimitive.DisconnectButton asChild>
+      <Button size="sm" variant="outline">Disconnect</Button>
+    </McpServerPrimitive.DisconnectButton>
+    <McpServerPrimitive.RemoveButton asChild>
+      <Button variant="ghost" size="icon"><Trash2Icon className="size-4" /></Button>
+    </McpServerPrimitive.RemoveButton>
+  </McpServerPrimitive.Root>
+);
+```
+
+## McpAddFormPrimitive
+
+The form for adding a custom server. `.Root` owns the form state and fires `onSubmitted` after a successful add and `onCancel` when dismissed; both are handy for closing the form. `.AuthSelect` chooses the auth scheme and `.AuthFields` renders whatever inputs that scheme needs (for example a bearer token field).
+
+| Part | Props | Description |
+|------|-------|-------------|
+| `.Root` | `onSubmitted`, `onCancel` | Form provider and submit handler |
+| `.NameField` | `asChild` | Server name input |
+| `.UrlField` | `asChild` | Server URL input |
+| `.AuthSelect` | `className` | Auth scheme `<select>` |
+| `.AuthFields` | | Inputs required by the selected scheme |
+| `.Error` | `className` | Validation / submit error text |
+| `.Submit` | `asChild` | Submits the form |
+| `.Cancel` | `asChild` | Cancels and fires `onCancel` |
+
+```tsx
+const AddServerForm: FC<{ onClose: () => void }> = ({ onClose }) => (
+  <McpAddFormPrimitive.Root onSubmitted={onClose} onCancel={onClose}>
+    <McpAddFormPrimitive.NameField asChild>
+      <Input placeholder="My MCP server" />
+    </McpAddFormPrimitive.NameField>
+    <McpAddFormPrimitive.UrlField asChild>
+      <Input placeholder="https://example.com/mcp" />
+    </McpAddFormPrimitive.UrlField>
+    <McpAddFormPrimitive.AuthSelect className="h-9 w-full rounded-md border px-2 text-sm" />
+    <McpAddFormPrimitive.AuthFields />
+    <McpAddFormPrimitive.Error className="text-destructive text-xs" />
+    <McpAddFormPrimitive.Cancel asChild>
+      <Button type="button" variant="ghost" size="sm">Cancel</Button>
+    </McpAddFormPrimitive.Cancel>
+    <McpAddFormPrimitive.Submit asChild>
+      <Button type="submit" size="sm">Add server</Button>
+    </McpAddFormPrimitive.Submit>
+  </McpAddFormPrimitive.Root>
+);
+```
+
+## MCPConnectionState
+
+Union of the six states a server can be in; useful for mapping status to a label or badge variant.
+
+```ts
+type MCPConnectionState =
+  | "connected"
+  | "connecting"
+  | "authRequired"
+  | "authPending"
+  | "error"
+  | "disconnected";
+```
+
+## Reading server state
+
+Inside a `McpServerPrimitive.Root` (or any `.Connectors` / `.CustomServers` child) read the current server from the store via `s.mcpServer`.
+
+```tsx
+const icon = useAuiState((s) => s.mcpServer.icon ?? null);
+const name = useAuiState((s) => s.mcpServer.name);
+const status = useAuiState((s) => s.mcpServer.connectionState);
+const message = useAuiState((s) => s.mcpServer.lastError?.message ?? null);
+```
+
+## McpConfigDialog
+
+The registry component is a shadcn dialog that lists connectors and custom servers with inline auth controls and an add form, composing every primitive above. Its only prop is `children`, which overrides the default trigger button.
+
+```ts
+export namespace McpConfigDialog {
+  export type Props = { children?: ReactNode };
+}
+```
+
+```tsx
+import { McpConfigDialog } from "@/components/assistant-ui/mcp-config";
+
+// default trigger ("MCP servers" button)
+<McpConfigDialog />
+
+// custom trigger
+<McpConfigDialog>
+  <Button variant="ghost">Servers</Button>
+</McpConfigDialog>
+```
+
+The dialog reads connectors and custom servers from the MCP manager resource on the runtime, so render it inside the same provider tree as your `AuiProvider`. See [setup.md](./setup.md) for mounting `McpManagerResource`.

--- a/assistant-ui/skills/runtime/SKILL.md
+++ b/assistant-ui/skills/runtime/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: runtime
-description: Guide for assistant-ui runtime system and state management. Use when working with runtimes, accessing state, or managing thread/message data.
-version: 0.0.1
+description: "Guide to the assistant-ui runtime system, single-thread state, and the imperative runtime API in @assistant-ui/react. Use when creating a runtime (useLocalRuntime with a ChatModelAdapter, useExternalStoreRuntime for Redux/Zustand, useRemoteThreadListRuntime), wiring AssistantRuntimeProvider, or reading/mutating thread, message, and composer state and events. Covers the unified hooks useAui, useAuiState, useAuiEvent (composer.send, thread.runStart, thread.runEnd), legacy hooks (useAssistantRuntime, useThreadRuntime, useMessageRuntime, useComposerRuntime, useThread, useThreadMessages), the AssistantRuntime/ThreadRuntime/MessageRuntime/ComposerRuntime hierarchy, thread operations (append, cancelRun, message().edit/reload), capabilities, and types (ThreadMessage, MessagePart, MessageStatus, ChatModelRunResult). Use for provider \"Cannot read property of undefined\" errors or state not updating. For multi-thread list UI and switching between conversations use thread-list instead."
 license: MIT
 ---
 
 # assistant-ui Runtime
 
-**Always consult [assistant-ui.com/llms.txt](https://assistant-ui.com/llms.txt) for latest API.**
+**Always consult [assistant-ui.com/llms.txt](https://www.assistant-ui.com/llms.txt) for the latest API.**
 
 ## References
 
@@ -16,6 +15,9 @@ license: MIT
 - [./references/thread-list.md](./references/thread-list.md) -- Thread list management
 - [./references/state-hooks.md](./references/state-hooks.md) -- State access hooks
 - [./references/types.md](./references/types.md) -- Type definitions
+- [./references/adapters.md](./references/adapters.md) -- Attachment, speech, dictation, suggestion, and history adapters
+- [./references/voice.md](./references/voice.md) -- Realtime voice chat
+- [./references/runtime-concepts.md](./references/runtime-concepts.md) -- Stability policy, transport runtime, message timing
 
 ## Runtime Hierarchy
 
@@ -66,20 +68,17 @@ function ChatControls() {
 const api = useAui();
 const thread = api.thread();
 
-// Append message
 thread.append({ role: "user", content: [{ type: "text", text: "Hello" }] });
 
-// Cancel generation
 thread.cancelRun();
 
-// Get current state
 const state = thread.getState();  // { messages, isRunning, ... }
 ```
 
 ## Message Operations
 
 ```tsx
-const message = api.thread().message(0);  // By index
+const message = api.thread().message(0);
 
 message.edit({ role: "user", content: [{ type: "text", text: "Updated" }] });
 message.reload();
@@ -101,28 +100,6 @@ useAuiEvent("thread.modelContextUpdate", () => {});
 ```tsx
 const caps = useAuiState(s => s.thread.capabilities);
 // { cancel, edit, reload, copy, speak, attachments }
-```
-
-## Quick Reference
-
-```tsx
-// Get messages
-const messages = useAuiState(s => s.thread.messages);
-
-// Check running state
-const isRunning = useAuiState(s => s.thread.isRunning);
-
-// Append message
-api.thread().append({ role: "user", content: [{ type: "text", text: "Hi" }] });
-
-// Cancel generation
-api.thread().cancelRun();
-
-// Edit message
-api.thread().message(index).edit({ ... });
-
-// Reload message
-api.thread().message(index).reload();
 ```
 
 ## Common Gotchas

--- a/assistant-ui/skills/runtime/references/adapters.md
+++ b/assistant-ui/skills/runtime/references/adapters.md
@@ -1,0 +1,524 @@
+# Runtime Adapters
+
+Optional capability adapters you register on the runtime `adapters` map: attachments, text to speech, dictation, suggestions, and thread history persistence.
+
+## Contents
+
+- [The adapters map](#the-adapters-map)
+- [Attachment adapters](#attachment-adapters)
+- [Built-in attachment adapters](#built-in-attachment-adapters)
+- [Custom attachment adapter](#custom-attachment-adapter)
+- [Async generator upload lifecycle](#async-generator-upload-lifecycle)
+- [CloudFileAttachmentAdapter](#cloudfileattachmentadapter)
+- [Attachment error handling](#attachment-error-handling)
+- [Text to speech](#text-to-speech)
+- [Custom TTS adapter](#custom-tts-adapter)
+- [Dictation](#dictation)
+- [Custom dictation adapter](#custom-dictation-adapter)
+- [Suggestion adapter](#suggestion-adapter)
+- [Thread history adapter](#thread-history-adapter)
+
+## The adapters map
+
+Every adapter is registered under a named key on the runtime's `adapters` option. The same map works across runtime factories (`useChatRuntime`, `useLocalRuntime`, `useAISDKRuntime`).
+
+```ts
+import { useChatRuntime } from "@assistant-ui/react";
+
+const runtime = useChatRuntime({
+  adapters: {
+    attachments: /* AttachmentAdapter */,
+    speech: /* SpeechSynthesisAdapter */,
+    dictation: /* DictationAdapter */,
+    suggestion: /* SuggestionAdapter */,
+    history: /* ThreadHistoryAdapter */,
+  },
+});
+```
+
+## Attachment adapters
+
+An `AttachmentAdapter` controls which files the composer accepts and how they are turned into message content. The interface from `@assistant-ui/react`:
+
+```ts
+import type {
+  AttachmentAdapter,
+  PendingAttachment,
+  CompleteAttachment,
+  Attachment,
+} from "@assistant-ui/react";
+
+type AttachmentAdapter = {
+  accept: string;
+  add: (state: { file: File }) =>
+    | Promise<PendingAttachment>
+    | AsyncGenerator<PendingAttachment, void>;
+  send: (attachment: PendingAttachment) => Promise<CompleteAttachment>;
+  remove: (attachment: Attachment) => Promise<void>;
+};
+```
+
+`accept` is a MIME type filter string, the same syntax as the HTML `accept` attribute (`"image/*"`, `"image/jpeg,image/png"`, or `"*"` for any file). `add` validates the chosen file and produces a `PendingAttachment`; `send` runs at composer send time and resolves to a `CompleteAttachment` carrying the `content` array that becomes part of the message; `remove` cleans up.
+
+The two statuses that flow through the lifecycle:
+
+```ts
+// add() typically returns a pending attachment that still needs sending
+status: { type: "requires-action", reason: "composer-send" }
+// send() returns the final, message-ready attachment
+status: { type: "complete" }
+```
+
+## Built-in attachment adapters
+
+Three adapters ship from `@assistant-ui/react`. `SimpleImageAttachmentAdapter` accepts `image/*` and converts files to data URLs, `SimpleTextAttachmentAdapter` accepts text files and wraps their content, and `CompositeAttachmentAdapter` combines several adapters and routes each file to the first one whose `accept` matches.
+
+```ts
+import {
+  CompositeAttachmentAdapter,
+  SimpleImageAttachmentAdapter,
+  SimpleTextAttachmentAdapter,
+} from "@assistant-ui/react";
+
+const runtime = useChatRuntime({
+  adapters: {
+    attachments: new CompositeAttachmentAdapter([
+      new SimpleImageAttachmentAdapter(),
+      new SimpleTextAttachmentAdapter(),
+    ]),
+  },
+});
+```
+
+To restrict to images only, register the single adapter directly:
+
+```ts
+const runtime = useChatRuntime({
+  adapters: {
+    attachments: new SimpleImageAttachmentAdapter(),
+  },
+});
+```
+
+## Custom attachment adapter
+
+Implement `AttachmentAdapter` to control validation and the content shape. This vision adapter rejects oversized images and emits an inline image content part.
+
+```ts
+import {
+  AttachmentAdapter,
+  PendingAttachment,
+  CompleteAttachment,
+} from "@assistant-ui/react";
+
+class VisionImageAdapter implements AttachmentAdapter {
+  accept = "image/jpeg,image/png,image/webp,image/gif";
+
+  async add({ file }: { file: File }): Promise<PendingAttachment> {
+    const maxSize = 20 * 1024 * 1024;
+    if (file.size > maxSize) throw new Error("Image size exceeds 20MB limit");
+    return {
+      id: crypto.randomUUID(),
+      type: "image",
+      name: file.name,
+      file,
+      status: { type: "requires-action", reason: "composer-send" },
+    };
+  }
+
+  async send(attachment: PendingAttachment): Promise<CompleteAttachment> {
+    const base64 = await this.fileToBase64DataURL(attachment.file);
+    return {
+      id: attachment.id,
+      type: "image",
+      name: attachment.name,
+      content: [{ type: "image", image: base64 }],
+      status: { type: "complete" },
+    };
+  }
+
+  async remove(attachment: PendingAttachment): Promise<void> {}
+
+  private async fileToBase64DataURL(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+  }
+}
+```
+
+Register it with any runtime:
+
+```ts
+import { useLocalRuntime } from "@assistant-ui/react";
+
+const runtime = useLocalRuntime(MyModelAdapter, {
+  adapters: {
+    attachments: new VisionImageAdapter(),
+  },
+});
+```
+
+## Async generator upload lifecycle
+
+When `add` is an async generator it can yield intermediate `PendingAttachment` states, which is how you surface upload progress. A `running` status carries a `progress` number; yield the final `requires-action` state once the file is uploaded so it is ready to send.
+
+```ts
+class ServerUploadAdapter implements AttachmentAdapter {
+  accept = "*";
+  private urls = new Map<string, string>();
+
+  async *add({ file }: { file: File }) {
+    const id = crypto.randomUUID();
+    yield {
+      id, type: "file" as const, name: file.name, file, contentType: file.type,
+      status: { type: "running" as const, reason: "uploading" as const, progress: 0 },
+    };
+
+    const form = new FormData();
+    form.append("file", file);
+    const { url } = await fetch("/api/upload", { method: "POST", body: form }).then((r) => r.json());
+    this.urls.set(id, url);
+
+    yield {
+      id, type: "file" as const, name: file.name, file, contentType: file.type,
+      status: { type: "requires-action" as const, reason: "composer-send" as const },
+    };
+  }
+
+  async send(attachment: PendingAttachment): Promise<CompleteAttachment> {
+    const url = this.urls.get(attachment.id)!;
+    this.urls.delete(attachment.id);
+    return {
+      ...attachment,
+      status: { type: "complete" },
+      content: [{ type: "file", data: url, mimeType: attachment.contentType ?? "", filename: attachment.name }],
+    };
+  }
+
+  async remove() {}
+}
+```
+
+This pattern avoids holding large files in memory as base64: the file is uploaded during `add`, and `send` only forwards the resulting URL into the message content.
+
+## CloudFileAttachmentAdapter
+
+`CloudFileAttachmentAdapter` stores attachments in assistant-ui Cloud. Pass an `AssistantCloud` instance to the constructor; it supplies its own `accept`, `add`, `send`, and `remove` defaults.
+
+```ts
+import { CloudFileAttachmentAdapter } from "@assistant-ui/react";
+import { AssistantCloud } from "@assistant-ui/react";
+
+const cloud = new AssistantCloud({ /* ... */ });
+
+const runtime = useChatRuntime({
+  adapters: {
+    attachments: new CloudFileAttachmentAdapter(cloud),
+  },
+});
+```
+
+## Attachment error handling
+
+Failures surface as the `composer.attachmentAddError` event rather than throwing into the render tree. Subscribe with `useAuiEvent` and branch on `reason`.
+
+```tsx
+import { useAuiEvent } from "@assistant-ui/react";
+
+function AttachmentErrorToast() {
+  useAuiEvent("composer.attachmentAddError", ({ reason, message, error }) => {
+    if (reason === "not-accepted") {
+      toast.error("This file type is not supported.");
+    } else if (reason === "no-adapter") {
+      toast.error("Attachments are not configured for this composer.");
+    } else {
+      if (error) console.error(error);
+      toast.error(message || "Attachment failed to upload.");
+    }
+  });
+  return null;
+}
+```
+
+`no-adapter` means no `AttachmentAdapter` was configured, `not-accepted` means the file type did not match `adapter.accept`, and `adapter-error` means `add()` threw or returned an error status.
+
+## Text to speech
+
+Register a `SpeechSynthesisAdapter` under `adapters.speech`. The built-in `WebSpeechSynthesisAdapter` uses the browser's native Web Speech API.
+
+```ts
+import { WebSpeechSynthesisAdapter } from "@assistant-ui/react";
+
+const runtime = useChatRuntime({
+  adapters: {
+    speech: new WebSpeechSynthesisAdapter(),
+  },
+});
+```
+
+`ActionBarPrimitive.Speak` is automatically disabled when no speech adapter is configured. Toggle speak and stop buttons with `useMessageTTS`, which reports whether the current message is being spoken.
+
+```tsx
+import { ActionBarPrimitive, useMessageTTS } from "@assistant-ui/react";
+import { AudioLinesIcon, StopCircleIcon } from "lucide-react";
+
+const AssistantActionBar = () => {
+  const isSpeaking = useMessageTTS();
+  return (
+    <ActionBarPrimitive.Root>
+      {!isSpeaking && (
+        <ActionBarPrimitive.Speak>
+          <AudioLinesIcon />
+        </ActionBarPrimitive.Speak>
+      )}
+      {isSpeaking && (
+        <ActionBarPrimitive.StopSpeaking>
+          <StopCircleIcon />
+        </ActionBarPrimitive.StopSpeaking>
+      )}
+      <ActionBarPrimitive.Copy />
+    </ActionBarPrimitive.Root>
+  );
+};
+```
+
+## Custom TTS adapter
+
+The interface is a single `speak` method that returns an `Utterance`. The utterance exposes a live `status`, a `cancel`, and a `subscribe` for change notifications.
+
+```ts
+import type { SpeechSynthesisAdapter } from "@assistant-ui/react";
+
+type SpeechSynthesisAdapter = {
+  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
+};
+
+type Utterance = {
+  status: SpeechSynthesisAdapter.Status;
+  cancel: () => void;
+  subscribe: (callback: () => void) => Unsubscribe;
+};
+
+type Status =
+  | { type: "starting" | "running" }
+  | { type: "ended"; reason: "finished" | "cancelled" | "error"; error?: unknown };
+```
+
+A custom adapter that fetches audio from an external endpoint and plays it through an `HTMLAudioElement`:
+
+```ts
+import type { SpeechSynthesisAdapter } from "@assistant-ui/react";
+
+export class CustomTTSAdapter implements SpeechSynthesisAdapter {
+  private apiUrl: string;
+  constructor(options: { apiUrl: string }) {
+    this.apiUrl = options.apiUrl;
+  }
+
+  speak(text: string): SpeechSynthesisAdapter.Utterance {
+    const subscribers = new Set<() => void>();
+    let status: SpeechSynthesisAdapter.Status = { type: "starting" };
+    let audio: HTMLAudioElement | null = null;
+
+    const notify = () => { for (const cb of subscribers) cb(); };
+    const finish = (reason: "finished" | "cancelled" | "error", error?: unknown) => {
+      if (status.type === "ended") return;
+      status = { type: "ended", reason, error };
+      notify();
+    };
+
+    fetch(this.apiUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text }),
+    })
+      .then((res) => res.blob())
+      .then((blob) => {
+        audio = new Audio(URL.createObjectURL(blob));
+        status = { type: "running" };
+        notify();
+        audio.onended = () => finish("finished");
+        audio.onerror = (e) => finish("error", e);
+        audio.play();
+      })
+      .catch((err) => finish("error", err));
+
+    return {
+      get status() { return status; },
+      cancel: () => { audio?.pause(); finish("cancelled"); },
+      subscribe: (cb) => { subscribers.add(cb); return () => subscribers.delete(cb); },
+    };
+  }
+}
+```
+
+Register it under `adapters.speech` exactly like the built-in adapter.
+
+## Dictation
+
+Register a `DictationAdapter` under `adapters.dictation` for speech to text input. The built-in `WebSpeechDictationAdapter` wraps the browser's Web Speech recognition API.
+
+```ts
+import { WebSpeechDictationAdapter } from "@assistant-ui/react";
+
+const runtime = useChatRuntime({
+  adapters: {
+    dictation: new WebSpeechDictationAdapter({
+      language: "en-US",
+      continuous: true,
+      interimResults: true,
+    }),
+  },
+});
+```
+
+Check browser support before registering:
+
+```ts
+if (WebSpeechDictationAdapter.isSupported()) {
+  // dictation available
+}
+```
+
+The current interim transcript is available at `composer.dictation?.transcript`; `composer.dictation` is `null` when not dictating. Toggle the mic button with `AuiIf` on that value:
+
+```tsx
+import { AuiIf, ComposerPrimitive } from "@assistant-ui/react";
+import { MicIcon, SquareIcon } from "lucide-react";
+
+function DictationButton() {
+  return (
+    <>
+      <AuiIf composer={{ dictation: false }}>
+        <ComposerPrimitive.Dictate>
+          <MicIcon />
+        </ComposerPrimitive.Dictate>
+      </AuiIf>
+      <AuiIf composer={{ dictation: true }}>
+        <ComposerPrimitive.StopDictation>
+          <SquareIcon />
+        </ComposerPrimitive.StopDictation>
+      </AuiIf>
+    </>
+  );
+}
+```
+
+## Custom dictation adapter
+
+The interface exposes an optional `disableInputDuringDictation` flag and a `listen` method that returns a session.
+
+```ts
+import type { DictationAdapter } from "@assistant-ui/react";
+
+type DictationAdapter = {
+  disableInputDuringDictation?: boolean;
+  listen: () => DictationAdapter.Session;
+};
+
+type Session = {
+  status: { type: "starting" | "running" | "ended" };
+  stop: () => Promise<void>;
+  cancel: () => void;
+  onSpeechStart: (cb: () => void) => Unsubscribe;
+  onSpeechEnd: (cb: () => void) => Unsubscribe;
+  onSpeech: (cb: (event: { transcript: string; isFinal?: boolean }) => void) => Unsubscribe;
+};
+```
+
+`stop` finalizes results and `cancel` discards them. The `onSpeech` callback receives a transcript chunk: `isFinal: true` commits the text to the input, while `isFinal: false` shows it as a preview only.
+
+Set `disableInputDuringDictation = true` when the underlying service returns cumulative transcripts that would conflict with simultaneous typing. The ElevenLabs Scribe adapter does this, and it registers the same way:
+
+```ts
+import { ElevenLabsScribeAdapter } from "./lib/elevenlabs-scribe-adapter";
+
+const runtime = useChatRuntime({
+  adapters: {
+    dictation: new ElevenLabsScribeAdapter({
+      tokenEndpoint: "/api/scribe-token",
+      languageCode: "en",
+      disableInputDuringDictation: true,
+    }),
+  },
+});
+```
+
+## Suggestion adapter
+
+A `SuggestionAdapter` generates follow up prompts shown in the thread. Its single `generate` method returns a list of `ThreadSuggestion`, either as a Promise or as an async generator for incremental delivery.
+
+```ts
+import type { SuggestionAdapter, ThreadSuggestion } from "@assistant-ui/react";
+
+type SuggestionAdapter = {
+  generate: (
+    options: SuggestionAdapterGenerateOptions,
+  ) =>
+    | Promise<readonly ThreadSuggestion[]>
+    | AsyncGenerator<readonly ThreadSuggestion[], void>;
+};
+```
+
+Register it under `adapters.suggestion`:
+
+```ts
+const runtime = useChatRuntime({
+  adapters: {
+    suggestion: {
+      generate: async (options) => {
+        return [
+          { prompt: "What can you help me with?" },
+          { prompt: "Summarize this document" },
+        ];
+      },
+    },
+  },
+});
+```
+
+Read the generated entries in the UI through `thread.suggestions`.
+
+## Thread history adapter
+
+A `ThreadHistoryAdapter` persists and restores thread messages. It exposes `load` and `append`, plus optional `resume` and `withFormat`.
+
+```ts
+type ThreadHistoryAdapter = {
+  load: () => Promise<ExportedMessageRepository & { unstable_resume?: boolean }>;
+  append: (item: ExportedMessageRepositoryItem) => Promise<void>;
+  resume?: (
+    options: ChatModelRunOptions,
+  ) => AsyncGenerator<ChatModelRunResult, void, unknown>;
+  withFormat?: <TMessage, TStorageFormat extends Record<string, unknown>>(
+    formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>,
+  ) => GenericThreadHistoryAdapter<TMessage>;
+};
+```
+
+`load` returns the persisted repository (an optional `unstable_resume` flag triggers a resume on mount), `append` is called for each new message, `resume` follows the same `ChatModelRunOptions` to `AsyncGenerator` contract as a model run to restore an in progress generation, and `withFormat` adapts the storage shape. `withFormat` is required when used with `useAISDKRuntime` or `useChatRuntime`, which store messages in the AI SDK format.
+
+```ts
+const runtime = useLocalRuntime(chatModelAdapter, {
+  adapters: {
+    history: myHistoryAdapter,
+  },
+});
+```
+
+The repository payload `load` resolves to and `append` receives an item of:
+
+```ts
+type ExportedMessageRepository = {
+  headId?: string | null;
+  messages: Array<{
+    message: ThreadMessage;
+    parentId: string | null;
+    runConfig?: RunConfig;
+  }>;
+};
+```

--- a/assistant-ui/skills/runtime/references/external-store.md
+++ b/assistant-ui/skills/runtime/references/external-store.md
@@ -2,6 +2,17 @@
 
 Connect assistant-ui to custom message stores (Redux, Zustand, etc.).
 
+## Contents
+
+- [Basic Usage](#basic-usage)
+- [Options](#options)
+- [With Redux](#with-redux)
+- [With Zustand](#with-zustand)
+- [Custom Message Format](#custom-message-format)
+- [Streaming Updates](#streaming-updates)
+- [With Edit and Reload](#with-edit-and-reload)
+- [Capabilities](#capabilities)
+
 ## Basic Usage
 
 ```tsx
@@ -31,7 +42,7 @@ function App() {
         id: crypto.randomUUID(),
         role: "assistant",
         content: [{ type: "text", text: data.text }],
-        status: "complete",
+        status: { type: "complete" },
         createdAt: new Date(),
       }]);
       setIsRunning(false);
@@ -180,7 +191,7 @@ function Chat() {
       id: msg.uuid,
       role: msg.sender === "human" ? "user" : "assistant",
       content: [{ type: "text", text: msg.text }],
-      status: "complete",
+      status: { type: "complete" },
       createdAt: new Date(msg.timestamp),
     }),
     onNew: async (appendMessage) => {
@@ -222,7 +233,7 @@ const runtime = useExternalStoreRuntime({
       id: assistantId,
       role: "assistant",
       content: [{ type: "text", text: "" }],
-      status: "running",
+      status: { type: "running" },
       createdAt: new Date(),
     });
 
@@ -245,14 +256,14 @@ const runtime = useExternalStoreRuntime({
       // Update message in place
       updateMessage(assistantId, {
         content: [{ type: "text", text: fullText }],
-        status: "running",
+        status: { type: "running" },
       });
     }
 
     // Mark complete
     updateMessage(assistantId, {
       content: [{ type: "text", text: fullText }],
-      status: "complete",
+      status: { type: "complete" },
     });
     setRunning(false);
   },
@@ -280,7 +291,7 @@ const runtime = useExternalStoreRuntime({
         id: crypto.randomUUID(),
         role: "user",
         content: message.content,
-        status: "complete",
+        status: { type: "complete" },
         createdAt: new Date(),
       },
     ]);

--- a/assistant-ui/skills/runtime/references/local-runtime.md
+++ b/assistant-ui/skills/runtime/references/local-runtime.md
@@ -96,25 +96,25 @@ interface LocalRuntimeOptions {
 
 ```tsx
 interface ChatModelAdapter {
-  run(options: ChatModelRunOptions): Promise<ChatModelRunResult> | AsyncGenerator<ChatModelRunResult>;
+  run(
+    options: ChatModelRunOptions,
+  ): Promise<ChatModelRunResult> | AsyncGenerator<ChatModelRunResult>;
 }
 
 interface ChatModelRunOptions {
-  messages: ThreadMessage[];
+  messages: readonly ThreadMessage[];
   abortSignal: AbortSignal;
-  config?: Record<string, unknown>;
+  runConfig: RunConfig;     // per-run configuration
+  context: ModelContext;    // tools, system prompt, callSettings, config
 }
 
-type ChatModelRunResult =
-  | ChatModelRunResultFinal
-  | ChatModelRunResultStream;
-
-interface ChatModelRunResultFinal {
-  content: MessagePart[];
+// Returned once (final) or yielded repeatedly (streaming).
+// All fields are optional; yield partial content to stream.
+interface ChatModelRunResult {
+  content?: MessagePart[];
+  status?: MessageStatus;   // object form, e.g. { type: "complete" }
+  metadata?: Record<string, unknown>;
 }
-
-// Streamed chunks are ChatModelRunResult objects
-type ChatModelRunResultStream = ChatModelRunResult;
 ```
 
 ## With OpenAI Direct
@@ -164,7 +164,6 @@ const runtime = useLocalRuntime({
     async *run({ messages, abortSignal }) {
       const toolCallId = "1";
 
-      // Yield tool call with parsed arguments
       yield {
         content: [
           {
@@ -177,7 +176,6 @@ const runtime = useLocalRuntime({
         ],
       };
 
-      // Execute tool
       const result = await getWeather({ city: "NYC" });
 
       // Send result on the same tool-call part
@@ -205,14 +203,11 @@ const runtime = useLocalRuntime({
 const runtime = useLocalRuntime({
   model: {
     async run({ messages }) {
-      // Access attachments from last message
       const lastMessage = messages[messages.length - 1];
       const attachments = lastMessage.attachments || [];
 
-      // Process attachments
       for (const attachment of attachments) {
         if (attachment.type === "image") {
-          // Handle image
         }
       }
 
@@ -221,18 +216,26 @@ const runtime = useLocalRuntime({
   },
   adapters: {
     attachments: {
-      accept: "image/*,application/pdf",
+      accept: "image/*",
+      // add() returns a PendingAttachment
       async add({ file }) {
-        const url = URL.createObjectURL(file);
         return {
           id: crypto.randomUUID(),
+          type: "image",
           name: file.name,
-          type: file.type.startsWith("image/") ? "image" : "file",
-          url,
+          contentType: file.type,
+          file,
+          status: { type: "requires-action", reason: "composer-send" },
         };
       },
+      // send() returns a CompleteAttachment with content parts
       async send(attachment) {
-        return attachment;
+        const dataUrl = await readAsDataURL(attachment.file);
+        return {
+          ...attachment,
+          status: { type: "complete" },
+          content: [{ type: "image", image: dataUrl }],
+        };
       },
       async remove() {},
     },
@@ -250,7 +253,7 @@ const runtime = useLocalRuntime({
       id: "1",
       role: "assistant",
       content: [{ type: "text", text: "Hello! How can I help you?" }],
-      status: "complete",
+      status: { type: "complete" },
       createdAt: new Date(),
     },
   ],

--- a/assistant-ui/skills/runtime/references/runtime-concepts.md
+++ b/assistant-ui/skills/runtime/references/runtime-concepts.md
@@ -1,0 +1,255 @@
+# Runtime Concepts
+
+Cross-cutting runtime concepts: the `unstable_` stability policy, how the runtimes layer, state-streaming custom agents, and message timing.
+
+## Contents
+
+- [The unstable_ stability policy](#the-unstable_-stability-policy)
+- [Runtime layering: LocalRuntime vs ExternalStoreRuntime](#runtime-layering-localruntime-vs-externalstoreruntime)
+- [useAssistantTransportRuntime (state-streaming agents)](#useassistanttransportruntime-state-streaming-agents)
+- [Reading agent state and sending commands](#reading-agent-state-and-sending-commands)
+- [Typing agent state](#typing-agent-state)
+- [Message timing (experimental)](#message-timing-experimental)
+- [Supplying timing manually](#supplying-timing-manually)
+
+## The unstable_ stability policy
+
+APIs prefixed with `unstable_` are publicly exported and meant to be built against, but their signature, naming, semantics, and return shape may change in any release, including patch releases. They carry no semver guarantees, so a breaking change can land in a patch or minor, not only a major.
+
+```ts
+import { unstable_createMessageConverter as createMessageConverter } from "@assistant-ui/react";
+```
+
+When an API stabilizes, the prefix is dropped (`unstable_foo` becomes `foo`). The old name is kept as a deprecated alias for at least one minor cycle, and the changelog notes the transition. Breaking changes are announced in the GitHub release notes and the migration guides under `/docs/migrations`.
+
+Recommended practices when consuming an `unstable_` API:
+
+- Pin your dependency range so updates do not silently break the integration.
+- Isolate the call site behind a thin wrapper, so an upstream rename touches one file.
+- Expect renames or removals at stabilization time.
+
+Examples of currently unstable exports: `unstable_createMessageConverter`, `unstable_humanToolNames` (`@assistant-ui/react`), `unstable_createLangGraphStream` (`@assistant-ui/react-langgraph`), `unstable_capabilities` on `ExternalStoreRuntime`, and the `unstable_state`, `unstable_annotations`, `unstable_data` message metadata fields.
+
+## Runtime layering: LocalRuntime vs ExternalStoreRuntime
+
+`ExternalStoreRuntime` is the lowest-level runtime. You own the message array and `isRunning` flag, and you implement `onNew`, `onEdit`, `onReload`, and friends against whatever store you already use (React state, Redux, Zustand). assistant-ui reads from your store and never holds its own copy. See `external-store.md`.
+
+```tsx
+const runtime = useExternalStoreRuntime({
+  messages,
+  isRunning,
+  onNew: async (message) => { /* you mutate your store */ },
+});
+```
+
+`LocalRuntime` sits above it. assistant-ui owns the message store, branching, and run lifecycle; you implement only a `ChatModelAdapter.run` that yields `ChatModelRunResult` chunks. Edit, reload, branch switching, and cancellation come for free. See `local-runtime.md`.
+
+```tsx
+const runtime = useLocalRuntime({
+  model: {
+    async *run({ messages, abortSignal }) {
+      yield { content: [{ type: "text", text: "..." }] };
+    },
+  },
+});
+```
+
+Note: reach for `ExternalStoreRuntime` when an external system is the source of truth for messages; reach for `LocalRuntime` when you only need to provide a model adapter and want message management handled for you.
+
+## useAssistantTransportRuntime (state-streaming agents)
+
+`useAssistantTransportRuntime` (from `@assistant-ui/react`) connects to a custom backend agent that streams its full state, rather than a message delta stream. You hold the agent's state object, and a `converter` projects that state into thread messages on every update.
+
+```tsx
+import { useAssistantTransportRuntime, AssistantRuntimeProvider } from "@assistant-ui/react";
+import { Thread } from "@/components/assistant-ui/thread";
+
+const runtime = useAssistantTransportRuntime({
+  initialState: { messages: [] },
+  api: "http://localhost:8010/assistant",
+  converter,
+  headers: async () => ({ Authorization: "Bearer token" }),
+  onError: (error, { commands, updateState }) => {
+    updateState((s) => ({ ...s, lastError: error.message }));
+  },
+});
+```
+
+Options:
+
+```ts
+interface AssistantTransportRuntimeOptions<T> {
+  initialState: T;                 // starting agent state
+  api: string;                     // backend endpoint URL
+  converter: (
+    state: T,
+    connectionMetadata: AssistantTransportConnectionMetadata,
+  ) => { messages: ThreadMessage[]; isRunning: boolean; state?: ReadonlyJSONValue };
+
+  resumeApi?: string;              // optional reconnect endpoint
+  protocol?: "data-stream" | "assistant-transport";
+  headers?: Record<string, string> | Headers | (() => Promise<Record<string, string> | Headers>);
+  body?: object | (() => Promise<object | undefined>);
+  prepareSendCommandsRequest?: (
+    body: SendCommandsRequestBody,
+  ) => Record<string, unknown> | Promise<Record<string, unknown>>;
+  capabilities?: { edit?: boolean };  // editing disabled by default
+  adapters?: { attachments?: AttachmentAdapter; history?: ThreadHistoryAdapter };
+
+  onResponse?: (response: Response) => void;
+  onFinish?: () => void;
+  onError?: (error: Error, params: { commands: Command[]; updateState: (fn: (s: T) => T) => void }) => void | Promise<void>;
+  onCancel?: (params: { commands: Command[]; updateState: (fn: (s: T) => T) => void; error?: Error }) => void;
+}
+```
+
+The `converter` receives `AssistantTransportConnectionMetadata` (exported from `@assistant-ui/react`) describing in-flight work:
+
+```ts
+interface AssistantTransportConnectionMetadata {
+  pendingCommands: Command[];
+  isSending: boolean;
+  toolStatuses: Record<string, ToolExecutionStatus>;
+}
+```
+
+Build the message side of the converter with `unstable_createMessageConverter`, which maps your own message shape to thread messages and back:
+
+```ts
+import { unstable_createMessageConverter as createMessageConverter } from "@assistant-ui/react";
+
+const messageConverter = createMessageConverter((message: YourMessage) => ({
+  role: message.role,
+  content: [{ type: "text", text: message.content }],
+}));
+
+const converter = (state: MyState) => ({
+  messages: messageConverter.toThreadMessages(state.messages),
+  isRunning: false,
+});
+
+// Reverse lookup when you need the source message back:
+// messageConverter.toOriginalMessage(threadMessage)
+```
+
+Note: `unstable_createMessageConverter` is explicitly `unstable_`. The wire format is also subject to change; it is documented as migrating to Server-Sent Events in a future release. Speech, dictation, feedback, and suggestions are not supported by this runtime; drop down to `ExternalStoreRuntime` if you need them.
+
+## Reading agent state and sending commands
+
+Inside components under the provider, read agent state with `useAssistantTransportState` (accepts an optional selector) and issue custom commands with `useAssistantTransportSendCommand`.
+
+```tsx
+import {
+  useAssistantTransportState,
+  useAssistantTransportSendCommand,
+} from "@assistant-ui/react";
+
+function CustomField() {
+  const value = useAssistantTransportState((s) => s.customField);
+  const sendCommand = useAssistantTransportSendCommand();
+
+  return (
+    <button onClick={() => sendCommand({ type: "set-field", value: "x" })}>
+      {value}
+    </button>
+  );
+}
+```
+
+To resume a run, use `resumeRun` via the general runtime accessor `useAui`.
+
+## Typing agent state
+
+Augment the `Assistant.ExternalState` interface so `useAssistantTransportState` and the converter are typed against your state shape:
+
+```ts
+declare module "@assistant-ui/react" {
+  namespace Assistant {
+    interface ExternalState {
+      myState: { messages: Message[]; customField: string };
+    }
+  }
+}
+```
+
+## Message timing (experimental)
+
+`useMessageTiming` (from `@assistant-ui/react`) returns streaming performance stats for the current message. It must be called inside a `MessagePrimitive.Root` context, and returns `MessageTiming | undefined`; undefined for non-assistant messages or when no timing data exists.
+
+Note: this is experimental. The `useMessageTiming` API and the set of tracked fields may change in future versions.
+
+```tsx
+import { useMessageTiming } from "@assistant-ui/react";
+
+function TimingStats() {
+  const timing = useMessageTiming();
+  if (!timing?.totalStreamTime) return null;
+
+  return (
+    <span>
+      {timing.tokensPerSecond?.toFixed(1)} tok/s ({timing.totalStreamTime}ms)
+    </span>
+  );
+}
+```
+
+The `MessageTiming` shape:
+
+```ts
+interface MessageTiming {
+  streamStartTime: number;   // Unix timestamp when the stream started
+  firstTokenTime?: number;   // time to first text token, in ms
+  totalStreamTime?: number;  // total stream duration, in ms
+  tokenCount?: number;       // output token count from message metadata usage
+  tokensPerSecond?: number;  // throughput, requires token usage
+  totalChunks: number;       // total stream chunks received
+  toolCallCount: number;     // number of tool calls
+}
+```
+
+Timing is tracked automatically for the Data Stream runtime (via `AssistantMessageAccumulator`), `useChatRuntime` (AI SDK), and the LangGraph, AG-UI, and OpenCode runtimes. For `useLocalRuntime` and `useExternalStoreRuntime`, supply it manually.
+
+## Supplying timing manually
+
+Both manual runtimes read the same fields from `metadata.timing`. For `LocalRuntime`, attach it to the final `ChatModelRunResult`:
+
+```tsx
+const runtime = useLocalRuntime({
+  model: {
+    async run({ messages }) {
+      const startTime = Date.now();
+      const result = await callModel(messages);
+      return {
+        content: [{ type: "text", text: result.text }],
+        metadata: {
+          timing: {
+            streamStartTime: startTime,
+            totalStreamTime: Date.now() - startTime,
+            tokenCount: result.usage?.completionTokens,
+            totalChunks: 1,
+            toolCallCount: 0,
+          },
+        },
+      };
+    },
+  },
+});
+```
+
+For `ExternalStoreRuntime`, put it on the `ThreadMessageLike.metadata.timing`:
+
+```tsx
+const message: ThreadMessageLike = {
+  role: "assistant",
+  content: [{ type: "text", text: fullText }],
+  metadata: {
+    timing: {
+      streamStartTime,
+      firstTokenTime,
+      totalStreamTime,
+      totalChunks,
+      toolCallCount: 0,
+    },
+  },
+};
+```

--- a/assistant-ui/skills/runtime/references/state-hooks.md
+++ b/assistant-ui/skills/runtime/references/state-hooks.md
@@ -140,7 +140,7 @@ interface AssistantState {
 
 ## Legacy Hooks
 
-These still work but prefer the modern API:
+These are deprecated. They still work (and the CLI `upgrade` codemod migrates them) but emit deprecation warnings and will be removed in a future release. Prefer the modern unified API above.
 
 ```tsx
 // Runtime access

--- a/assistant-ui/skills/runtime/references/thread-list.md
+++ b/assistant-ui/skills/runtime/references/thread-list.md
@@ -4,7 +4,7 @@ Managing multiple chat threads.
 
 ## Overview
 
-Thread list features are automatically available when using `useChatRuntime` with cloud persistence or `unstable_useRemoteThreadListRuntime`.
+Thread list features are automatically available when using `useChatRuntime` with cloud persistence or `useRemoteThreadListRuntime`.
 
 ## ThreadListRuntime API
 
@@ -69,17 +69,14 @@ import { useAui, useAuiState } from "@assistant-ui/react";
 function ThreadListComponent() {
   const api = useAui();
 
-  // Get thread list state
   const { threadIds, archivedThreadIds, isLoading } = useAuiState(
     (s) => s.threads
   );
 
-  // Switch threads
   const handleSwitch = (threadId: string) => {
     api.threads().switchToThread(threadId);
   };
 
-  // Create new thread
   const handleNew = () => {
     api.threads().switchToNewThread();
   };
@@ -144,6 +141,7 @@ function ThreadList() {
 
       <div className="space-y-1">
         <ThreadListPrimitive.Items>
+          {() => (
           <ThreadListItemPrimitive.Root className="flex items-center p-2 hover:bg-gray-100 rounded group">
             <ThreadListItemPrimitive.Trigger className="flex-1 text-left truncate">
               <ThreadListItemPrimitive.Title />
@@ -158,6 +156,7 @@ function ThreadList() {
               </ThreadListItemPrimitive.Delete>
             </div>
           </ThreadListItemPrimitive.Root>
+          )}
         </ThreadListPrimitive.Items>
       </div>
     </ThreadListPrimitive.Root>
@@ -214,7 +213,7 @@ For custom persistence:
 ```tsx
 import {
   AssistantRuntimeProvider,
-  unstable_useRemoteThreadListRuntime as useRemoteThreadListRuntime,
+  useRemoteThreadListRuntime,
   useLocalRuntime,
 } from "@assistant-ui/react";
 import { Thread } from "@/components/assistant-ui/thread";

--- a/assistant-ui/skills/runtime/references/types.md
+++ b/assistant-ui/skills/runtime/references/types.md
@@ -36,12 +36,18 @@ interface ThreadSystemMessage {
 
 ## Message Status
 
+`status` is an object with a `type` discriminator (not a bare string):
+
 ```typescript
 type MessageStatus =
-  | "running"          // Generation in progress
-  | "complete"         // Finished successfully
-  | "incomplete"       // Stopped early
-  | "requires-action"; // Needs tool response
+  | { type: "running" }                                    // Generation in progress
+  | { type: "requires-action"; reason: "tool-calls" | "interrupt" }
+  | { type: "complete"; reason: "stop" | "unknown" }       // Finished
+  | {
+      type: "incomplete";                                  // Stopped early
+      reason: "cancelled" | "tool-calls" | "length" | "content-filter" | "other" | "error";
+      error?: unknown;
+    };
 ```
 
 ## Message Parts
@@ -102,10 +108,13 @@ interface FilePart {
 ```typescript
 interface Attachment {
   id: string;
-  type: "image" | "file" | "document";
+  type: "image" | "document" | "file";
   name: string;
+  contentType?: string;
   file?: File;
   content?: AttachmentContent[];
+  // Pending attachments are "requires-action"; completed ones are "complete"
+  status: { type: "running" | "requires-action" | "complete" | "incomplete"; reason?: string };
 }
 
 type AttachmentContent =
@@ -159,30 +168,39 @@ interface ThreadListItemState {
 ```typescript
 interface ComposerState {
   text: string;
+  role: MessageRole;            // role of the message being composed
   attachments: Attachment[];
+  attachmentAccept: string;
   isEmpty: boolean;
-  isSubmitting: boolean;
-  isDictating: boolean;
+  isEditing: boolean;           // editing an existing message
+  canCancel: boolean;
+  dictation?: DictationState;   // present while dictation is active
 }
 ```
 
 ## Tool Call Types
 
 ```typescript
-type ToolCallStatus =
-  | "running"         // Tool executing
-  | "complete"        // Finished
-  | "incomplete"      // Stopped early
-  | "requires-action" // Needs user input
+type ToolCallMessagePartStatus =
+  | { type: "running" }        // Tool executing
+  | { type: "complete" }       // Finished
+  | { type: "incomplete"; reason: "cancelled" | "length" | "content-filter" | "other" | "error" }
+  | { type: "requires-action"; reason: "interrupt" };  // Needs input
 
-interface ToolUIProps<TArgs = unknown, TResult = unknown> {
+// Props passed to a makeAssistantToolUI render component
+interface ToolCallMessagePartProps<TArgs = unknown, TResult = unknown> {
   toolCallId: string;
   toolName: string;
   args: TArgs;
   argsText: string;
   result?: TResult;
-  status: ToolCallStatus;
-  submitResult: (result: unknown) => void;
+  isError?: boolean;
+  artifact?: unknown;
+  status: ToolCallMessagePartStatus;
+
+  addResult: (result: unknown) => void;   // renderer-supplied result
+  resume: (payload: unknown) => void;      // resume a context.human(...) tool
+  respondToApproval: (response: { approved: boolean; reason?: string }) => void;
 }
 ```
 

--- a/assistant-ui/skills/runtime/references/voice.md
+++ b/assistant-ui/skills/runtime/references/voice.md
@@ -1,0 +1,280 @@
+# Realtime Voice Chat
+
+Connect a realtime voice backend (ElevenLabs, LiveKit, OpenAI Realtime, etc.) to assistant-ui via a `RealtimeVoiceAdapter`.
+
+## Contents
+
+- [Configuration](#configuration)
+- [useVoiceState](#usevoicestate)
+- [useVoiceControls](#usevoicecontrols)
+- [useVoiceVolume](#usevoicevolume)
+- [UI Controls](#ui-controls)
+- [RealtimeVoiceAdapter Interface](#realtimevoiceadapter-interface)
+- [createVoiceSession Helper](#createvoicesession-helper)
+- [Status, Mode, and Transcript Types](#status-mode-and-transcript-types)
+- [Transcript Handling](#transcript-handling)
+- [ElevenLabs Example](#elevenlabs-example)
+- [LiveKit Example](#livekit-example)
+
+## Configuration
+
+Pass an adapter via `adapters.voice`. When provided, `capabilities.voice` is automatically set to `true`.
+
+```ts
+import { useChatRuntime } from "@assistant-ui/react";
+
+const runtime = useChatRuntime({
+  adapters: {
+    voice: new MyVoiceAdapter({ /* ... */ }),
+  },
+});
+```
+
+All voice hooks and types come from `@assistant-ui/react`:
+
+```ts
+import {
+  useVoiceState,
+  useVoiceControls,
+  useVoiceVolume,
+  createVoiceSession,
+} from "@assistant-ui/react";
+import type { RealtimeVoiceAdapter } from "@assistant-ui/react";
+```
+
+## useVoiceState
+
+Returns the current session state, or `undefined` when no session is active.
+
+```ts
+const voiceState = useVoiceState();
+
+voiceState?.status.type; // "starting" | "running" | "ended"
+voiceState?.isMuted;     // boolean
+voiceState?.mode;        // "listening" | "speaking"
+```
+
+```tsx
+function VoiceStatus() {
+  const voiceState = useVoiceState();
+  if (!voiceState) return <span>Idle</span>;
+
+  if (voiceState.status.type === "starting") return <span>Connecting…</span>;
+  if (voiceState.status.type === "ended") return <span>Ended</span>;
+  return <span>{voiceState.mode === "speaking" ? "Assistant speaking" : "Listening"}</span>;
+}
+```
+
+## useVoiceControls
+
+Imperative session controls. `connect` starts a session; the rest act on the active one.
+
+```ts
+const { connect, disconnect, mute, unmute } = useVoiceControls();
+// connect: () => void
+// disconnect: () => void
+// mute: () => void
+// unmute: () => void
+```
+
+## useVoiceVolume
+
+Real time audio level on its own subscription, a number from `0` to `1`. Kept separate from `useVoiceState` so high frequency volume updates do not re-render state consumers.
+
+```tsx
+function VolumeBar() {
+  const volume = useVoiceVolume(); // 0 to 1
+  return <div style={{ width: `${volume * 100}%` }} className="volume-fill" />;
+}
+```
+
+## UI Controls
+
+```tsx
+function VoiceControls() {
+  const voiceState = useVoiceState();
+  const { connect, disconnect, mute, unmute } = useVoiceControls();
+
+  const isRunning = voiceState?.status.type === "running";
+  const isStarting = voiceState?.status.type === "starting";
+  const isMuted = voiceState?.isMuted ?? false;
+
+  if (!isRunning && !isStarting) {
+    return (
+      <button onClick={() => connect()}>
+        <PhoneIcon /> Connect
+      </button>
+    );
+  }
+
+  return (
+    <>
+      <button onClick={() => (isMuted ? unmute() : mute())} disabled={!isRunning}>
+        {isMuted ? <MicOffIcon /> : <MicIcon />}
+      </button>
+      <button onClick={() => disconnect()}>
+        <PhoneOffIcon /> Disconnect
+      </button>
+    </>
+  );
+}
+```
+
+## RealtimeVoiceAdapter Interface
+
+An adapter's `connect` returns a `RealtimeVoiceAdapter.Session`. Each `on*` method registers a callback and returns its unsubscribe function.
+
+```ts
+class MyVoiceAdapter implements RealtimeVoiceAdapter {
+  connect(options: { abortSignal?: AbortSignal }): RealtimeVoiceAdapter.Session {
+    return {
+      get status() { /* RealtimeVoiceAdapter.Status */ },
+      get isMuted() { /* boolean */ },
+      disconnect: () => { /* ... */ },
+      mute: () => { /* ... */ },
+      unmute: () => { /* ... */ },
+      onStatusChange: (callback) => {
+        // { type: "starting" } -> { type: "running" } -> { type: "ended", reason }
+        return () => {}; // unsubscribe
+      },
+      onTranscript: (callback) => {
+        // callback({ role: "user" | "assistant", text: "...", isFinal: true })
+        return () => {};
+      },
+      onModeChange: (callback) => {
+        // callback("listening") | callback("speaking")
+        return () => {};
+      },
+      onVolumeChange: (callback) => {
+        // callback(0.72)
+        return () => {};
+      },
+    };
+  }
+}
+```
+
+## createVoiceSession Helper
+
+`createVoiceSession` removes the manual `Set<callback>` bookkeeping of implementing `Session` by hand. It takes the `connect` options and an async setup function that receives `helpers` and returns the session controls (`disconnect`, `mute`, `unmute`).
+
+Signature:
+
+```ts
+createVoiceSession(
+  options: { abortSignal?: AbortSignal },
+  setup: (helpers: VoiceSessionHelpers) => Promise<VoiceSessionControls>,
+): RealtimeVoiceAdapter.Session;
+```
+
+`helpers` (`VoiceSessionHelpers`):
+
+```ts
+helpers.setStatus(status: RealtimeVoiceAdapter.Status): void;
+helpers.end(reason: "finished" | "cancelled" | "error", error?: unknown): void;
+helpers.emitTranscript(item: RealtimeVoiceAdapter.TranscriptItem): void;
+helpers.emitMode(mode: RealtimeVoiceAdapter.Mode): void;
+helpers.emitVolume(volume: number): void;
+helpers.isDisposed(): boolean;
+```
+
+Usage:
+
+```ts
+export class MyVoiceAdapter implements RealtimeVoiceAdapter {
+  connect(options: { abortSignal?: AbortSignal }): RealtimeVoiceAdapter.Session {
+    return createVoiceSession(options, async (helpers) => {
+      const client = await MyVoiceClient.connect();
+
+      client.on("open", () => helpers.setStatus({ type: "running" }));
+      client.on("close", () => helpers.end("finished"));
+      client.on("error", (err) => helpers.end("error", err));
+      client.on("transcript", (item) => helpers.emitTranscript(item));
+      client.on("mode", (mode) => helpers.emitMode(mode));
+      client.on("volume", (v) => helpers.emitVolume(v));
+
+      return {
+        disconnect: () => client.close(),
+        mute: () => client.setMuted(true),
+        unmute: () => client.setMuted(false),
+      };
+    });
+  }
+}
+```
+
+Note: `helpers.isDisposed()` reports whether the session has ended or its `abortSignal` fired; guard late async work with it before emitting.
+
+## Status, Mode, and Transcript Types
+
+```ts
+// RealtimeVoiceAdapter.Status
+type Status =
+  | { type: "starting" }
+  | { type: "running" }
+  | { type: "ended"; reason: "finished" | "cancelled" | "error"; error?: unknown };
+
+// RealtimeVoiceAdapter.Mode
+type Mode = "listening" | "speaking";
+
+// RealtimeVoiceAdapter.TranscriptItem
+interface TranscriptItem {
+  role: "user" | "assistant";
+  text: string;
+  isFinal: boolean;
+}
+```
+
+The session lifecycle moves `starting -> running -> ended`. The `VoiceSessionState` exposed by `useVoiceState` adds `isMuted` and `mode` alongside `status`.
+
+## Transcript Handling
+
+assistant-ui turns emitted transcripts into thread messages:
+
+- User transcripts (`role: "user"`, `isFinal: true`) are appended as user messages.
+- Assistant transcripts (`role: "assistant"`) are streamed into an assistant message with `running` status until `isFinal: true` marks it complete.
+
+## ElevenLabs Example
+
+```bash
+npm install @elevenlabs/client
+```
+
+Wire the ElevenLabs conversation callbacks to the session helpers inside the adapter: `onConnect` -> `setStatus({ type: "running" })`, `onDisconnect` -> `end("finished")`, `onError` -> `end("error", error)`, `onModeChange` -> `emitMode("speaking" | "listening")`, and `onMessage` -> `emitTranscript({ role, text, isFinal: true })`.
+
+```ts
+import { ElevenLabsVoiceAdapter } from "@/lib/elevenlabs-voice-adapter";
+
+const runtime = useChatRuntime({
+  adapters: {
+    voice: new ElevenLabsVoiceAdapter({
+      agentId: process.env.NEXT_PUBLIC_ELEVENLABS_AGENT_ID!,
+    }),
+  },
+});
+```
+
+## LiveKit Example
+
+```bash
+npm install livekit-client livekit-server-sdk
+```
+
+Mint the access token server side and pass an async `token` resolver to the adapter.
+
+```ts
+import { LiveKitVoiceAdapter } from "@/lib/livekit-voice-adapter";
+
+const runtime = useChatRuntime({
+  adapters: {
+    voice: new LiveKitVoiceAdapter({
+      url: process.env.NEXT_PUBLIC_LIVEKIT_URL!,
+      token: async () => {
+        const res = await fetch("/api/livekit-token", { method: "POST" });
+        const { token } = await res.json();
+        return token;
+      },
+    }),
+  },
+});
+```

--- a/assistant-ui/skills/setup/SKILL.md
+++ b/assistant-ui/skills/setup/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: setup
-description: Setup and configure assistant-ui in a project. Use when installing packages, configuring runtimes, setting up chat UI, or troubleshooting setup issues.
-version: 0.1.0
+description: "Installs and configures assistant-ui in a project via the CLI, and picks the right runtime for a backend. Use for first-time install, scaffold, or config: `npx assistant-ui@latest create my-app` (templates default, minimal, cloud, cloud-clerk, langgraph, mcp), `npx assistant-ui@latest init [--yes] [--overwrite]` in an existing Next.js app, or `npx assistant-ui@latest add` registry components (markdown-text, thread-list). Also use to choose a runtime hook for a backend: useChatRuntime (AI SDK), useLangGraphRuntime, useAgUiRuntime, useA2ARuntime, useLocalRuntime (custom streaming API), or useExternalStoreRuntime (Redux/Zustand). Covers Vite/TanStack Start setup, shadcn styling, the playground --preset flag, and avoiding the deprecated @assistant-ui/styles and @assistant-ui/react-ui packages. For upgrading an existing install or post-upgrade breakage use update; for building UI from raw parts use primitives."
 license: MIT
 ---
 
 # assistant-ui Setup
+
+**Always consult [assistant-ui.com/llms.txt](https://www.assistant-ui.com/llms.txt) for the latest API.**
 
 ## CLI Commands
 
@@ -87,6 +88,13 @@ For runtimes other than AI SDK or frameworks other than Next.js, consult the ref
 | Custom streaming API | `useLocalRuntime` | [references/custom-backend.md](./references/custom-backend.md) |
 | Existing state (Redux/Zustand) | `useExternalStoreRuntime` | [references/custom-backend.md](./references/custom-backend.md) |
 | Vite / TanStack Start | — | [references/tanstack.md](./references/tanstack.md) |
+| LangChain agents | `useStreamRuntime` | [references/langchain.md](./references/langchain.md) |
+| Google ADK agents | `useAdkRuntime` | [references/google-adk.md](./references/google-adk.md) |
+| Mastra agents | `useChatRuntime` | [references/mastra.md](./references/mastra.md) |
+| Cloudflare Agents | `useAISDKRuntime` | [references/cloudflare-agents.md](./references/cloudflare-agents.md) |
+| Legacy AI SDK v4/v5 | `useVercelUseChatRuntime` / `useDataStreamRuntime` | [references/ai-sdk-legacy.md](./references/ai-sdk-legacy.md) |
+| Registry UI components (modal, sidebar, model selector) | registry | [references/registry-components.md](./references/registry-components.md) |
+| DevTools inspector | dev only | [references/devtools.md](./references/devtools.md) |
 
 ---
 

--- a/assistant-ui/skills/setup/references/a2a.md
+++ b/assistant-ui/skills/setup/references/a2a.md
@@ -1,11 +1,11 @@
 # A2A Protocol Integration
 
-Connect assistant-ui to Agent-to-Agent (A2A) protocol backends for multi-agent systems.
+Connect assistant-ui to Agent-to-Agent (A2A) protocol servers via `@assistant-ui/react-a2a`.
 
 ## Installation
 
 ```bash
-npm install @assistant-ui/react-a2a
+npm install @assistant-ui/react @assistant-ui/react-a2a
 ```
 
 ## Exports
@@ -13,39 +13,39 @@ npm install @assistant-ui/react-a2a
 ```tsx
 import {
   useA2ARuntime,
-  useA2AMessages,
-  useA2ATaskState,
+  useA2ATask,
   useA2AArtifacts,
-  useA2ASend,
-  convertA2AMessages,
-  A2AMessageAccumulator,
-  appendA2AChunk,
+  useA2AAgentCard,
+  A2AClient,
+  A2AError,
+  // conversion utilities (advanced)
+  a2aMessageToContent,
+  taskStateToMessageStatus,
+  contentPartsToA2AParts,
+  isTerminalTaskState,
+  isInterruptedTaskState,
 } from "@assistant-ui/react-a2a";
 ```
 
 ## Basic Setup
 
+`useA2ARuntime` connects to an A2A server by `baseUrl` (it creates a client for you) or a pre-built `client`. There is no `stream` callback.
+
 ```tsx
+"use client";
+
 import { AssistantRuntimeProvider } from "@assistant-ui/react";
 import { Thread } from "@/components/assistant-ui/thread";
 import { useA2ARuntime } from "@assistant-ui/react-a2a";
 
-function Chat() {
+export function MyRuntimeProvider({ children }: { children: React.ReactNode }) {
   const runtime = useA2ARuntime({
-    stream: async function* (messages, config) {
-      const response = await fetch("/api/a2a", {
-        method: "POST",
-        body: JSON.stringify({ messages, config }),
-      });
-
-      const reader = response.body?.getReader();
-      // ... yield A2A events
-    },
+    baseUrl: "http://localhost:9999",
   });
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
-      <Thread />
+      {children}
     </AssistantRuntimeProvider>
   );
 }
@@ -55,102 +55,68 @@ function Chat() {
 
 ```tsx
 const runtime = useA2ARuntime({
-  stream: A2AStreamCallback,                  // Required: streaming function
-  contextId: "thread-id",                     // Optional: thread context ID (deprecated)
-  autoCancelPendingToolCalls: true,           // Optional: auto-cancel pending tools
-  unstable_allowCancellation: false,          // Optional: enable cancellation
-  onSwitchToNewThread: () => {},              // Optional: new thread handler (deprecated)
-  onSwitchToThread: async (id) => ({          // Optional: switch thread handler
-    messages: [],
-    artifacts: [],
-  }),
-  adapters: {
-    attachments: AttachmentAdapter,
-    speech: SpeechSynthesisAdapter,
-    feedback: FeedbackAdapter,
+  // Provide a baseUrl OR a pre-built client
+  baseUrl: "https://my-agent.example.com",
+  // client: new A2AClient({ baseUrl: "https://my-agent.example.com" }),
+
+  // baseUrl-only options
+  basePath: "/v1",
+  tenant: "my-tenant",
+  headers: { Authorization: `Bearer ${token}` },
+  extensions: [],
+  fetchOptions: { credentials: "include" },
+
+  contextId: "conversation-context-id",
+  configuration: {
+    /* A2ASendMessageConfiguration */
   },
-  eventHandlers: {                            // Optional: A2A event callbacks
-    onTaskUpdate: (event) => {},
-    onArtifacts: (event) => {},
-    onError: (event) => {},
-    onStateUpdate: (event) => {},
-    onCustomEvent: (event) => {},
+
+  onError: (error) => {},
+  onCancel: () => {},
+  onArtifactComplete: (artifact) => {},
+
+  adapters: {
+    attachments: attachmentAdapter,
+    speech: speechAdapter,
+    feedback: feedbackAdapter,
+    history: historyAdapter,
   },
 });
+```
+
+## Pre-built Client
+
+```tsx
+import { A2AClient } from "@assistant-ui/react-a2a";
+
+const client = new A2AClient({ baseUrl: "https://my-agent.example.com" });
+const runtime = useA2ARuntime({ client });
 ```
 
 ## Accessing A2A State
 
 ```tsx
-import { useA2ATaskState, useA2AArtifacts, useA2ASend } from "@assistant-ui/react-a2a";
+import {
+  useA2ATask,
+  useA2AArtifacts,
+  useA2AAgentCard,
+} from "@assistant-ui/react-a2a";
 
-function MyComponent() {
-  const taskState = useA2ATaskState();  // Current task state
-  const artifacts = useA2AArtifacts();  // Accumulated artifacts
-  const send = useA2ASend();            // Send function for manual control
+function TaskStatus() {
+  const task = useA2ATask();         // current A2A task (state + status message)
+  const artifacts = useA2AArtifacts(); // accumulated artifacts
+  const agentCard = useA2AAgentCard(); // agent card (capabilities/skills)
 
-  // Send messages manually
-  await send(
-    [{ role: "user", content: "Hello" }],
-    { contextId: "my-context" }
-  );
+  return <div>{task?.status?.state}</div>;
 }
 ```
 
-## A2A Message Types
+## Thread Persistence
+
+Pass a `history` or `threadList` adapter via `adapters`, or combine with the cloud thread list runtime (exported from `@assistant-ui/react`):
 
 ```tsx
-type A2AMessage = {
-  id?: string;
-  role: "user" | "assistant" | "system" | "tool";
-  content: string | A2AMessageContent[];
-  tool_calls?: A2AToolCall[];
-  tool_call_id?: string;
-  artifacts?: A2AArtifact[];
-  status?: MessageStatus;
-};
-
-type A2AMessageContent =
-  | { type: "text"; text: string }
-  | { type: "image_url"; image_url: string | { url: string } }
-  | { type: "data"; data: any };
-
-type A2AToolCall = {
-  id: string;
-  name: string;
-  args: ReadonlyJSONObject;
-  argsText?: string;
-};
-
-type A2AArtifact = {
-  name: string;
-  parts: A2AArtifactPart[];
-};
-```
-
-## With Cloud Thread Management
-
-For thread persistence, use `useCloudThreadListRuntime`:
-
-```tsx
-import { useA2ARuntime } from "@assistant-ui/react-a2a";
-import { useCloudThreadListRuntime } from "assistant-cloud/react";
-
-function Chat() {
-  const runtime = useA2ARuntime({
-    stream: myStreamFunction,
-    // Don't use contextId/onSwitchToThread here
-  });
-
-  // Use cloud for thread management instead
-  const threadListRuntime = useCloudThreadListRuntime({ cloud });
-
-  return (
-    <AssistantRuntimeProvider runtime={runtime}>
-      <Thread />
-    </AssistantRuntimeProvider>
-  );
-}
+import { useCloudThreadListRuntime } from "@assistant-ui/react";
 ```
 
 ## When to Use A2A

--- a/assistant-ui/skills/setup/references/ai-sdk-legacy.md
+++ b/assistant-ui/skills/setup/references/ai-sdk-legacy.md
@@ -1,0 +1,166 @@
+# AI SDK Legacy (v5 and v4)
+
+Keep an app on a legacy AI SDK release instead of migrating to v6. v5 stays on `@assistant-ui/react-ai-sdk@0.x` + `ai@^5` with `useVercelUseChatRuntime`; v4 uses `useDataStreamRuntime` from `@assistant-ui/react-data-stream` + `ai@^4`. For new projects on `ai@^6`, see `ai-sdk.md` instead.
+
+## Contents
+
+- [AI SDK v5 (legacy)](#ai-sdk-v5-legacy)
+  - [Install](#install)
+  - [Backend route](#backend-route)
+  - [Frontend with useVercelUseChatRuntime](#frontend-with-usevercelusechatruntime)
+  - [Note on 0.11.3+](#note-on-0113)
+- [AI SDK v4 (legacy)](#ai-sdk-v4-legacy)
+  - [Install](#install-1)
+  - [Backend route](#backend-route-1)
+  - [Frontend with useDataStreamRuntime](#frontend-with-usedatastreamruntime)
+  - [useDataStreamRuntime options](#usedatastreamruntime-options)
+- [Why these are legacy](#why-these-are-legacy)
+
+## AI SDK v5 (legacy)
+
+Stays on `@assistant-ui/react-ai-sdk@0.x` paired with `ai@^5`. Tools use `parameters:` (not `inputSchema:`), and the route returns `toDataStreamResponse()`.
+
+### Install
+
+```bash
+npm install @assistant-ui/react @assistant-ui/react-ai-sdk@0.x ai@^5 @ai-sdk/openai@^1 zod
+```
+
+### Backend route
+
+```ts
+// app/api/chat/route.ts
+import { openai } from "@ai-sdk/openai";
+import { streamText, tool } from "ai";
+import type { Message } from "ai";
+import { z } from "zod";
+
+export const maxDuration = 30;
+
+export async function POST(req: Request) {
+  const { messages }: { messages: Message[] } = await req.json();
+
+  const result = streamText({
+    model: openai("gpt-5.4-nano"),
+    messages,
+    tools: {
+      get_current_weather: tool({
+        description: "Get the current weather",
+        parameters: z.object({ city: z.string() }),
+        execute: async ({ city }) => `The weather in ${city} is sunny`,
+      }),
+    },
+  });
+
+  return result.toDataStreamResponse();
+}
+```
+
+Note: in v5 `streamText` takes `messages` directly (no `convertToModelMessages`), tools use `parameters:`, and the response is `toDataStreamResponse()`.
+
+### Frontend with useVercelUseChatRuntime
+
+Drive the AI SDK `useChat` hook yourself, then hand the chat helpers to `useVercelUseChatRuntime`. The `useChat` import comes from `ai/react` in v5.
+
+```tsx
+"use client";
+
+import { useChat } from "ai/react";
+import { useVercelUseChatRuntime } from "@assistant-ui/react-ai-sdk";
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { Thread } from "@/components/assistant-ui/thread";
+
+export default function Home() {
+  const chat = useChat({ api: "/api/chat" });
+  const runtime = useVercelUseChatRuntime(chat);
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <div className="h-dvh">
+        <Thread />
+      </div>
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+### Note on 0.11.3+
+
+`useVercelUseChatRuntime` is the wiring for `@assistant-ui/react-ai-sdk` older than 0.11.3. On 0.11.3 and later (still within the `0.x` line) you can call `useChatRuntime` directly instead of managing `useChat` yourself.
+
+## AI SDK v4 (legacy)
+
+`@assistant-ui/react-ai-sdk` targets `ai@^6` and up, so v4 apps integrate through `@assistant-ui/react-data-stream`, which speaks the same data stream protocol that v4's `toDataStreamResponse()` emits.
+
+### Install
+
+```bash
+npm install @assistant-ui/react @assistant-ui/react-data-stream ai@^4 @ai-sdk/openai
+```
+
+### Backend route
+
+```ts
+// app/api/chat/route.ts
+import { streamText } from "ai";
+import { openai } from "@ai-sdk/openai";
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+  const result = streamText({ model: openai("gpt-5.4-nano"), messages });
+  return result.toDataStreamResponse();
+}
+```
+
+### Frontend with useDataStreamRuntime
+
+`useDataStreamRuntime` comes from `@assistant-ui/react-data-stream`. Set `protocol: "data-stream"` so it parses v4's `toDataStreamResponse()` output; the default protocol expects the SSE format used by newer AI SDK releases.
+
+```tsx
+"use client";
+
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { useDataStreamRuntime } from "@assistant-ui/react-data-stream";
+import { Thread } from "@/components/assistant-ui/thread";
+
+export default function Home() {
+  const runtime = useDataStreamRuntime({
+    api: "/api/chat",
+    protocol: "data-stream",
+  });
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <div className="h-full">
+        <Thread />
+      </div>
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+### useDataStreamRuntime options
+
+- `api`: endpoint URL for the data stream protocol.
+- `protocol`: `"data-stream"` to pair with v4's `toDataStreamResponse()`.
+- `headers`: `Record<string, string>`, `Headers`, or an async function returning headers.
+- `body`: object or async function returning extra request body params.
+- Lifecycle callbacks: `onResponse`, `onFinish`, `onError`, `onCancel`.
+
+Note: human in the loop tools (`human()` interrupts) are not supported by the data stream runtime; use `LocalRuntime` directly if you need approval flows.
+
+## Why these are legacy
+
+AI SDK v6 introduced breaking API changes, and `@assistant-ui/react-ai-sdk` follows v6 going forward. Differences that show up when these legacy stacks are upgraded:
+
+| Area | v4 | v5 | v6 (current) |
+|---|---|---|---|
+| `ai` package | `ai@^4` | `ai@^5` | `ai@^6` |
+| `@ai-sdk/openai` | any | `^1` | `^3` |
+| Runtime package | `@assistant-ui/react-data-stream` | `@assistant-ui/react-ai-sdk@0.x` | `@assistant-ui/react-ai-sdk` |
+| Runtime hook | `useDataStreamRuntime` | `useVercelUseChatRuntime` | `useChatRuntime` |
+| `convertToModelMessages` | not used | sync | async (`await`) |
+| Tool schema key | n/a | `parameters:` | `inputSchema:` |
+| Response method | `toDataStreamResponse()` | `toDataStreamResponse()` | `toUIMessageStreamResponse()` |
+
+To move off legacy, switch the runtime hook to `useChatRuntime`, update the backend to v6 `streamText`, and apply the AI SDK codemods at `ai-sdk.dev/docs/migration-guides`.

--- a/assistant-ui/skills/setup/references/ai-sdk.md
+++ b/assistant-ui/skills/setup/references/ai-sdk.md
@@ -66,7 +66,6 @@ export async function POST(req: Request) {
     messages: await convertToModelMessages(messages),
     tools: {
       ...frontendTools(tools ?? {}),
-      // backend tools here...
     },
   });
 
@@ -178,7 +177,6 @@ const WeatherToolUI = makeAssistantToolUI({
   },
 });
 
-// Register inside the provider tree
 <AssistantRuntimeProvider runtime={runtime}>
   <WeatherToolUI />
   <Thread />
@@ -258,7 +256,7 @@ function ChatPage() {
 }
 ```
 
-See the [cloud reference](./cloud.md) for authentication and configuration details.
+See the `/cloud` skill for authentication and configuration details.
 
 ## Troubleshooting
 

--- a/assistant-ui/skills/setup/references/cloudflare-agents.md
+++ b/assistant-ui/skills/setup/references/cloudflare-agents.md
@@ -1,0 +1,217 @@
+# Cloudflare Agents Integration
+
+Wire Cloudflare's stateful agent framework into assistant-ui via the AI SDK runtime: `useAgent` -> `useAgentChat` -> `useAISDKRuntime` -> `AssistantRuntimeProvider`.
+
+## Contents
+
+- [Architecture](#architecture)
+- [Packages](#packages)
+- [Server: define the agent](#server-define-the-agent)
+- [Server: route requests](#server-route-requests)
+- [Server: wrangler config](#server-wrangler-config)
+- [Server: run locally](#server-run-locally)
+- [Client: wire the runtime](#client-wire-the-runtime)
+- [Client: environment](#client-environment)
+- [Type compatibility with useChat](#type-compatibility-with-usechat)
+- [Cloudflare-specific extras](#cloudflare-specific-extras)
+- [setMessages round-trips through the Durable Object](#setmessages-round-trips-through-the-durable-object)
+- [Authentication](#authentication)
+- [Version stability](#version-stability)
+
+## Architecture
+
+This is an integration guide, not a runtime adapter. assistant-ui ships no `@assistant-ui/react-cloudflare-agents` package. The two halves:
+
+- Server: a Durable Object subclasses `AIChatAgent` from `@cloudflare/ai-chat`, owns the SQLite-backed message history, and streams responses over a WebSocket.
+- Client: `@cloudflare/ai-chat/react`'s `useAgentChat` wraps that WebSocket and exposes the same `messages`, `sendMessage`, `regenerate`, `status`, `stop`, `setMessages`, `addToolOutput` surface as the AI SDK's `useChat`. `useAISDKRuntime` from `@assistant-ui/react-ai-sdk` reads those methods off whatever you pass it, so feeding it `useAgentChat`'s return value yields a full runtime: streaming, tool calling, edit, reload, history import and export.
+
+Note: `AssistantCloud` integrates via `useChatRuntime` (which builds its own `useChat`) and is not compatible with the `useAgentChat` wiring shown here. Multi-thread support needs a custom thread list wired around `useAISDKRuntime`.
+
+## Packages
+
+Worker side:
+
+```sh
+npm install agents@0.12.4 @cloudflare/ai-chat@0.7.0 ai@latest @ai-sdk/openai@latest
+```
+
+Frontend side (in addition to `@assistant-ui/react` and `@assistant-ui/react-ai-sdk` from `npx assistant-ui@latest create`):
+
+```sh
+npm install agents@0.12.4 @cloudflare/ai-chat@0.7.0
+```
+
+Pin `agents` and `@cloudflare/ai-chat` to exact versions; both are pre-1.0 and ship breaking changes between minor releases.
+
+## Server: define the agent
+
+`AIChatAgent` already implements message persistence, the streaming protocol, and WebSocket plumbing. Override `onChatMessage` to plug in your model and tools. `this.messages` is the persisted history for this Durable Object instance.
+
+```ts title="src/chat.ts"
+import { AIChatAgent } from "@cloudflare/ai-chat";
+import { openai } from "@ai-sdk/openai";
+import { streamText, convertToModelMessages } from "ai";
+
+export type Env = {
+  OPENAI_API_KEY: string;
+  Chat: DurableObjectNamespace<Chat>;
+};
+
+export class Chat extends AIChatAgent<Env> {
+  async onChatMessage(onFinish: Parameters<typeof streamText>[0]["onFinish"]) {
+    return streamText({
+      model: openai("gpt-4o-mini"),
+      messages: await convertToModelMessages(this.messages),
+      onFinish,
+    });
+  }
+}
+```
+
+The `Chat: DurableObjectNamespace<Chat>` field mirrors the binding declared in `wrangler.jsonc` and is what `routeAgentRequest` looks up to resolve the agent. Each unique agent `name` you connect with from the client gets its own instance and its own message log.
+
+## Server: route requests
+
+`routeAgentRequest` handles WebSocket upgrades, agent lookup by URL path, and the `/get-messages` HTTP endpoint the frontend uses for history rehydration. The `cors` helper reflects the request origin so the frontend can talk to the Worker across ports during local development; WebSocket upgrades bypass CORS in the browser, but the `/get-messages` fetch needs these headers.
+
+```ts title="src/index.ts"
+import { routeAgentRequest } from "agents";
+import { Chat, type Env } from "./chat";
+
+export { Chat };
+
+const cors = (request: Request) => ({
+  "Access-Control-Allow-Origin": request.headers.get("Origin") ?? "*",
+  "Access-Control-Allow-Headers": "Content-Type, Upgrade",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+});
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.method === "OPTIONS") {
+      return new Response(null, { headers: cors(request) });
+    }
+    const upstream =
+      (await routeAgentRequest(request, env)) ??
+      new Response("Not found", { status: 404 });
+    const res = new Response(upstream.body, upstream);
+    for (const [k, v] of Object.entries(cors(request))) res.headers.set(k, v);
+    return res;
+  },
+} satisfies ExportedHandler<Env>;
+```
+
+For production, replace the wildcard origin fallback with an explicit allowlist.
+
+## Server: wrangler config
+
+The binding `name` and `class_name` must match the exported class. `new_sqlite_classes` is required so the Durable Object can use SQLite for message storage.
+
+```jsonc title="wrangler.jsonc"
+{
+  "name": "my-agent",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-01-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "durable_objects": {
+    "bindings": [{ "name": "Chat", "class_name": "Chat" }]
+  },
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["Chat"] }
+  ]
+}
+```
+
+## Server: run locally
+
+Local `wrangler dev` reads environment variables from `.dev.vars`, not the remote secret store:
+
+```sh title=".dev.vars"
+OPENAI_API_KEY=sk-...
+```
+
+```sh
+wrangler dev
+```
+
+The Worker boots on `http://localhost:8787`. For production, upload the same key as a deployed Worker secret before `wrangler deploy`:
+
+```sh
+wrangler secret put OPENAI_API_KEY
+```
+
+## Client: wire the runtime
+
+The full chain: `useAgent` -> `useAgentChat` -> `useAISDKRuntime` -> `AssistantRuntimeProvider`.
+
+```tsx title="app/assistant.tsx"
+"use client";
+
+import { useAgent } from "agents/react";
+import { useAgentChat } from "@cloudflare/ai-chat/react";
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { useAISDKRuntime } from "@assistant-ui/react-ai-sdk";
+import { Thread } from "@/components/assistant-ui/thread";
+
+export const Assistant = () => {
+  const agent = useAgent({
+    agent: "Chat",
+    name: "default",
+    host: process.env.NEXT_PUBLIC_AGENT_HOST!,
+  });
+  const chat = useAgentChat({ agent });
+  const runtime = useAISDKRuntime(chat);
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  );
+};
+```
+
+`agent` is the Durable Object class name. `name: "default"` is the instance key; pass a per-user value (a user ID, session ID, or chat ID) to give each user their own persisted history. Switching `name` opens a new WebSocket to a different Durable Object instance. `host` is the Worker base URL.
+
+## Client: environment
+
+```sh title=".env.local"
+NEXT_PUBLIC_AGENT_HOST=http://localhost:8787
+```
+
+`NEXT_PUBLIC_*` exposes the value to the browser. In production, point it at your deployed Worker (e.g. `https://my-agent.example.workers.dev`).
+
+## Type compatibility with useChat
+
+`useAgentChat`'s return type is `Omit<ReturnType<typeof useChat>, "addToolOutput"> & { ... }`. The `addToolOutput` option shape differs slightly: `useChat` accepts `{ state, tool, toolCallId, ... }`; `useAgentChat` accepts `{ state, toolCallId, toolName?, ... }`. At runtime the paths converge through `useAISDKRuntime` without issue. If the compiler flags the call, cast at the call site:
+
+```tsx
+const runtime = useAISDKRuntime(
+  chat as Parameters<typeof useAISDKRuntime>[0],
+);
+```
+
+If TypeScript still refuses the direct cast, use `chat as unknown as Parameters<typeof useAISDKRuntime>[0]`. Note: `satisfies` does not help; it validates assignability without changing the inferred type, so it surfaces the same error.
+
+## Cloudflare-specific extras
+
+`useAgentChat` exposes three values that `useChat` does not. Destructure them alongside `chat` and pass them into your UI directly; they don't need to flow through the runtime.
+
+- `clearHistory()` sends a `cf_agent_chat_clear` frame and wipes the Durable Object's SQLite store. `setMessages([])` alone only clears the client view.
+- `isServerStreaming` is `true` while the server is pushing tokens, independent of client-initiated request state. Use it for a universal streaming indicator.
+- `isToolContinuation` distinguishes "server auto-continuing after a tool result" from "user just sent a new message"; useful for typing-indicator gating.
+
+## setMessages round-trips through the Durable Object
+
+`useAgentChat` overrides `setMessages` to broadcast the new list over the WebSocket so the Durable Object's SQLite history stays in sync. This means assistant-ui's `onImport`, `onEdit`, `onReload`, and pending-tool cancellation paths all persist server-side automatically. The tradeoff is one extra WebSocket round-trip per mutation, which can race if the connection lags; assume eventual consistency, not transactional.
+
+## Authentication
+
+`routeAgentRequest` accepts any client that knows the agent class and `name`. If you derive `name` from a user ID, any client that knows or guesses another user's ID can connect to that Durable Object and read its full message log. Before deploying:
+
+- Gate the fetch handler with a header or cookie check (e.g. a JWT issued by your auth backend), and only call `routeAgentRequest` after the request is authenticated.
+- Pass the same credential from the frontend via `useAgent`'s `headers` or `query` options so the WebSocket upgrade carries it.
+- Tighten the CORS `Access-Control-Allow-Origin` to an explicit allowlist.
+
+## Version stability
+
+`agents` and `@cloudflare/ai-chat` are pre-1.0 and ship breaking changes between minor versions. Pin both to exact versions in `package.json` and read the Cloudflare changelog before bumping. The `useAgentChat` return shape has been additive since 0.3.0, so this integration should keep working across patch releases.

--- a/assistant-ui/skills/setup/references/custom-backend.md
+++ b/assistant-ui/skills/setup/references/custom-backend.md
@@ -2,6 +2,12 @@
 
 Connect assistant-ui to any backend using useLocalRuntime or useExternalStoreRuntime.
 
+## Contents
+
+- [useLocalRuntime](#uselocalruntime)
+- [useExternalStoreRuntime](#useexternalstoreruntime)
+- [Streaming Updates with External Store](#streaming-updates-with-external-store)
+
 ## useLocalRuntime
 
 For backends that return streaming responses. Emit `ChatModelRunResult` chunks (append-only `content` parts).
@@ -183,7 +189,7 @@ function Chat() {
         id: crypto.randomUUID(),
         role: "assistant",
         content: [{ type: "text", text: response.text }],
-        status: "complete",
+        status: { type: "complete" },
         createdAt: new Date(),
       };
       setMessages((prev) => [...prev, assistantMessage]);
@@ -267,7 +273,7 @@ function Chat() {
         id: crypto.randomUUID(),
         role: "assistant",
         content: [{ type: "text", text: response }],
-        status: "complete",
+        status: { type: "complete" },
         createdAt: new Date(),
       });
       setRunning(false);
@@ -299,7 +305,7 @@ const runtime = useExternalStoreRuntime<MyMessage>({
     id: msg.uuid,
     role: msg.sender === "human" ? "user" : "assistant",
     content: [{ type: "text", text: msg.text }],
-    status: "complete",
+    status: { type: "complete" },
     createdAt: new Date(msg.timestamp),
   }),
   onNew: async (appendMessage) => {
@@ -335,7 +341,7 @@ const runtime = useExternalStoreRuntime({
       id: assistantId,
       role: "assistant",
       content: [{ type: "text", text: "" }],
-      status: "running",
+      status: { type: "running" },
       createdAt: new Date(),
     });
 
@@ -358,7 +364,7 @@ const runtime = useExternalStoreRuntime({
       });
     }
 
-    updateMessage(assistantId, { status: "complete" });
+    updateMessage(assistantId, { status: { type: "complete" } });
     setIsRunning(false);
   },
 });

--- a/assistant-ui/skills/setup/references/devtools.md
+++ b/assistant-ui/skills/setup/references/devtools.md
@@ -1,0 +1,80 @@
+# DevTools
+
+Inspect assistant-ui runtime state, context, and events in the browser without `console.log`.
+
+## Installation
+
+```bash
+npm install @assistant-ui/react-devtools
+```
+
+The package peer-depends on `@assistant-ui/react` (`^0.14.12`); it reads from the same Assistant API context, so it only works inside a runtime provider.
+
+## Basic Setup
+
+Render `<DevToolsModal />` as a child of `AssistantRuntimeProvider`, alongside your assistant UI. In development builds a floating button appears in the lower-right corner; clicking it opens the inspector.
+
+```tsx
+"use client";
+
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { DevToolsModal } from "@assistant-ui/react-devtools";
+import { Thread } from "@/components/assistant-ui/thread";
+
+export function Assistant() {
+  const runtime = useChatRuntime();
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <DevToolsModal />
+      <Thread />
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+## Dev-Only by Default
+
+`DevToolsModal` is self-guarding: it returns `null` when `process.env.NODE_ENV === "production"`, so bundlers eliminate it via dead code elimination. You can leave it mounted without shipping the inspector to production and without writing your own environment check.
+
+```tsx
+// no manual guard needed; this renders nothing in production builds
+<DevToolsModal />
+```
+
+Note: the guard keys off `process.env.NODE_ENV`. If your bundler does not define it (some non-standard setups), gate the render yourself.
+
+```tsx
+{process.env.NODE_ENV !== "production" && <DevToolsModal />}
+```
+
+## Inline Frame
+
+`DevToolsFrame` embeds the same inspector inline instead of behind a modal button. Use it to dock DevTools into a panel of your own layout. It accepts standard iframe props such as `style`.
+
+```tsx
+import { DevToolsFrame } from "@assistant-ui/react-devtools";
+
+<div className="h-96 w-full">
+  <DevToolsFrame style={{ width: "100%", height: "100%", border: "none" }} />
+</div>
+```
+
+`DevToolsModal` itself wraps a `DevToolsFrame`, so both surfaces show the same event log, context viewer, and runtime inspector.
+
+## Dark Mode
+
+The modal reads dark mode from the `dark` class on `<html>` or `<body>` and reacts to changes via a `MutationObserver`, matching the shadcn class-based dark mode used by registry components. No configuration is required.
+
+## Chrome Extension
+
+A standalone Chrome extension consumes the same package and connects to any page running assistant-ui, so you can inspect runtime state without adding `DevToolsModal` to your app. Source lives at [`apps/devtools-extension`](https://github.com/assistant-ui/assistant-ui/tree/main/apps/devtools-extension).
+
+## Exports
+
+| Export | Purpose |
+|-------|-------|
+| `DevToolsModal` | Floating button plus modal overlay; dev-only, no props |
+| `DevToolsFrame` | Inline iframe host for the inspector; accepts iframe props |
+
+Lower-level host and frame bridges (`FrameHost`, `DevToolsHost`, `ExtensionHost`, `FrameClient`) and serialization helpers (`sanitizeForMessage`, `serializeModelContext`, `normalizeToolList`) are also exported for building custom hosts such as the Chrome extension. Most apps only need `DevToolsModal`.

--- a/assistant-ui/skills/setup/references/google-adk.md
+++ b/assistant-ui/skills/setup/references/google-adk.md
@@ -1,0 +1,329 @@
+# Google ADK Runtime
+
+Connect assistant-ui to Google's Agent Development Kit (ADK) via `@assistant-ui/react-google-adk`. The runtime is layered on `ExternalStoreRuntime` and normalizes ADK event fields from snake_case to camelCase (`function_call` becomes `functionCall`, `requested_tool_confirmations` becomes `requestedToolConfirmations`).
+
+## Contents
+
+- [Installation](#installation)
+- [Server route](#server-route)
+- [Client setup](#client-setup)
+- [createAdkStream](#createadkstream)
+- [useAdkRuntime options](#useadkruntime-options)
+- [Session adapter and thread persistence](#session-adapter-and-thread-persistence)
+- [Message editing](#message-editing)
+- [Server helpers](#server-helpers)
+- [State hooks](#state-hooks)
+- [Tool confirmations](#tool-confirmations)
+- [Auth credential flow](#auth-credential-flow)
+- [Input requests (HITL)](#input-requests-hitl)
+- [Artifacts, escalation, metadata](#artifacts-escalation-metadata)
+- [Structured events](#structured-events)
+
+## Installation
+
+```bash
+npm install @assistant-ui/react @assistant-ui/react-google-adk @google/adk
+```
+
+The client imports come from `@assistant-ui/react-google-adk`; server helpers live under the `/server` subpath. `@google/adk` is only used server-side.
+
+## Server route
+
+Build an ADK `LlmAgent` and `InMemoryRunner`, then expose a POST handler with `createAdkApiRoute`. Both `userId` and `sessionId` accept a static string or a `(req: Request) => string` function.
+
+```ts
+// app/api/chat/route.ts
+import { createAdkApiRoute } from "@assistant-ui/react-google-adk/server";
+import { InMemoryRunner, LlmAgent } from "@google/adk";
+
+const agent = new LlmAgent({
+  name: "my_agent",
+  model: "gemini-2.5-flash",
+  instruction: "You are a helpful assistant.",
+});
+
+const runner = new InMemoryRunner({ agent, appName: "my-app" });
+
+export const POST = createAdkApiRoute({
+  runner,
+  userId: "user_1",
+  sessionId: (req) => new URL(req.url).searchParams.get("sessionId") ?? "default",
+});
+```
+
+## Client setup
+
+`useAdkRuntime` takes a `stream` built with `createAdkStream`. In proxy mode the `api` option points at your own route, which forwards to ADK.
+
+```tsx
+"use client";
+
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { useAdkRuntime, createAdkStream } from "@assistant-ui/react-google-adk";
+import { Thread } from "@/components/assistant-ui/thread";
+
+export function MyAssistant() {
+  const runtime = useAdkRuntime({
+    stream: createAdkStream({ api: "/api/chat" }),
+  });
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+## createAdkStream
+
+Proxy mode posts to your route. Direct mode talks to an ADK server directly and requires `appName` plus `userId`.
+
+```ts
+import { createAdkStream } from "@assistant-ui/react-google-adk";
+
+// Proxy mode: POST to your own route
+const stream = createAdkStream({ api: "/api/chat" });
+
+// Direct mode: talk to an ADK server (appName enables it; userId required)
+const directStream = createAdkStream({
+  api: "http://localhost:8000",
+  appName: "my-app",
+  userId: "user-1",
+});
+```
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `api` | `string` | URL to POST to |
+| `appName` | `string?` | Enables direct mode when set |
+| `userId` | `string?` | Required with `appName` |
+| `headers` | `Record<string, string>` or `() => ...` | Static or dynamic headers |
+
+## useAdkRuntime options
+
+```ts
+const runtime = useAdkRuntime({
+  stream: createAdkStream({ api: "/api/chat" }),
+
+  // Thread management: pick one approach
+  sessionAdapter: adapter, // from createAdkSessionAdapter
+  load, // from createAdkSessionAdapter
+  // or custom callbacks:
+  create: async () => ({ externalId: sessionId }),
+  delete: async (externalId) => { await deleteSession(externalId); },
+  // or cloud persistence:
+  cloud,
+
+  // Enables edit/regenerate (server-side forking)
+  getCheckpointId: async (threadId, parentMessages) => checkpointId,
+
+  adapters: { attachments, history, speech, feedback },
+
+  eventHandlers: {
+    onError: (error) => {},
+    onAgentTransfer: (toAgent) => {},
+    onCustomEvent: (key, value) => {},
+  },
+});
+```
+
+Pick one thread-management approach: the `sessionAdapter` + `load` pair from `createAdkSessionAdapter`, custom `create` / `load` / `delete` callbacks, or a `cloud` instance.
+
+## Session adapter and thread persistence
+
+`createAdkSessionAdapter` wires thread history to ADK's session REST API. It returns an `adapter` (a `RemoteThreadListAdapter`), a `load` that reconstructs messages from session events via `AdkEventAccumulator`, and `artifacts` helpers to fetch, list, and delete session artifacts.
+
+```ts
+import { createAdkSessionAdapter } from "@assistant-ui/react-google-adk";
+
+const { adapter, load, artifacts } = createAdkSessionAdapter({
+  apiUrl: ADK_URL,
+  appName: "my-app",
+  userId: "user-1",
+});
+
+const runtime = useAdkRuntime({
+  stream: createAdkStream({ api: "/api/chat" }),
+  sessionAdapter: adapter,
+  load,
+});
+```
+
+| Option | Type |
+| --- | --- |
+| `apiUrl` | `string` |
+| `appName` | `string` |
+| `userId` | `string` |
+| `headers` | `Record<string, string>` or `() => ...` |
+
+## Message editing
+
+Edit and regenerate buttons only appear when you provide `getCheckpointId`. Without server-side forking the buttons stay hidden, because truncating client-side messages without forking the session would produce incorrect state.
+
+```ts
+const runtime = useAdkRuntime({
+  stream: createAdkStream({ api: "/api/chat" }),
+  getCheckpointId: async (threadId, parentMessages) => checkpointId,
+});
+```
+
+## Server helpers
+
+Imported from `@assistant-ui/react-google-adk/server`.
+
+```ts
+import {
+  createAdkApiRoute,
+  adkEventStream,
+  parseAdkRequest,
+  toAdkContent,
+} from "@assistant-ui/react-google-adk/server";
+```
+
+`adkEventStream` converts an `AsyncGenerator<Event>` into an SSE `Response`, so you can run the agent manually instead of using `createAdkApiRoute`:
+
+```ts
+const events = runner.runAsync({ userId, sessionId, newMessage });
+return adkEventStream(events);
+```
+
+`parseAdkRequest` and `toAdkContent` parse the incoming request (user messages, tool results, `stateDelta`, `checkpointId`, and multimodal content) into an ADK content payload:
+
+```ts
+const parsed = await parseAdkRequest(req);
+// parsed.type is "message" or "tool-result"
+// parsed.config holds runConfig and checkpointId
+// parsed.stateDelta holds session state changes
+const newMessage = toAdkContent(parsed);
+```
+
+## State hooks
+
+Read ADK session, app, user, and temp state, plus agent info, from within the runtime.
+
+```tsx
+import {
+  useAdkAgentInfo,
+  useAdkSessionState,
+  useAdkAppState,
+  useAdkUserState,
+  useAdkTempState,
+  useAdkSend,
+} from "@assistant-ui/react-google-adk";
+
+function AgentBadge() {
+  const info = useAdkAgentInfo();
+  const sessionState = useAdkSessionState();
+  return <span>{info?.name}</span>;
+}
+```
+
+## Tool confirmations
+
+Read pending confirmation requests with `useAdkToolConfirmations` (each item exposes `toolCallId`, `toolName`, and `hint`) and respond with `useAdkConfirmTool`.
+
+```tsx
+import {
+  useAdkToolConfirmations,
+  useAdkConfirmTool,
+} from "@assistant-ui/react-google-adk";
+
+function ToolConfirmations() {
+  const pending = useAdkToolConfirmations();
+  const confirmTool = useAdkConfirmTool();
+
+  return pending.map((conf) => (
+    <div key={conf.toolCallId}>
+      <p>{conf.toolName}: {conf.hint}</p>
+      <button onClick={() => confirmTool(conf.toolCallId, true)}>Allow</button>
+      <button onClick={() => confirmTool(conf.toolCallId, false)}>Deny</button>
+    </div>
+  ));
+}
+```
+
+## Auth credential flow
+
+`useAdkAuthRequests` surfaces pending credential requests; `useAdkSubmitAuth` submits them. The `AdkAuthCredential` type covers `"apiKey"`, `"http"`, `"oauth2"`, `"openIdConnect"`, and `"serviceAccount"`.
+
+```tsx
+import {
+  useAdkAuthRequests,
+  useAdkSubmitAuth,
+  type AdkAuthCredential,
+} from "@assistant-ui/react-google-adk";
+
+function AuthPrompt() {
+  const requests = useAdkAuthRequests();
+  const submitAuth = useAdkSubmitAuth();
+
+  const credential: AdkAuthCredential = { authType: "apiKey", apiKey: "..." };
+  return <button onClick={() => submitAuth(requests[0].id, credential)}>Submit</button>;
+}
+```
+
+## Input requests (HITL)
+
+`useAdkSubmitInput` answers ADK workflow input requests. Render it inside a `makeAssistantToolUI` for the `"adk_request_input"` tool. It is sugar over the generic `addResult`: `submitInput(toolCallId, value)` wraps the answer as `{ result }` for ADK's `unwrap_response`.
+
+```tsx
+import { makeAssistantToolUI } from "@assistant-ui/react";
+import { useAdkSubmitInput } from "@assistant-ui/react-google-adk";
+
+const RequestInputUI = makeAssistantToolUI({
+  toolName: "adk_request_input",
+  render: ({ toolCallId, args }) => {
+    const submitInput = useAdkSubmitInput();
+    return (
+      <button onClick={() => submitInput(toolCallId, "yes")}>
+        {args.prompt}
+      </button>
+    );
+  },
+});
+```
+
+## Artifacts, escalation, metadata
+
+```tsx
+import {
+  useAdkArtifacts,
+  useAdkEscalation,
+  useAdkMessageMetadata,
+} from "@assistant-ui/react-google-adk";
+
+function Status() {
+  const artifacts = useAdkArtifacts(); // Record<string, number>: filename to version
+  const escalated = useAdkEscalation(); // boolean
+  const metadata = useAdkMessageMetadata(); // per-message map
+  // entries may include groundingMetadata, citationMetadata, usageMetadata
+  return <pre>{Object.keys(artifacts).join(", ")}</pre>;
+}
+```
+
+Note: `useAdkLongRunningToolIds` returns the ids of tool calls ADK is running in the background.
+
+## Structured events
+
+`toAdkStructuredEvents` turns a raw ADK event into typed entries; switch on `e.type` using the `AdkEventType` constants `CONTENT`, `THOUGHT`, `TOOL_CALL`, and `ERROR`.
+
+```ts
+import {
+  toAdkStructuredEvents,
+  AdkEventType,
+} from "@assistant-ui/react-google-adk";
+
+for (const e of toAdkStructuredEvents(event)) {
+  switch (e.type) {
+    case AdkEventType.CONTENT:
+      break;
+    case AdkEventType.THOUGHT:
+      break;
+    case AdkEventType.TOOL_CALL:
+      break;
+    case AdkEventType.ERROR:
+      break;
+  }
+}
+```

--- a/assistant-ui/skills/setup/references/langchain.md
+++ b/assistant-ui/skills/setup/references/langchain.md
@@ -1,0 +1,184 @@
+# LangChain React Runtime
+
+A thin LangGraph adapter via `@assistant-ui/react-langchain`. `useStreamRuntime` wraps `useStream` from `@langchain/react` and exposes it as an assistant-ui runtime, delegating stream plumbing to the upstream hook. It targets the same backend as `@assistant-ui/react-langgraph` (LangGraph Cloud) but at a higher level.
+
+## Contents
+
+- [Installation](#installation)
+- [Basic setup](#basic-setup)
+- [Environment variables](#environment-variables)
+- [useStreamRuntime options](#usestreamruntime-options)
+- [Reading custom state keys](#reading-custom-state-keys)
+- [Interrupts](#interrupts)
+- [Message conversion](#message-conversion)
+- [Cloud persistence](#cloud-persistence)
+- [Custom messagesKey](#custom-messageskey)
+- [react-langgraph vs react-langchain](#react-langgraph-vs-react-langchain)
+
+## Installation
+
+```bash
+npm install @assistant-ui/react @assistant-ui/react-langchain @langchain/react @langchain/langgraph-sdk
+```
+
+## Basic setup
+
+`useStreamRuntime` takes `assistantId` and `apiUrl`. There is no `stream` / `create` / `load` to write; thread plumbing is handled by the upstream `useStream`.
+
+```tsx
+"use client";
+
+import { Thread } from "@/components/assistant-ui/thread";
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { useStreamRuntime } from "@assistant-ui/react-langchain";
+
+export function MyAssistant() {
+  const runtime = useStreamRuntime({
+    assistantId: process.env["NEXT_PUBLIC_LANGGRAPH_ASSISTANT_ID"]!,
+    apiUrl: process.env["NEXT_PUBLIC_LANGGRAPH_API_URL"],
+  });
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+The runtime is layered on `ExternalStoreRuntime`. Graph state is the source of truth; it renders messages from `state.values.messages` and submits user input back to the graph. The graph state must include a `messages` key with LangChain-alike messages, or you pass a custom `messagesKey`.
+
+## Environment variables
+
+Point at a LangGraph Cloud API server (locally via LangGraph Studio, or hosted via LangSmith).
+
+```
+NEXT_PUBLIC_LANGGRAPH_API_URL=http://localhost:2024
+NEXT_PUBLIC_LANGGRAPH_ASSISTANT_ID=your_graph_id
+```
+
+## useStreamRuntime options
+
+`useStreamRuntime` accepts every option upstream `useStream` does (`UseStreamOptions`), plus three assistant-ui specific fields.
+
+| Option | Type | Description |
+|---|---|---|
+| `cloud` | `AssistantCloud` | Optional. Persists threads via assistant-cloud. |
+| `adapters` | `{ attachments?, speech?, feedback? }` | Optional. Attachment, speech, and feedback adapters. |
+| `messagesKey` | `string` | The state key that holds messages. Defaults to `"messages"`. |
+
+## Reading custom state keys
+
+LangGraph agents often expose structured state beyond messages (plans, todos, scratch files). Read them directly with `useLangChainState`. It mirrors `useStream().values[key]` upstream and updates when the stream emits new state.
+
+```tsx
+import { useLangChainState } from "@assistant-ui/react-langchain";
+
+type Todo = { id: string; title: string; done: boolean };
+
+function TodoList() {
+  const todos = useLangChainState<Todo[]>("todos", []);
+  return (
+    <ul>
+      {todos.map((t) => (
+        <li key={t.id}>
+          {t.done ? "✓" : "○"} {t.title}
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+Signatures:
+
+```ts
+useLangChainState<T>(key: string): T | undefined;
+useLangChainState<T>(key: string, defaultValue: T): T;
+```
+
+Note: reading the state key directly avoids reconstructing a list from partial tool-call args (for example the `deepagents` middleware updates `state.todos` alongside the tool-call stream).
+
+## Interrupts
+
+LangGraph interrupts pause the graph and wait for client input. `useLangChainInterruptState` exposes the current interrupt; `useLangChainSubmit` resumes the graph with a raw state update.
+
+```tsx
+import {
+  useLangChainInterruptState,
+  useLangChainSubmit,
+} from "@assistant-ui/react-langchain";
+import { Command } from "@langchain/langgraph-sdk";
+
+function InterruptPrompt() {
+  const interrupt = useLangChainInterruptState();
+  const submit = useLangChainSubmit();
+  if (!interrupt) return null;
+  return (
+    <div>
+      <pre>{JSON.stringify(interrupt.value, null, 2)}</pre>
+      <button
+        onClick={() =>
+          submit(null, { command: new Command({ resume: "approved" }) })
+        }
+      >
+        Approve
+      </button>
+    </div>
+  );
+}
+```
+
+## Message conversion
+
+`convertLangChainBaseMessage` transforms a LangChain `BaseMessage` into an assistant-ui message. Use it when building a custom `ExternalStoreAdapter` that consumes LangChain messages outside `useStreamRuntime`.
+
+```ts
+import { convertLangChainBaseMessage } from "@assistant-ui/react-langchain";
+```
+
+## Cloud persistence
+
+Pass an `AssistantCloud` instance to persist threads across sessions. The runtime automatically wires thread list management and resumes state from the cloud.
+
+```tsx
+const runtime = useStreamRuntime({
+  cloud,
+  assistantId: "agent",
+  apiUrl: "http://localhost:2024",
+});
+```
+
+See the `/cloud` skill for authentication and configuration details.
+
+## Custom messagesKey
+
+If your graph stores messages under a non-default key, pass `messagesKey` so the runtime submits tool results and human turns to the correct state slot.
+
+```ts
+const runtime = useStreamRuntime({
+  assistantId: "agent",
+  apiUrl: "http://localhost:2024",
+  messagesKey: "chat_messages",
+});
+```
+
+## react-langgraph vs react-langchain
+
+Both packages connect assistant-ui to LangGraph backends and both build on `useExternalStoreRuntime`. They are independent adapters for different upstream libraries; one is not a successor to the other. `react-langgraph` wraps the raw `@langchain/langgraph-sdk` (~7,500 lines); `react-langchain` wraps `useStream` from `@langchain/react` (~600 lines).
+
+Pick `react-langchain` when your app already depends on `@langchain/react`, when you want to read custom state keys reactively with `useLangChainState<T>(key)`, or when you prefer a thin wrapper pinned to upstream behavior. Pick `react-langgraph` when scaffolding via `npx create-assistant-ui -t langgraph` (the template uses it), or when you need per-message metadata, generative UI messages, subgraph/namespaced stream events, or end-to-end cancellation today. Features absent from `react-langchain` have not been ported, not deprecated.
+
+Hook name mapping:
+
+| react-langgraph | react-langchain | Notes |
+|---|---|---|
+| `useLangGraphRuntime` | `useStreamRuntime` | Options extend upstream `UseStreamOptions`; no `stream` / `create` / `load` to write. |
+| `useLangGraphInterruptState` | `useLangChainInterruptState` | Same return shape. |
+| `useLangGraphSendCommand` | `useLangChainSubmit` | `submit(values, { command })` replaces the dedicated hook. |
+| `useLangGraphSend` | use `runtime.thread.append` | No direct equivalent; send turns through the runtime. |
+| `useLangGraphMessageMetadata` | not available | Open an issue if you rely on this. |
+| `useLangGraphUIMessages` | not available | Open an issue if you rely on this. |
+| *(none)* | `useLangChainState<T>(key)` | Reads any custom state key reactively. |
+
+See the `langgraph.md` reference for the full-featured adapter.

--- a/assistant-ui/skills/setup/references/langgraph.md
+++ b/assistant-ui/skills/setup/references/langgraph.md
@@ -1,91 +1,66 @@
 # LangGraph Setup
 
-Integration with LangGraph Python agents.
+Integration with LangGraph agents via `@assistant-ui/react-langgraph`.
 
 ## Installation
 
 ```bash
-npm install @assistant-ui/react @assistant-ui/react-langgraph
+npm install @assistant-ui/react @assistant-ui/react-langgraph @langchain/langgraph-sdk
+```
+
+## Client
+
+```ts
+// lib/chatApi.ts
+import { Client } from "@langchain/langgraph-sdk";
+
+export const createClient = () =>
+  new Client({
+    apiUrl: process.env.NEXT_PUBLIC_LANGGRAPH_API_URL ?? "http://localhost:8123",
+  });
 ```
 
 ## Basic Setup
 
+`useLangGraphRuntime` takes a `stream` callback plus optional `create` / `load` / `delete` handlers for thread lifecycle. Build the stream with `unstable_createLangGraphStream`.
+
 ```tsx
+"use client";
+
+import { useMemo } from "react";
 import { AssistantRuntimeProvider } from "@assistant-ui/react";
 import { Thread } from "@/components/assistant-ui/thread";
-import { useLangGraphRuntime } from "@assistant-ui/react-langgraph";
+import {
+  unstable_createLangGraphStream,
+  useLangGraphRuntime,
+  type LangChainMessage,
+} from "@assistant-ui/react-langgraph";
+import { createClient } from "@/lib/chatApi";
 
-function Chat() {
-  const runtime = useLangGraphRuntime({
-    threadId: "my-thread-id",
-    stream: async function* (messages, config) {
-      const response = await fetch("/api/langgraph", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ messages, config }),
-      });
+const ASSISTANT_ID = process.env.NEXT_PUBLIC_LANGGRAPH_ASSISTANT_ID!;
 
-      const reader = response.body?.getReader();
-      const decoder = new TextDecoder();
-
-      while (reader) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        const chunk = decoder.decode(value);
-        // Parse LangGraph events and yield
-        for (const event of parseLangGraphEvents(chunk)) {
-          yield event;
-        }
-      }
-    },
-  });
-
-  return (
-    <AssistantRuntimeProvider runtime={runtime}>
-      <Thread />
-    </AssistantRuntimeProvider>
+export function MyAssistant() {
+  const client = useMemo(() => createClient(), []);
+  const stream = useMemo(
+    () => unstable_createLangGraphStream({ client, assistantId: ASSISTANT_ID }),
+    [client],
   );
-}
-```
-
-## With LangGraph Client SDK
-
-```tsx
-import { Client } from "@langchain/langgraph-sdk";
-import { useLangGraphRuntime } from "@assistant-ui/react-langgraph";
-
-const client = new Client({
-  apiUrl: process.env.NEXT_PUBLIC_LANGGRAPH_API_URL || "http://localhost:8123",
-});
-
-function Chat() {
-  const [threadId, setThreadId] = useState<string | null>(null);
 
   const runtime = useLangGraphRuntime({
-    threadId,
-    stream: async function* (messages, config) {
-      // Create thread if needed
-      let currentThreadId = threadId;
-      if (!currentThreadId) {
-        const thread = await client.threads.create();
-        currentThreadId = thread.thread_id;
-        setThreadId(currentThreadId);
-      }
-
-      // Stream from LangGraph
-      const stream = client.runs.stream(
-        currentThreadId,
-        "my-assistant",  // Assistant name in LangGraph
-        {
-          input: { messages },
-          config,
-        }
-      );
-
-      for await (const event of stream) {
-        yield event;
-      }
+    unstable_allowCancellation: true,
+    stream,
+    create: async () => {
+      const { thread_id } = await client.threads.create();
+      return { externalId: thread_id };
+    },
+    load: async (externalId) => {
+      const state = await client.threads.getState<{
+        messages: LangChainMessage[];
+      }>(externalId);
+      return {
+        messages: state.values.messages,
+        interrupts: state.tasks[0]?.interrupts,
+      };
     },
   });
 
@@ -101,49 +76,87 @@ function Chat() {
 
 ```tsx
 const runtime = useLangGraphRuntime({
-  // Thread identifier
-  threadId: string | undefined,
+  // Required: stream callback (typically from unstable_createLangGraphStream)
+  stream,
 
-  // Streaming function (required)
-  stream: async function* (
-    messages: ThreadMessage[],
-    config: LangGraphConfig
-  ): AsyncGenerator<LangGraphEvent>,
+  // Optional thread lifecycle (enables history, switching, and persistence)
+  create: async () => ({ externalId: "thread-id" }),
+  load: async (externalId, { signal } = {}) => ({
+    messages: [],
+    interrupts: [],
+  }),
+  delete: async (externalId) => {},
 
-  // Message conversion (optional)
-  convertMessage?: (message: ThreadMessage) => LangGraphMessage,
+  // Optional: enables message editing and regeneration via server-side forking
+  getCheckpointId: (threadId, parentMessages) => undefined,
 
-  // Adapters (optional)
-  adapters?: {
-    attachments?: AttachmentAdapter,
-    feedback?: FeedbackAdapter,
+  autoCancelPendingToolCalls: true,
+  unstable_allowCancellation: true, // enable the cancel button
+
+  adapters: {
+    attachments: attachmentAdapter,
+    feedback: feedbackAdapter,
+    speech: speechAdapter,
+  },
+
+  eventHandlers: {
+    onMessageChunk: (chunk) => {},
+    onMetadata: (event) => {},
+    onError: (error) => {},
+    onCustomEvent: (event, options) => {},
   },
 });
 ```
 
-## LangGraph Event Types
+`useLangGraphRuntime` no longer takes `threadId` or `convertMessage`. Thread identity is handled by `create`/`load`/`delete` (the v0.7 migration removed `onSwitchToThread`; use `load` instead).
 
-The stream callback should yield append-only content updates (same shape as `ChatModelRunResult` content parts). Common cases:
+## Custom Stream (Advanced)
 
-- Text: `{ content: [{ type: "text", text: "partial text" }] }`
-- Tool call start/result (single part): `{ content: [{ type: "tool-call", toolCallId, toolName, args, argsText, result? }] }`
+Instead of `unstable_createLangGraphStream`, you can pass your own `LangGraphStreamCallback`. It receives the messages and a config object (with `abortSignal`) and yields LangGraph message events:
+
+```tsx
+const runtime = useLangGraphRuntime({
+  stream: async function* (messages, { abortSignal, ...config }) {
+    const response = await fetch("/api/langgraph", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messages, config }),
+      signal: abortSignal,
+    });
+
+    const reader = response.body?.getReader();
+    const decoder = new TextDecoder();
+
+    while (reader) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      for (const event of parseLangGraphEvents(decoder.decode(value))) {
+        yield event; // LangGraphMessagesEvent
+      }
+    }
+  },
+});
+```
 
 ## With Tool UI
+
+LangGraph tool calls can have custom UI. Remember the render prop `status` is an object; branch on `status.type`.
 
 ```tsx
 import { makeAssistantToolUI } from "@assistant-ui/react";
 
-// LangGraph tools can have custom UI
 const SearchToolUI = makeAssistantToolUI({
   toolName: "tavily_search",
   render: ({ args, result, status }) => {
-    if (status === "running") {
+    if (status.type === "running") {
       return <div>Searching for: {args.query}...</div>;
     }
     return (
       <div>
         {result?.results?.map((r: any) => (
-          <a key={r.url} href={r.url}>{r.title}</a>
+          <a key={r.url} href={r.url}>
+            {r.title}
+          </a>
         ))}
       </div>
     );
@@ -171,41 +184,20 @@ graph.set_finish_point("chat")
 
 app = graph.compile()
 
-# Run with: langgraph serve
+# Run with: langgraph dev
 ```
 
 ## Thread Persistence
 
-LangGraph handles thread persistence server-side. The `threadId` you pass to the runtime maps to LangGraph's thread management.
-
-```tsx
-// Thread list with LangGraph
-function ThreadSelector() {
-  const [threads, setThreads] = useState([]);
-
-  useEffect(() => {
-    client.threads.list().then(setThreads);
-  }, []);
-
-  return (
-    <select onChange={(e) => setThreadId(e.target.value)}>
-      {threads.map((t) => (
-        <option key={t.thread_id} value={t.thread_id}>
-          {t.thread_id}
-        </option>
-      ))}
-    </select>
-  );
-}
-```
+LangGraph handles thread persistence server-side. The `create` handler returns the LangGraph `thread_id` as `externalId`, and `load` rehydrates a thread's messages and interrupts when the user switches to it. Combine with the assistant-ui `ThreadList` (cloud or a remote thread list adapter) to show saved threads.
 
 ## Troubleshooting
 
 **"Stream not yielding events"**
-Ensure your stream function yields events in the correct format. Debug by logging events before yielding.
+Ensure your stream yields `LangGraphMessagesEvent` chunks. When using `unstable_createLangGraphStream`, verify `assistantId` matches a graph registered on your LangGraph server.
 
 **"Thread not persisting"**
-LangGraph persistence is server-side. Check that your LangGraph server is configured with a checkpointer.
+LangGraph persistence is server-side. Check that your server is configured with a checkpointer, and that `create`/`load` are wired up.
 
 **"Tool calls not rendering"**
 Tool names must match between LangGraph and `makeAssistantToolUI`.

--- a/assistant-ui/skills/setup/references/mastra.md
+++ b/assistant-ui/skills/setup/references/mastra.md
@@ -1,0 +1,208 @@
+# Mastra Integration
+
+Wire Mastra agents into assistant-ui. There is no `@assistant-ui/react-mastra` package; use `useChatRuntime` from `@assistant-ui/react-ai-sdk` against a route that wraps `agent.stream()`.
+
+## Contents
+
+- [Two Deployment Modes](#two-deployment-modes)
+- [Full-Stack (agent in a Next.js route)](#full-stack-agent-in-a-nextjs-route)
+- [Separate Server (@mastra/ai-sdk chatRoute)](#separate-server-mastraai-sdk-chatroute)
+- [Frontend (shared)](#frontend-shared)
+- [Notes](#notes)
+- [Troubleshooting](#troubleshooting)
+
+## Two Deployment Modes
+
+| Mode | Where the agent runs | Backend wiring | Frontend transport |
+|------|----------------------|----------------|--------------------|
+| Full-stack | Next.js API route in the same app | `agent.stream()` + `toAISdkStream` + `createUIMessageStream` | default (`AssistantChatTransport` to `/api/chat`) |
+| Separate server | Standalone Mastra server | `chatRoute({ path })` from `@mastra/ai-sdk` | `AssistantChatTransport` pointed at the Mastra URL |
+
+Both modes use `useChatRuntime` from `@assistant-ui/react-ai-sdk`. Mastra never exposes a dedicated assistant-ui package; the integration rides the AI SDK v6 runtime. Do not reach for `@mastra/client-js` for the chat stream; the browser talks to the Mastra HTTP route directly through `AssistantChatTransport`.
+
+## Full-Stack (agent in a Next.js route)
+
+Install `@mastra/core`, `@mastra/ai-sdk`, and `zod` alongside the assistant-ui packages (`npx assistant-ui@latest init` brings in `ai`).
+
+```bash
+npm install @mastra/core @mastra/ai-sdk zod
+```
+
+Mark Mastra as a server external package so its native deps are not bundled:
+
+```js
+// next.config.mjs
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  serverExternalPackages: ["@mastra/*"],
+};
+export default nextConfig;
+```
+
+Define the agent:
+
+```ts
+// mastra/agents/chefAgent.ts
+import { Agent } from "@mastra/core/agent";
+
+export const chefAgent = new Agent({
+  name: "chef-agent",
+  instructions:
+    "You are Michel, a practical and experienced home chef. " +
+    "You help people cook with whatever ingredients they have available.",
+  model: "openai/gpt-5.4-mini",
+});
+```
+
+Register it on a `Mastra` instance:
+
+```ts
+// mastra/index.ts
+import { Mastra } from "@mastra/core";
+import { chefAgent } from "./agents/chefAgent";
+
+export const mastra = new Mastra({
+  agents: { chefAgent },
+});
+```
+
+The route resolves the agent, calls `agent.stream(messages)`, then adapts the Mastra stream into AI SDK UI message parts with `toAISdkStream` and returns them via `createUIMessageStreamResponse`:
+
+```ts
+// app/api/chat/route.ts
+import { createUIMessageStream, createUIMessageStreamResponse } from "ai";
+import { toAISdkStream } from "@mastra/ai-sdk";
+import { mastra } from "@/mastra";
+
+export const maxDuration = 30;
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+  const agent = mastra.getAgent("chefAgent");
+  const stream = await agent.stream(messages);
+
+  const uiMessageStream = createUIMessageStream({
+    originalMessages: messages,
+    execute: async ({ writer }) => {
+      for await (const part of toAISdkStream(stream, { from: "agent" })) {
+        await writer.write(part);
+      }
+    },
+  });
+
+  return createUIMessageStreamResponse({ stream: uiMessageStream });
+}
+```
+
+`mastra.getAgent("chefAgent")` keys off the property name in the `agents` object, not the agent's `name` field. Set `OPENAI_API_KEY` (or the relevant provider key) in `.env.local`.
+
+## Separate Server (@mastra/ai-sdk chatRoute)
+
+Run Mastra standalone (for example via `npx create-mastra@latest`) and add the AI SDK adapter:
+
+```bash
+npm install @mastra/ai-sdk
+```
+
+`chatRoute` from `@mastra/ai-sdk` registers an HTTP endpoint that already emits an AI SDK UI message stream, so no manual `agent.stream()` plumbing is needed. The `:agentId` segment matches the key in the `agents` object:
+
+```ts
+// src/mastra/index.ts
+import { Mastra } from "@mastra/core";
+import { chatRoute } from "@mastra/ai-sdk";
+import { chefAgent } from "./agents/chefAgent";
+
+export const mastra = new Mastra({
+  agents: { chefAgent },
+  server: {
+    cors: {
+      origin: process.env.FRONTEND_ORIGIN ?? "http://localhost:3000",
+      credentials: true,
+    },
+    apiRoutes: [chatRoute({ path: "/chat/:agentId" })],
+  },
+});
+```
+
+The agent definition is identical to the full-stack one. With the Mastra server on its default port, `chefAgent` is reachable at `http://localhost:4111/chat/chefAgent` (the property key is camelCase, not the kebab-case `name`). Delete the scaffolded `app/api/chat/route.ts` in the frontend; the agent lives on the Mastra server now.
+
+CORS must allow the frontend origin. Without it the browser blocks the request and the chat silently fails.
+
+## Frontend (shared)
+
+Full-stack apps use the default transport (the route is local at `/api/chat`):
+
+```tsx
+// app/assistant.tsx
+"use client";
+
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import { Thread } from "@/components/assistant-ui/thread";
+
+export const Assistant = () => {
+  const runtime = useChatRuntime();
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  );
+};
+```
+
+Separate-server apps point `AssistantChatTransport` at the Mastra URL:
+
+```tsx
+// app/assistant.tsx
+"use client";
+
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { AssistantChatTransport, useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import { Thread } from "@/components/assistant-ui/thread";
+
+export const Assistant = () => {
+  const runtime = useChatRuntime({
+    transport: new AssistantChatTransport({
+      api: process.env.NEXT_PUBLIC_MASTRA_URL!,
+    }),
+  });
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  );
+};
+```
+
+```
+# .env.local (frontend)
+NEXT_PUBLIC_MASTRA_URL=http://localhost:4111/chat/chefAgent
+```
+
+For auth, `AssistantChatTransport` accepts `headers` and `credentials` options; combine `credentials: "include"` with the server's `cors.credentials: true`.
+
+## Notes
+
+- No `@assistant-ui/react-mastra` exists. Anything claiming such an import is wrong.
+- `toAISdkStream(stream, { from: "agent" })` adapts the Mastra-native stream from `agent.stream()` into AI SDK parts; `from: "agent"` tags the source.
+- Mastra runs its own server with `.env.development`; the assistant-ui frontend uses `.env.local`. Keep them separate.
+- Because the integration is the AI SDK v6 runtime, the AI SDK reference (frontend tool forwarding, attachments, cloud persistence) applies unchanged. See the AI SDK reference.
+
+## Troubleshooting
+
+**Module not found: @assistant-ui/react-mastra**
+That package does not exist. Use `useChatRuntime` from `@assistant-ui/react-ai-sdk` against a Mastra route.
+
+**Chat silently fails in separate-server mode**
+Missing CORS on the Mastra server. Configure `server.cors.origin` to the frontend origin (and `credentials: true` if sending cookies).
+
+**404 from the Mastra route**
+The `:agentId` path segment must match the key in the `agents` object (camelCase property name), not the agent's `name` field. `agents: { chefAgent }` serves `/chat/chefAgent`.
+
+**Native module bundling errors in Next.js**
+Add `serverExternalPackages: ["@mastra/*"]` to `next.config.mjs`.
+
+**Stream renders nothing in full-stack mode**
+Wrap `agent.stream()` output with `toAISdkStream(...)` and write each part into `createUIMessageStream`; return it via `createUIMessageStreamResponse`. Returning the raw Mastra stream will not parse.

--- a/assistant-ui/skills/setup/references/registry-components.md
+++ b/assistant-ui/skills/setup/references/registry-components.md
@@ -1,0 +1,246 @@
+# Prebuilt Registry Components
+
+Optional UI components installed via `npx assistant-ui add <name>`. Like all registry components they land as editable local TSX under `components/assistant-ui/`, so customize them in place (see the `styling` reference).
+
+## Contents
+
+- [AssistantModal](#assistantmodal)
+- [AssistantSidebar](#assistantsidebar)
+- [ModelSelector](#modelselector)
+- [Attachment UI](#attachment-ui)
+
+## AssistantModal
+
+Floating popup chat launched from a corner button. Built on `AssistantModalPrimitive` and renders the standard `Thread` inside.
+
+```bash
+npx assistant-ui add assistant-modal
+```
+
+```tsx
+// app/page.tsx
+import { AssistantModal } from "@/components/assistant-ui/assistant-modal";
+
+export default function Page() {
+  return <AssistantModal />;
+}
+```
+
+Must be a descendant of `AssistantRuntimeProvider` so it shares the same runtime as the rest of the app.
+
+The generated component composes these primitives from `@assistant-ui/react`:
+
+```tsx
+import { AssistantModalPrimitive } from "@assistant-ui/react";
+
+<AssistantModalPrimitive.Root>
+  <AssistantModalPrimitive.Anchor>
+    <AssistantModalPrimitive.Trigger asChild>
+      {/* the floating bot button */}
+    </AssistantModalPrimitive.Trigger>
+  </AssistantModalPrimitive.Anchor>
+  <AssistantModalPrimitive.Content sideOffset={16}>
+    <Thread />
+  </AssistantModalPrimitive.Content>
+</AssistantModalPrimitive.Root>
+```
+
+`AssistantModalPrimitive.Content` accepts `sideOffset` (number) and `className`. The trigger swaps a `BotIcon` for a `ChevronDownIcon` based on `data-state="open" | "closed"`.
+
+## AssistantSidebar
+
+Resizable two-panel co-pilot layout: your app on the left, a `Thread` on the right, separated by a draggable handle. Good for inline assistance alongside existing UI.
+
+```bash
+npx assistant-ui add assistant-sidebar
+```
+
+```tsx
+// app/page.tsx
+import { AssistantSidebar } from "@/components/assistant-ui/assistant-sidebar";
+
+export default function Home() {
+  return (
+    <div className="h-full">
+      <AssistantSidebar>{/* your main app content */}</AssistantSidebar>
+    </div>
+  );
+}
+```
+
+`AssistantSidebar` is `FC<PropsWithChildren>`; `children` fill the left panel. It depends on the shadcn `resizable` component (`components/ui/resizable`), which `add` installs automatically. Edit the generated file to tune panel sizes:
+
+```tsx
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable";
+import { Thread } from "@/components/assistant-ui/thread";
+
+<ResizablePanelGroup direction="horizontal">
+  <ResizablePanel defaultSize={60} minSize={30}>
+    {children}
+  </ResizablePanel>
+  <ResizableHandle withHandle />
+  <ResizablePanel defaultSize={40} minSize={20}>
+    <Thread />
+  </ResizablePanel>
+</ResizablePanelGroup>
+```
+
+Wrap the whole thing in `AssistantRuntimeProvider` as usual.
+
+## ModelSelector
+
+Client-side dropdown to switch models. The chosen model `id` is registered into the runtime's model context as `config.modelName`, which the server route reads off the request body.
+
+```bash
+npx assistant-ui add model-selector
+```
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { ModelSelector } from "@/components/assistant-ui/model-selector";
+
+const models = [
+  { id: "gpt-5.4", name: "GPT-5.4", description: "Most capable" },
+  { id: "gpt-5.4-nano", name: "GPT-5.4 nano", description: "Fast and cheap" },
+];
+
+function Toolbar() {
+  const [modelId, setModelId] = useState("gpt-5.4-nano");
+  return (
+    <ModelSelector
+      models={models}
+      value={modelId}
+      onValueChange={setModelId}
+    />
+  );
+}
+```
+
+Render it inside `AssistantRuntimeProvider`. Each `ModelOption` is `{ id, name, description?, icon?, disabled? }`; the `id` is what travels to the server.
+
+`ModelSelector` props: `models` (required `ModelOption[]`), `value` / `defaultValue` / `onValueChange`, `variant` (`"outline" | "ghost" | "muted"`, default `"outline"`), `size` (`"sm" | "default" | "lg"`), and `contentClassName`.
+
+### How registration works
+
+The component subscribes the selected model into the model context via `useAui().modelContext().register`. The `register` callback returns its own unsubscribe function, so returning it from `useEffect` cleans up on change:
+
+```tsx
+import { useEffect } from "react";
+import { useAui } from "@assistant-ui/react";
+
+const api = useAui();
+
+useEffect(() => {
+  const config = { config: { modelName: value } };
+  return api.modelContext().register({
+    getModelContext: () => config,
+  });
+}, [api, value]);
+```
+
+### Reading it server-side
+
+The `config` object rides along in the request body. With the AI SDK route the runtime POSTs `{ messages, config }`:
+
+```ts
+// app/api/chat/route.ts
+import { openai } from "@ai-sdk/openai";
+import { streamText, convertToModelMessages } from "ai";
+
+export async function POST(req: Request) {
+  const { messages, config } = await req.json();
+  const result = streamText({
+    model: openai(config?.modelName ?? "gpt-5.4-nano"),
+    messages: convertToModelMessages(messages),
+  });
+  return result.toUIMessageStreamResponse();
+}
+```
+
+### Composable parts
+
+For custom layout, drop the all-in-one `ModelSelector` and compose `ModelSelectorRoot` / `ModelSelectorTrigger` / `ModelSelectorContent` (also `ModelSelectorItem`, `ModelSelectorValue`):
+
+```tsx
+import {
+  ModelSelectorRoot,
+  ModelSelectorTrigger,
+  ModelSelectorContent,
+} from "@/components/assistant-ui/model-selector";
+
+<ModelSelectorRoot models={models} value={modelId} onValueChange={setModelId}>
+  <ModelSelectorTrigger variant="ghost" />
+  <ModelSelectorContent />
+</ModelSelectorRoot>
+```
+
+Note: `ModelSelectorRoot` is presentational only. The runtime registration lives in the all-in-one `ModelSelector`, so a bare `Root` does not switch the server model on its own.
+
+## Attachment UI
+
+Tiles and buttons for file attachments in the composer and in user messages. The `add attachment` command writes `components/assistant-ui/attachment.tsx` exporting three components.
+
+```bash
+npx assistant-ui add attachment
+```
+
+Wire them into your `thread.tsx`. In the composer:
+
+```tsx
+import {
+  ComposerAttachments,
+  ComposerAddAttachment,
+} from "@/components/assistant-ui/attachment";
+
+<ComposerPrimitive.Root>
+  <ComposerAttachments />
+  <ComposerAddAttachment />
+  <ComposerPrimitive.Input />
+</ComposerPrimitive.Root>
+```
+
+In a user message, render the sent attachments above the text:
+
+```tsx
+import { UserMessageAttachments } from "@/components/assistant-ui/attachment";
+
+<MessagePrimitive.Root>
+  <UserMessageAttachments />
+  <MessagePrimitive.Parts />
+</MessagePrimitive.Root>
+```
+
+- `ComposerAttachments`: tiles for pending attachments in the composer, each with a remove button.
+- `ComposerAddAttachment`: the add-file button that opens the OS file picker.
+- `UserMessageAttachments`: read-only tiles for attachments on a sent user message.
+
+These are built from `AttachmentPrimitive.Root` / `.Name` / `.Remove`, `ComposerPrimitive.Attachments` / `.AddAttachment`, and `MessagePrimitive.Attachments`.
+
+### Adapters are required
+
+These components render UI only. Nothing attaches unless an attachment adapter is configured on the runtime. The adapters live in `@assistant-ui/react`:
+
+```tsx
+import {
+  CompositeAttachmentAdapter,
+  SimpleImageAttachmentAdapter,
+  SimpleTextAttachmentAdapter,
+} from "@assistant-ui/react";
+
+const runtime = useChatRuntime({
+  adapters: {
+    attachments: new CompositeAttachmentAdapter([
+      new SimpleImageAttachmentAdapter(),
+      new SimpleTextAttachmentAdapter(),
+    ]),
+  },
+});
+```
+
+`SimpleImageAttachmentAdapter` handles `image/*` as data URLs; `SimpleTextAttachmentAdapter` handles text files; `CompositeAttachmentAdapter` fans out across a list. For uploads or other content types, implement the `AttachmentAdapter` interface yourself. See the attachments guide for full adapter setup.

--- a/assistant-ui/skills/streaming/SKILL.md
+++ b/assistant-ui/skills/streaming/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: streaming
-description: Guide for assistant-stream package and streaming protocols. Use when implementing streaming backends, custom protocols, or debugging stream issues.
-version: 0.0.1
+description: "Streaming backends and wire protocols for assistant-ui via the assistant-stream package. Use when building a custom (non-AI-SDK) streaming endpoint with createAssistantStreamResponse or createAssistantStreamController, emitting parts through appendText/appendReasoning/appendSource/appendFile/addToolCallPart and setResponse; choosing between the AI SDK Data Stream format (toUIMessageStreamResponse) and the native Assistant Transport format; encoding or decoding streams with DataStreamEncoder/DataStreamDecoder, AssistantTransportEncoder/AssistantTransportDecoder, PlainTextEncoder, or UIMessageStreamDecoder; or wiring streamed chunks into useLocalRuntime or useChatRuntime. Use specifically for debugging stream wire issues: text-delta, part-start, result events, text/event-stream content-type, SSE format, tool calls not rendering, or partial text not showing. For general non-stream debugging route to the relevant focused skill, not the parent overview."
 license: MIT
 ---
 
 # assistant-ui Streaming
 
-**Always consult [assistant-ui.com/llms.txt](https://assistant-ui.com/llms.txt) for latest API.**
+**Always consult [assistant-ui.com/llms.txt](https://www.assistant-ui.com/llms.txt) for the latest API.**
 
 The `assistant-stream` package handles streaming from AI backends.
 
@@ -16,6 +15,7 @@ The `assistant-stream` package handles streaming from AI backends.
 - [./references/data-stream.md](./references/data-stream.md) -- AI SDK data stream format
 - [./references/assistant-transport.md](./references/assistant-transport.md) -- Native assistant-ui format
 - [./references/encoders.md](./references/encoders.md) -- Encoders and decoders
+- [./references/resumable.md](./references/resumable.md) -- Resumable streams
 
 ## When to Use
 
@@ -41,7 +41,6 @@ export async function POST(req: Request) {
     stream.appendText("Hello ");
     stream.appendText("world!");
 
-    // Tool call example
     const tool = stream.addToolCallPart({ toolCallId: "1", toolName: "get_weather" });
     tool.argsText.append('{"city":"NYC"}');
     tool.argsText.close();

--- a/assistant-ui/skills/streaming/references/data-stream.md
+++ b/assistant-ui/skills/streaming/references/data-stream.md
@@ -37,11 +37,9 @@ import { createAssistantStreamResponse } from "assistant-stream";
 
 export async function POST(req: Request) {
   return createAssistantStreamResponse(async (stream) => {
-    // Text
     stream.appendText("Hello ");
     stream.appendText("world!");
 
-    // Tool call
     const tool = stream.addToolCallPart({
       toolCallId: "call_123",
       toolName: "search",
@@ -50,7 +48,6 @@ export async function POST(req: Request) {
     tool.argsText.close();
     tool.setResponse({ result: { temperature: 22 } });
 
-    // Finish
     stream.close();
   });
 }
@@ -91,32 +88,6 @@ Decoded `AssistantStreamChunk` shapes:
 - `result` (tool results)
 - `step-start` / `step-finish` / `message-finish`
 - `error`
-
-## With Tools Example
-
-```ts
-import { createAssistantStreamResponse } from "assistant-stream";
-
-async function streamWithTools(req: Request) {
-  return createAssistantStreamResponse(async (stream) => {
-    stream.appendText("Let me search for that...\n\n");
-
-    const toolCallId = "call_" + Date.now();
-    const tool = stream.addToolCallPart({
-      toolCallId,
-      toolName: "search",
-    });
-    tool.argsText.append('{"query":"weather NYC"}');
-    tool.argsText.close();
-
-    const result = await searchWeather("NYC");
-    tool.setResponse({ result });
-
-    stream.appendText(`The current weather in NYC is ${result.temp}°F`);
-    stream.close();
-  });
-}
-```
 
 ## Wire Format
 

--- a/assistant-ui/skills/streaming/references/encoders.md
+++ b/assistant-ui/skills/streaming/references/encoders.md
@@ -17,10 +17,8 @@ AI SDK compatible format. You normally don't call it directly—wrap an `Assista
 ```ts
 import { AssistantStream, DataStreamEncoder, DataStreamDecoder } from "assistant-stream";
 
-// Server
 const response = AssistantStream.toResponse(stream, new DataStreamEncoder());
 
-// Client
 const stream = AssistantStream.fromResponse(response, new DataStreamDecoder());
 for await (const chunk of stream) {
   console.log(chunk);
@@ -37,10 +35,8 @@ import {
   AssistantTransportDecoder,
 } from "assistant-stream";
 
-// Encoding: wrap AssistantStream chunks
 const response = AssistantStream.toResponse(stream, new AssistantTransportEncoder());
 
-// Decoding
 const stream = AssistantStream.fromResponse(response, new AssistantTransportDecoder());
 for await (const chunk of stream) {
   console.log(chunk);
@@ -54,11 +50,9 @@ Simple text-only streaming.
 ```ts
 import { PlainTextEncoder, PlainTextDecoder } from "assistant-stream";
 
-// Encoding
 const encoder = new PlainTextEncoder();
 const stream = encoder.encode("Hello world!");
 
-// Decoding
 const decoder = new PlainTextDecoder();
 for await (const text of decoder.decode(stream)) {
   console.log(text);
@@ -91,27 +85,7 @@ const stream = AssistantStream.fromResponse(response, new DataStreamDecoder());
 
 ## Server Response Helpers
 
-### Create Streaming Response
-
-Use `createAssistantStreamController` to build an `AssistantStream` and encode it:
-
-```ts
-import {
-  AssistantStream,
-  AssistantTransportEncoder,
-  createAssistantStreamController,
-} from "assistant-stream";
-
-export async function POST() {
-  const [stream, controller] = createAssistantStreamController();
-
-  controller.appendText("Hello ");
-  controller.appendText("world!");
-  controller.close();
-
-  return AssistantStream.toResponse(stream, new AssistantTransportEncoder());
-}
-```
+Build a stream with `createAssistantStreamController` and encode it via `AssistantStream.toResponse(stream, encoder)`, or use `createAssistantStreamResponse` for the Data Stream default. See [./assistant-transport.md](./assistant-transport.md) and [./data-stream.md](./data-stream.md) for full server examples.
 
 ## Debugging
 
@@ -132,7 +106,6 @@ while (reader) {
 ### Validate Format
 
 ```ts
-// Check if response is valid SSE
 const contentType = response.headers.get("Content-Type");
 console.log("Content-Type:", contentType);  // Should be text/event-stream
 ```

--- a/assistant-ui/skills/streaming/references/resumable.md
+++ b/assistant-ui/skills/streaming/references/resumable.md
@@ -1,0 +1,307 @@
+# Resumable Streams
+
+Persist an in-flight LLM response on the server so the client can reload, drop its connection, or open a new tab and pick up the same stream. This is assistant-ui's own `assistant-stream/resumable` subpackage, not Vercel's `resumable-stream`.
+
+## Contents
+
+- [How it works](#how-it-works)
+- [Server: the context](#server-the-context)
+- [Server: POST route](#server-post-route)
+- [Server: GET resume route](#server-get-resume-route)
+- [Context API](#context-api)
+- [Client: AssistantChatTransport](#client-assistantchattransport)
+- [createResumableAssistantStreamResponse](#createresumableassistantstreamresponse)
+- [Stores](#stores)
+- [Redis and ioredis](#redis-and-ioredis)
+- [Custom ResumableStreamStore](#custom-resumablestreamstore)
+- [Production notes](#production-notes)
+- [Exports](#exports)
+
+## How it works
+
+Persistence happens at the byte level after encoding, so it works with any encoder that ships in `assistant-stream` (AI SDK UI message stream, data stream, assistant transport SSE, or your own). The first request becomes the producer and writes encoded bytes to a store while the LLM call is in flight; reconnects become consumers that replay the persisted bytes plus any new ones until the producer finalizes. Streams are addressed by an opaque `streamId`.
+
+## Server: the context
+
+Construct a `ResumableStreamContext` once per process and reuse it across requests. It is the seam between route handlers and the storage backend.
+
+```ts
+// /lib/resumable-context.ts
+import {
+  createInMemoryResumableStreamStore,
+  createResumableStreamContext,
+} from "assistant-stream/resumable";
+
+const store = createInMemoryResumableStreamStore();
+export const resumableContext = createResumableStreamContext({ store });
+```
+
+Options on `createResumableStreamContext`:
+
+- `store`: a `ResumableStreamStore` implementation (required).
+- `waitUntil`: pass `after` from `next/server` (or your platform's `ctx.waitUntil`) so the producer task survives past the response on serverless.
+- `ttlMs`: per-deployment TTL override.
+- `onAcquire`, `onAppend`, `onFinalize`, `onError`: observability hooks.
+
+## Server: POST route
+
+Wrap the response body in `ctx.run(streamId, makeStream)`. The first caller for `streamId` becomes the producer (the callback runs); later callers and reconnects become consumers. Set the stream id on the response header so the client can find it.
+
+```ts
+// /app/api/chat/route.ts
+import { streamText } from "ai";
+import { RESUMABLE_STREAM_ID_HEADER } from "assistant-stream/resumable";
+import { resumableContext } from "@/lib/resumable-context";
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+  const streamId = crypto.randomUUID();
+
+  const result = streamText({ /* model, messages, tools, ... */ });
+  const sourceBody = result.toUIMessageStreamResponse().body!;
+
+  const stream = await resumableContext.run(streamId, () => sourceBody);
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      [RESUMABLE_STREAM_ID_HEADER]: streamId,
+    },
+  });
+}
+```
+
+`RESUMABLE_STREAM_ID_HEADER` is the string `"x-resumable-stream-id"`.
+
+## Server: GET resume route
+
+A separate GET endpoint replays persisted bytes for reconnecting clients. `ctx.resume(streamId)` returns `null` when no stream exists.
+
+```ts
+// /app/api/chat/resume/[streamId]/route.ts
+import { RESUMABLE_STREAM_ID_HEADER } from "assistant-stream/resumable";
+import { resumableContext } from "@/lib/resumable-context";
+
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ streamId: string }> },
+) {
+  const { streamId } = await ctx.params;
+  const stream = await resumableContext.resume(streamId);
+  if (!stream) {
+    return new Response(JSON.stringify({ error: "stream not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      [RESUMABLE_STREAM_ID_HEADER]: streamId,
+    },
+  });
+}
+```
+
+## Context API
+
+| Method | Behavior |
+| --- | --- |
+| `ctx.run(streamId, makeStream)` | First caller is the producer (runs `makeStream`); reconnects become consumers. |
+| `ctx.resume(streamId)` | Returns a replay stream, or `null` if the stream is missing. |
+| `ctx.requireResume(streamId)` | Like `resume`, but throws `ResumableStreamError` with code `"missing"` when absent. |
+| `ctx.status(streamId)` | Returns `"streaming" \| "done" \| "error" \| "missing"`. |
+| `ctx.delete(streamId)` | Removes all persisted state and terminates active readers. |
+
+`ResumableStreamError` is exported from `assistant-stream/resumable` with codes `"missing" | "exists" | "finalized" | "invalid-id"`. Catch it in the resume route to distinguish "stream gone" from other failures.
+
+## Client: AssistantChatTransport
+
+`@assistant-ui/react-ai-sdk` ships a `resumable` option on `AssistantChatTransport`. It captures the stream id from the response header, redirects `chat.resumeStream()` reconnects to your resume route, and clears the stored id when the response finishes naturally. `useChatRuntime` fires `chat.resumeStream()` on mount whenever a pending id is present in storage.
+
+```tsx
+// /app/page.tsx
+"use client";
+
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import {
+  AssistantChatTransport,
+  createResumableSessionStorage,
+  useChatRuntime,
+} from "@assistant-ui/react-ai-sdk";
+import { useMemo } from "react";
+import { Thread } from "@/components/assistant-ui/thread";
+
+const storage = createResumableSessionStorage();
+
+export default function Page() {
+  const transport = useMemo(
+    () =>
+      new AssistantChatTransport({
+        api: "/api/chat",
+        resumable: {
+          storage,
+          resumeApi: (streamId) => `/api/chat/resume/${streamId}`,
+        },
+      }),
+    [],
+  );
+  const runtime = useChatRuntime({ transport });
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+`createResumableSessionStorage` returns a `ResumableClientStorage` backed by `window.sessionStorage`. Pass `{ key }` to namespace per route or per chat surface, or supply your own object implementing `getStreamId`, `setStreamId`, and `clear`.
+
+The default finish detector scans the SSE body for the AI SDK `"type":"finish"` marker. Override `isFinishEvent` on the `resumable` option when you ship a custom encoder.
+
+## createResumableAssistantStreamResponse
+
+If you produce streams via `createAssistantStream` rather than the AI SDK, two helpers bridge the controller-callback style and any encoder to the store. They set the `x-resumable-stream-id` header automatically.
+
+```ts
+import {
+  createResumableAssistantStreamResponse,
+  createResumeAssistantStreamResponse,
+} from "assistant-stream/resumable";
+import { resumableContext } from "@/lib/resumable-context";
+
+// POST handler
+return createResumableAssistantStreamResponse({
+  context: resumableContext,
+  streamId,
+  callback: (controller) => {
+    /* same shape as createAssistantStreamResponse */
+  },
+});
+
+// GET resume handler
+return createResumeAssistantStreamResponse({
+  context: resumableContext,
+  streamId,
+});
+```
+
+Both default to the data-stream encoder; pass `encoder: () => new AssistantTransportEncoder()` (or any custom encoder) to override.
+
+## Stores
+
+`createInMemoryResumableStreamStore` is for development and tests. State lives in a process-local `Map`, so it does not survive a server restart. Options:
+
+- `defaultTtlMs`: TTL after the last write (built-in default is 24 hours).
+- `maxChunkBytes`: cap on a single appended chunk.
+- `maxEntriesPerStream`: cap on entries retained per stream.
+- `maxStreams`: cap on concurrently tracked streams.
+- `gcIntervalMs`: interval for periodic eviction.
+
+## Redis and ioredis
+
+For production, use the optional Redis adapters via `assistant-stream/resumable/redis` (node-redis v5) or `assistant-stream/resumable/ioredis`. Both batch the per-append write and TTL refresh into a single pipelined round trip, store chunk values as binary, and accept the same `keyPrefix`, `defaultTtlMs`, `pollIntervalMs`, and `maxChunkBytes` options. Cluster routing works because each stream's keys share a `{streamId}` hash tag.
+
+```ts
+// /lib/resumable-context.ts
+import {
+  createResumableStreamContext,
+  type ResumableStreamStore,
+} from "assistant-stream/resumable";
+
+async function createStore(): Promise<ResumableStreamStore> {
+  if (!process.env.REDIS_URL) {
+    const { createInMemoryResumableStreamStore } = await import(
+      "assistant-stream/resumable"
+    );
+    return createInMemoryResumableStreamStore();
+  }
+  const { createClient } = await import("redis");
+  const { createRedisResumableStreamStore } = await import(
+    "assistant-stream/resumable/redis"
+  );
+  const client = createClient({ url: process.env.REDIS_URL });
+  await client.connect();
+  return createRedisResumableStreamStore(client);
+}
+
+export const resumableContext = createResumableStreamContext({
+  store: await createStore(),
+});
+```
+
+The ioredis sub-path exposes `createIoredisResumableStreamStore` with the same shape. The Redis adapters validate `streamId` against `/^[A-Za-z0-9_.:-]{1,256}$/`; UUIDv4 is compatible.
+
+## Custom ResumableStreamStore
+
+For Postgres, Cloudflare Durable Objects, Upstash REST, or any backend you operate, implement `ResumableStreamStore` directly. It is six async methods over an opaque `streamId` and a monotonic byte log.
+
+```ts
+import type { ResumableStreamStore } from "assistant-stream/resumable";
+
+export interface ResumableStreamStore {
+  acquire(
+    streamId: string,
+    options?: ResumableStreamAcquireOptions,
+  ): Promise<ResumableStreamRole>;
+  append(streamId: string, chunk: Uint8Array): Promise<void>;
+  finalize(
+    streamId: string,
+    status: "done" | "error",
+    error?: string,
+  ): Promise<void>;
+  read(
+    streamId: string,
+    cursor: string,
+    signal: AbortSignal,
+  ): AsyncIterable<ResumableStreamEntry>;
+  status(streamId: string): Promise<ResumableStreamStatus>;
+  delete(streamId: string): Promise<void>;
+}
+```
+
+Contract:
+
+- `acquire` arbitrates ownership. The first caller resolves to `"producer"`, every later caller (including after `finalize`) to `"consumer"`. The check and insert must be atomic: Redis `SET key value NX EX ttl`; Postgres `INSERT ... ON CONFLICT (stream_id) DO NOTHING RETURNING ...`; Durable Objects one object per `streamId` plus a boolean; Upstash REST `set` with `nx=true`. `options.ttlMs` overrides the store default for this stream.
+- `append` adds a chunk under a fresh monotonically increasing cursor, observable to `read` before the promise resolves; refresh the TTL and reject when missing or finalized.
+- `finalize` is an idempotent terminal flip; a duplicate call with the same status is a no-op.
+- `read` yields every entry whose cursor sorts strictly after `cursor`, then waits for new appends, then completes on finalize. Cursor `""` means start from the beginning. Aborting `signal` resolves the iterable cleanly without throwing; do not busy-loop.
+- `status` returns `"streaming" | "done" | "error" | "missing"`.
+- `delete` removes all state, no-ops when missing, and terminates active `read` iterables.
+
+Cursors are opaque strings the store assigns and the context echoes back; they must be strictly monotonic per stream (sequence number, ULID, `bigserial`, Redis stream id are all fine). Cross-stream ordering is not required. Wire any conforming instance in as `store`:
+
+```ts
+// /lib/resumable-context.ts
+import { createResumableStreamContext } from "assistant-stream/resumable";
+import { createMapResumableStreamStore } from "@/lib/map-resumable-store";
+
+export const resumableContext = createResumableStreamContext({
+  store: createMapResumableStreamStore(),
+});
+```
+
+Note: a full `Map`-backed worked example lives in the [Custom Resumable Stream Stores](https://www.assistant-ui.com/docs/guides/resumable-stream-stores) guide.
+
+## Production notes
+
+- Auth. The resume route serves any caller that knows the stream id. Bind `streamId` to the requesting user at acquire time and verify the binding in the resume handler. Treat the id as opaque, not a credential; it leaks via response headers, `sessionStorage`, browser history, and access logs.
+- `waitUntil` on serverless. On Vercel and Cloudflare the handler is killed once the response returns, interrupting the producer. Pass `createResumableStreamContext({ store, waitUntil: after })` with `after` from `next/server`.
+- TTL. Streams expire 24 hours after the last write by default. Configure with `defaultTtlMs` on the store or `ttlMs` on the context. When a stream expires, treat it like `finalize(streamId, "error", "Stream expired")`. Match TTLs across the store, any owner-binding key, and any signed cookie referencing a `streamId`.
+- Scaffold the runnable example with `npx assistant-ui create my-app -e with-resumable-stream`.
+
+## Exports
+
+`assistant-stream/resumable`:
+
+- `createResumableStreamContext`, type `ResumableStreamContext`, type `ResumableStreamContextOptions`
+- `createInMemoryResumableStreamStore`, type `InMemoryResumableStreamStoreOptions`
+- `createResumableAssistantStreamResponse`, `createResumeAssistantStreamResponse`, `RESUMABLE_STREAM_ID_HEADER`
+- `ResumableStreamError`, type `ResumableStreamErrorCode`
+- types `ResumableStreamStore`, `ResumableStreamRole`, `ResumableStreamStatus`, `ResumableStreamEntry`, `ResumableStreamAcquireOptions`
+- types `RedisLikeClient`, `RedisResumableStreamStoreOptions`
+
+`assistant-stream/resumable/redis`: `createRedisResumableStreamStore`. `assistant-stream/resumable/ioredis`: `createIoredisResumableStreamStore`.
+
+`@assistant-ui/react-ai-sdk`: `AssistantChatTransport` (with the `resumable` option), `createResumableSessionStorage`, `useChatRuntime`.

--- a/assistant-ui/skills/thread-list/SKILL.md
+++ b/assistant-ui/skills/thread-list/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: thread-list
-description: Guide for multi-thread management in assistant-ui. Use when implementing thread lists, switching threads, or managing conversation history.
-version: 0.0.1
+description: "Implements multi-thread (conversation history) management in assistant-ui apps: rendering the prebuilt `ThreadList` next to `Thread`, or building a custom sidebar with `ThreadListPrimitive` and `ThreadListItemPrimitive` (Root, New, Items, Trigger, Title, Archive, Unarchive, Delete). Covers thread CRUD through the `useAui()`/`useAuiState()` API: `switchToThread`, `switchToNewThread`, and per item `rename`, `archive`, `unarchive`, `delete`, `generateTitle`, `initialize`, plus reading `s.threads.threadIds`/`archivedThreadIds`/`mainThreadId`. Includes cloud-backed persistence via `useChatRuntime` + `AssistantCloud` and a local `useRemoteThreadListRuntime` + `InMemoryThreadListAdapter` path. Use when a user wants a thread list/sidebar, switching, searching, sorting, drag-and-drop, or renaming/archiving/deleting conversations. For single-thread state, messages, or composer use runtime; for cloud auth/persistence setup use cloud."
 license: MIT
 ---
 
 # assistant-ui Thread List
 
-**Always consult [assistant-ui.com/llms.txt](https://assistant-ui.com/llms.txt) for latest API.**
+**Always consult [assistant-ui.com/llms.txt](https://www.assistant-ui.com/llms.txt) for the latest API.**
 
 Manage multiple chat threads with built-in or custom UI.
 
@@ -60,13 +59,10 @@ const { threadIds, mainThreadId } = useAuiState((s) => ({
   mainThreadId: s.threads.mainThreadId,
 }));
 
-// Switch to thread
 api.threads().switchToThread(threadId);
 
-// Create new thread
 api.threads().switchToNewThread();
 
-// Thread item operations
 const item = api.threads().item({ id: threadId });
 await item.rename("New Title");
 await item.archive();
@@ -86,13 +82,15 @@ function CustomThreadList() {
       </ThreadListPrimitive.New>
 
       <ThreadListPrimitive.Items>
-        <ThreadListItemPrimitive.Root className="flex p-2 hover:bg-gray-100">
-          <ThreadListItemPrimitive.Trigger className="flex-1">
-            <ThreadListItemPrimitive.Title />
-          </ThreadListItemPrimitive.Trigger>
-          <ThreadListItemPrimitive.Archive>Archive</ThreadListItemPrimitive.Archive>
-          <ThreadListItemPrimitive.Delete>Delete</ThreadListItemPrimitive.Delete>
-        </ThreadListItemPrimitive.Root>
+        {() => (
+          <ThreadListItemPrimitive.Root className="flex p-2 hover:bg-gray-100">
+            <ThreadListItemPrimitive.Trigger className="flex-1">
+              <ThreadListItemPrimitive.Title />
+            </ThreadListItemPrimitive.Trigger>
+            <ThreadListItemPrimitive.Archive>Archive</ThreadListItemPrimitive.Archive>
+            <ThreadListItemPrimitive.Delete>Delete</ThreadListItemPrimitive.Delete>
+          </ThreadListItemPrimitive.Root>
+        )}
       </ThreadListPrimitive.Items>
     </ThreadListPrimitive.Root>
   );
@@ -103,8 +101,8 @@ function CustomThreadList() {
 
 ```tsx
 import {
-  unstable_useRemoteThreadListRuntime as useRemoteThreadListRuntime,
-  unstable_InMemoryThreadListAdapter as InMemoryThreadListAdapter,
+  useRemoteThreadListRuntime,
+  InMemoryThreadListAdapter,
 } from "@assistant-ui/react";
 
 const runtime = useRemoteThreadListRuntime({

--- a/assistant-ui/skills/thread-list/references/custom-ui.md
+++ b/assistant-ui/skills/thread-list/references/custom-ui.md
@@ -2,6 +2,15 @@
 
 Build custom thread list interfaces.
 
+## Contents
+
+- [Using Primitives](#using-primitives)
+- [Fully Custom with Hooks](#fully-custom-with-hooks)
+- [With Search](#with-search)
+- [With Drag and Drop](#with-drag-and-drop)
+- [Modal/Dropdown Style](#modaldropdown-style)
+- [With Categories/Folders](#with-categoriesfolders)
+
 ## Using Primitives
 
 ```tsx
@@ -13,23 +22,20 @@ import {
 function CustomThreadList() {
   return (
     <ThreadListPrimitive.Root className="flex flex-col h-full">
-      {/* New thread button */}
       <ThreadListPrimitive.New className="m-2 p-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600">
         + New Conversation
       </ThreadListPrimitive.New>
 
-      {/* Thread items */}
       <div className="flex-1 overflow-y-auto">
         <ThreadListPrimitive.Items>
-          <CustomThreadItem />
+          {() => <CustomThreadItem />}
         </ThreadListPrimitive.Items>
       </div>
 
-      {/* Archived section */}
       <div className="border-t p-2">
         <h3 className="text-sm text-gray-500 mb-2">Archived</h3>
         <ThreadListPrimitive.Items archived>
-          <CustomThreadItem archived />
+          {() => <CustomThreadItem archived />}
         </ThreadListPrimitive.Items>
       </div>
     </ThreadListPrimitive.Root>
@@ -80,7 +86,6 @@ function FullyCustomThreadList() {
 
   return (
     <div className="w-64 h-full bg-gray-50">
-      {/* Header */}
       <div className="p-4 border-b">
         <button
           onClick={() => api.threads().switchToNewThread()}
@@ -90,7 +95,6 @@ function FullyCustomThreadList() {
         </button>
       </div>
 
-      {/* Thread list */}
       <nav className="p-2 space-y-1">
         {threads.map((threadId) => (
           <ThreadItem
@@ -101,7 +105,6 @@ function FullyCustomThreadList() {
         ))}
       </nav>
 
-      {/* Archived */}
       {archivedThreads.length > 0 && (
         <div className="border-t mt-4 pt-4 px-2">
           <h3 className="text-xs text-gray-500 uppercase mb-2">Archived</h3>
@@ -225,7 +228,6 @@ function SearchableThreadList() {
 
   return (
     <div className="flex flex-col h-full">
-      {/* Search */}
       <div className="p-2">
         <input
           value={search}
@@ -235,7 +237,6 @@ function SearchableThreadList() {
         />
       </div>
 
-      {/* New button */}
       <button
         onClick={() => api.threads().switchToNewThread()}
         className="mx-2 py-2 bg-blue-500 text-white rounded-lg"
@@ -243,7 +244,6 @@ function SearchableThreadList() {
         + New Chat
       </button>
 
-      {/* Results */}
       <div className="flex-1 overflow-y-auto p-2">
         {filteredThreads.length === 0 ? (
           <p className="text-gray-500 text-center py-4">No results</p>
@@ -320,11 +320,11 @@ function DraggableThreadList() {
 function ThreadDropdown() {
   const [open, setOpen] = useState(false);
   const api = useAui();
-  const { threads, mainThreadId } = useAuiState((s) => ({
+  const { threads, mainThreadId, currentItem } = useAuiState((s) => ({
     threads: s.threads.threadIds,
     mainThreadId: s.threads.mainThreadId,
+    currentItem: s.threadListItem,
   }));
-  const currentItem = api.threads().item("main").getState();
 
   return (
     <div className="relative">
@@ -332,7 +332,7 @@ function ThreadDropdown() {
         onClick={() => setOpen(!open)}
         className="px-4 py-2 border rounded-lg flex items-center gap-2"
       >
-        <span>{currentItem.title || "Select Thread"}</span>
+        <span>{currentItem?.title || "Select Thread"}</span>
         <span>{open ? "▲" : "▼"}</span>
       </button>
 
@@ -380,7 +380,6 @@ function CategorizedThreadList() {
   const api = useAui();
   const { threads } = useAuiState((s) => ({ threads: s.threads.threadIds }));
 
-  // Group by title first letter
   const grouped = threads.reduce((acc, id) => {
     const item = api.threads().item({ id }).getState();
     const category = (item.title || "Untitled").charAt(0).toUpperCase();

--- a/assistant-ui/skills/thread-list/references/management.md
+++ b/assistant-ui/skills/thread-list/references/management.md
@@ -153,8 +153,8 @@ const item2 = threads.item({ index: 0 });
 // By index (archived)
 const item3 = threads.item({ index: 0, archived: true });
 
-// Current thread
-const mainItem = threads.item("main");
+// Current thread's item state is available reactively:
+// const current = useAuiState((s) => s.threadListItem);
 ```
 
 ## Batch Operations

--- a/assistant-ui/skills/tools/SKILL.md
+++ b/assistant-ui/skills/tools/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: tools
-description: Guide for tool registration and tool UI in assistant-ui. Use when implementing LLM tools, tool call rendering, or human-in-the-loop patterns.
-version: 0.0.1
+description: "Registers LLM tools and renders custom tool-call UI in assistant-ui (@assistant-ui/react). Use when adding frontend-only tools with makeAssistantTool / useAssistantTool (browser actions like clipboard, navigation, localStorage, async-generator streaming, AbortSignal), rendering backend AI SDK tool() calls with makeAssistantToolUI / useAssistantToolUI (status.type running/complete/incomplete/requires-action, args, result, artifact via ToolCallMessagePartProps), building generative UI from tool results, or implementing human-in-the-loop and approval flows (addResult, resume with context.human(), respondToApproval for server-side needsApproval gates). Covers registering tool components inside AssistantRuntimeProvider and the case-sensitive toolName matching that connects a tool to its UI. Reach for this when tool UI is not rendering, a tool is not being called, or a result is not showing."
 license: MIT
 ---
 
 # assistant-ui Tools
 
-**Always consult [assistant-ui.com/llms.txt](https://assistant-ui.com/llms.txt) for latest API.**
+**Always consult [assistant-ui.com/llms.txt](https://www.assistant-ui.com/llms.txt) for the latest API.**
 
 Tools let LLMs trigger actions with custom UI rendering.
 
@@ -16,6 +15,10 @@ Tools let LLMs trigger actions with custom UI rendering.
 - [./references/make-tool.md](./references/make-tool.md) -- makeAssistantTool/useAssistantTool
 - [./references/tool-ui.md](./references/tool-ui.md) -- makeAssistantToolUI rendering
 - [./references/human-in-loop.md](./references/human-in-loop.md) -- Confirmation patterns
+- [./references/toolkits.md](./references/toolkits.md) -- Toolkits and the Tools component
+- [./references/mcp-server.md](./references/mcp-server.md) -- Server-side MCP tools
+- [./references/generative-ui.md](./references/generative-ui.md) -- Declarative generative UI
+- [./references/registry-components.md](./references/registry-components.md) -- ToolFallback, ToolGroup, Image renderers
 
 ## Tool Types
 
@@ -31,38 +34,48 @@ Where does the tool execute?
 
 ```ts
 // Backend (app/api/chat/route.ts)
-import { tool, stepCountIs } from "ai";
+import { openai } from "@ai-sdk/openai";
+import {
+  streamText,
+  tool,
+  stepCountIs,
+  convertToModelMessages,
+  type UIMessage,
+} from "ai";
 import { z } from "zod";
 
-const tools = {
-  get_weather: tool({
-    description: "Get weather for a city",
-    inputSchema: z.object({ city: z.string() }),
-    execute: async ({ city }) => ({ temp: 22, city }),
-  }),
-};
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json();
 
-const result = streamText({
-  model: openai("gpt-4o"),
-  messages,
-  tools,
-  stopWhen: stepCountIs(5),
-});
+  const result = streamText({
+    model: openai("gpt-4o"),
+    messages: await convertToModelMessages(messages),
+    stopWhen: stepCountIs(5),
+    tools: {
+      get_weather: tool({
+        description: "Get weather for a city",
+        inputSchema: z.object({ city: z.string() }),
+        execute: async ({ city }) => ({ temp: 22, city }),
+      }),
+    },
+  });
+
+  return result.toUIMessageStreamResponse();
+}
 ```
 
 ```tsx
-// Frontend
 import { makeAssistantToolUI } from "@assistant-ui/react";
 
 const WeatherToolUI = makeAssistantToolUI({
   toolName: "get_weather",
   render: ({ args, result, status }) => {
-    if (status === "running") return <div>Loading weather...</div>;
+    // status is an object; check status.type (not status === "running")
+    if (status.type === "running") return <div>Loading weather...</div>;
     return <div>{result?.city}: {result?.temp}°C</div>;
   },
 });
 
-// Register in app
 <AssistantRuntimeProvider runtime={runtime}>
   <WeatherToolUI />
   <Thread />
@@ -93,15 +106,29 @@ const CopyTool = makeAssistantTool({
 ## API Reference
 
 ```tsx
-// makeAssistantToolUI props
-interface ToolUIProps {
+// makeAssistantToolUI render props (ToolCallMessagePartProps)
+interface ToolCallMessagePartProps {
   toolCallId: string;
   toolName: string;
   args: Record<string, unknown>;
-  argsText: string;
+  argsText: string;          // raw streamed JSON
   result?: unknown;
-  status: "running" | "complete" | "incomplete" | "requires-action";
-  submitResult: (result: unknown) => void;  // For interactive tools
+  isError?: boolean;
+  artifact?: unknown;        // UI-only artifact attached to the result
+
+  // status is an OBJECT, not a string. Branch on status.type.
+  status:
+    | { type: "running" }
+    | { type: "complete" }
+    | { type: "incomplete"; reason: "cancelled" | "length" | "content-filter" | "other" | "error" }
+    | { type: "requires-action"; reason: "interrupt" };
+
+  // Supply a result from the renderer (instead of a tool execute function)
+  addResult: (result: unknown) => void;
+  // Resume a frontend tool paused via context.human(...)
+  resume: (payload: unknown) => void;
+  // Respond to a server-side approval gate
+  respondToApproval: (response: { approved: boolean; reason?: string }) => void;
 }
 ```
 
@@ -110,13 +137,13 @@ interface ToolUIProps {
 ```tsx
 const DeleteToolUI = makeAssistantToolUI({
   toolName: "delete_file",
-  render: ({ args, status, submitResult }) => {
-    if (status === "requires-action") {
+  render: ({ args, status, addResult }) => {
+    if (status.type === "requires-action") {
       return (
         <div>
           <p>Delete {args.path}?</p>
-          <button onClick={() => submitResult({ confirmed: true })}>Confirm</button>
-          <button onClick={() => submitResult({ confirmed: false })}>Cancel</button>
+          <button onClick={() => addResult({ confirmed: true })}>Confirm</button>
+          <button onClick={() => addResult({ confirmed: false })}>Cancel</button>
         </div>
       );
     }
@@ -137,4 +164,4 @@ const DeleteToolUI = makeAssistantToolUI({
 
 **Result not showing**
 - Tool must return a value
-- Check `status === "complete"` before accessing result
+- Check `status.type === "complete"` before accessing result

--- a/assistant-ui/skills/tools/references/generative-ui.md
+++ b/assistant-ui/skills/tools/references/generative-ui.md
@@ -1,0 +1,293 @@
+# Declarative Generative UI
+
+Render agent-described React UI from a JSON spec resolved against a consumer-provided component allowlist. This is the supported replacement for hand-rolled `render_ui` tool components that returned arbitrary JSX.
+
+## Contents
+
+- [Overview](#overview)
+- [The spec format](#the-spec-format)
+- [The component allowlist](#the-component-allowlist)
+- [MessagePrimitive.GenerativeUI](#messageprimitivegenerativeui)
+- [Rendering inside MessagePrimitive.Parts](#rendering-inside-messageprimitiveparts)
+- [GenerativeUIRenderError and Fallback](#generativeuirendererror-and-fallback)
+- [The AI SDK bridge: render_gui and parseRenderGuiResult](#the-ai-sdk-bridge-render_gui-and-parserenderguiresult)
+- [Server-side render_gui tool](#server-side-render_gui-tool)
+- [Replacing the older render_ui pattern](#replacing-the-older-render_ui-pattern)
+- [Security](#security)
+
+## Overview
+
+The agent emits a `generative-ui` message part carrying a JSON spec. `MessagePrimitive.GenerativeUI` walks that spec and resolves each `component` name against an allowlist you provide. Names not in the allowlist throw `GenerativeUIRenderError` unless you pass a `Fallback`. The spec is plain JSON; there is no `eval` or dynamic import. Rendering is stream friendly, so a partially streamed spec renders progressively as it fills in.
+
+All exports live in `@assistant-ui/react`.
+
+```tsx
+import {
+  MessagePrimitive,
+  GenerativeUIRenderError,
+  type GenerativeUISpec,
+  type GenerativeUINode,
+  type GenerativeUIMessagePart,
+  type GenerativeUIComponentRegistry,
+} from "@assistant-ui/react";
+```
+
+## The spec format
+
+A node is either a bare string (rendered as text) or an object describing one allowlisted component. The spec wraps one or more root nodes.
+
+```ts
+export type GenerativeUINode =
+  | string
+  | {
+      readonly component: string;
+      readonly props?: Record<string, unknown>;
+      readonly children?: readonly GenerativeUINode[];
+      readonly key?: string;
+    };
+
+export type GenerativeUISpec = {
+  readonly root: GenerativeUINode | readonly GenerativeUINode[];
+};
+
+export type GenerativeUIMessagePart = {
+  readonly type: "generative-ui";
+  readonly spec: GenerativeUISpec;
+  readonly id?: string;
+  readonly parentId?: string;
+};
+```
+
+- `component` is the allowlist key resolved against your registry.
+- `props` are passed to the resolved component and must be JSON serializable.
+- `children` render below the component; strings become text, objects recurse.
+- `key` is an optional stable React key. When omitted, the renderer derives a key from the node's path in the tree.
+
+A native `generative-ui` part as emitted from ExternalStore or a manual message looks like this.
+
+```json
+{
+  "type": "generative-ui",
+  "spec": {
+    "root": {
+      "component": "Card",
+      "props": { "title": "Welcome" },
+      "children": [
+        { "component": "Button", "props": { "label": "Get started" } }
+      ]
+    }
+  }
+}
+```
+
+## The component allowlist
+
+The allowlist is a plain record from spec name to React component. Its type is `GenerativeUIComponentRegistry`, which is `Record<string, ComponentType<any>>`. Define each component to accept only the primitive, display oriented props the agent is allowed to pass.
+
+```tsx
+import type { ComponentType, PropsWithChildren } from "react";
+
+const Card: ComponentType<
+  PropsWithChildren<{ title?: string; description?: string }>
+> = ({ title, description, children }) => (
+  <div className="bg-card rounded-xl border p-4 shadow-sm">
+    {title ? <div className="text-base font-semibold">{title}</div> : null}
+    {description ? (
+      <div className="text-muted-foreground mt-1 text-sm">{description}</div>
+    ) : null}
+    {children ? <div className="mt-3">{children}</div> : null}
+  </div>
+);
+
+const Button: ComponentType<PropsWithChildren<{ label?: string }>> = ({
+  label,
+  children,
+}) => (
+  <button
+    type="button"
+    className="bg-primary text-primary-foreground mt-2 inline-flex items-center rounded-md px-3 py-1.5 text-sm font-medium"
+  >
+    {children ?? label ?? "Click"}
+  </button>
+);
+
+export const componentsAllowlist = { Card, Button };
+```
+
+## MessagePrimitive.GenerativeUI
+
+The primitive accepts the allowlist via `components`, an optional `Fallback`, and an optional `spec` override. When `spec` is omitted, it reads the `generative-ui` part from the surrounding message part context.
+
+```tsx
+type Props = {
+  components: GenerativeUIComponentRegistry;
+  spec?: GenerativeUISpec | undefined;
+  Fallback?:
+    | ComponentType<{ component: string; props?: unknown }>
+    | undefined;
+};
+```
+
+In the simplest case, pass the allowlist and let the primitive read the part from context.
+
+```tsx
+<MessagePrimitive.GenerativeUI components={componentsAllowlist} />
+```
+
+Pass `spec` explicitly only when you have the spec in hand, for example from the AI SDK bridge below.
+
+## Rendering inside MessagePrimitive.Parts
+
+`MessagePrimitive.Parts` accepts a `generativeUI` entry in its `components` map. Provide the allowlist there and the primitive renders any `generative-ui` part automatically.
+
+```tsx
+<MessagePrimitive.Parts
+  components={{
+    generativeUI: {
+      components: componentsAllowlist,
+      Fallback: UnknownComponentFallback,
+    },
+  }}
+/>
+```
+
+When you fork the thread to hand render part types with `MessagePrimitive.GroupedParts`, handle the `generative-ui` case explicitly.
+
+```tsx
+case "generative-ui":
+  return (
+    <MessagePrimitive.GenerativeUI
+      components={componentsAllowlist}
+      Fallback={UnknownComponentFallback}
+    />
+  );
+```
+
+If a `generative-ui` part arrives but no allowlist was wired, the primitive renders nothing and warns in development. The default shadcn `Thread` does not wire this, so opt in explicitly.
+
+## GenerativeUIRenderError and Fallback
+
+The allowlist is the security boundary. A spec that references a component name absent from the allowlist throws `GenerativeUIRenderError`, which carries a typed `componentName` field.
+
+```ts
+export class GenerativeUIRenderError extends Error {
+  public readonly componentName: string;
+}
+```
+
+The default message is `Component "<name>" is not in the generative-ui allowlist.`. Catch it with a React error boundary, or pass a `Fallback` to opt into a soft fail UX. The `Fallback` receives the unresolved `component` name and the attempted `props`.
+
+```tsx
+const UnknownComponentFallback = ({ component }: { component: string }) => (
+  <span className="bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
+    unknown component: {component}
+  </span>
+);
+
+<MessagePrimitive.GenerativeUI
+  components={componentsAllowlist}
+  Fallback={UnknownComponentFallback}
+/>;
+```
+
+## The AI SDK bridge: render_gui and parseRenderGuiResult
+
+With `useChatRuntime`, the AI SDK maps a tool result to a `tool-call` part rather than a native `generative-ui` part. Bridge it by calling a `render_gui` tool whose result carries the spec, then parse that result and feed it to the primitive. This is an interim bridge; the native part path above is preferred when available.
+
+`parseRenderGuiResult` validates the tool result against the spec schema and returns the `GenerativeUISpec`, or `undefined` if it does not match.
+
+```ts
+import type { GenerativeUISpec } from "@assistant-ui/react";
+
+export const parseRenderGuiResult = (
+  result: unknown,
+): GenerativeUISpec | undefined => { /* zod safeParse of { spec } */ };
+```
+
+Wire it in the `tool-call` case. When the spec parses, render through the primitive with the explicit `spec` prop.
+
+```tsx
+case "tool-call":
+  if (part.toolName === "render_gui") {
+    const spec = parseRenderGuiResult(part.result);
+    if (spec) {
+      return (
+        <MessagePrimitive.GenerativeUI
+          spec={spec}
+          components={componentsAllowlist}
+          Fallback={UnknownComponentFallback}
+        />
+      );
+    }
+  }
+  return part.toolUI ?? <ToolFallback {...part} />;
+```
+
+Two further details keep the bridge clean. Exclude `render_gui` from any tool group chrome so the call does not render as a generic tool card; for example return an empty group array for it in `groupBy`. The spec arrives only at tool completion through `part.result`, not incrementally, so this path does not stream.
+
+```tsx
+groupBy={(part) => {
+  if (part.type === "tool-call" && part.toolName === "render_gui") return [];
+  return [];
+}}
+```
+
+## Server-side render_gui tool
+
+Define the tool with the AI SDK `tool` helper and return the spec from `execute`. The input and result both carry `{ spec }`, validated by a zod schema.
+
+```ts
+import { streamText, tool, zodSchema } from "ai";
+import { z } from "zod";
+
+const generativeUINodeSchema: z.ZodType<unknown> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.object({
+      component: z.string().min(1),
+      props: z.record(z.string(), z.unknown()).optional(),
+      children: z.array(generativeUINodeSchema).optional(),
+      key: z.string().optional(),
+    }),
+  ]),
+);
+
+const renderGuiToolInputSchema = z.object({
+  spec: z.object({
+    root: z.union([
+      generativeUINodeSchema,
+      z.array(generativeUINodeSchema).min(1),
+    ]),
+  }),
+});
+
+const result = streamText({
+  model,
+  messages,
+  tools: {
+    render_gui: tool({
+      description:
+        "Compose inline UI from the allowlisted component library. " +
+        "Pass a JSON spec with a root node tree.",
+      inputSchema: zodSchema(renderGuiToolInputSchema),
+      execute: async (input) => ({ spec: input.spec }),
+    }),
+  },
+});
+```
+
+Instruct the model to call `render_gui` for UI requests and to keep its text reply brief, so it does not paste the JSON spec or the tool result back into the message text.
+
+## Replacing the older render_ui pattern
+
+The older approach defined a tool such as `render_ui` and a hand written tool UI component that interpreted an ad hoc payload and returned arbitrary JSX. That coupled the rendering contract to one component, offered no allowlist boundary, and reimplemented spec walking per project.
+
+The declarative path replaces it. Components describe what they can render through the allowlist, the agent describes what to render through the `{ component, props, children }` spec, and `MessagePrimitive.GenerativeUI` walks the tree once with a typed error boundary. Prefer the native `generative-ui` part when your runtime emits it, and use the `render_gui` plus `parseRenderGuiResult` bridge as the interim path on the AI SDK runtime.
+
+## Security
+
+The allowlist bounds which components render; it does not constrain the props those components receive. Treat every allowlisted component as receiving untrusted input.
+
+- Never pass agent supplied props to `dangerouslySetInnerHTML`.
+- Validate or block `javascript:` URLs in `href` and `src`.
+- Prefer primitive, display oriented props; avoid event handlers or escape hatches that an agent supplied value could drive.

--- a/assistant-ui/skills/tools/references/human-in-loop.md
+++ b/assistant-ui/skills/tools/references/human-in-loop.md
@@ -2,9 +2,23 @@
 
 Tools that require user confirmation or input.
 
+## Contents
+
+- [Overview](#overview)
+- [Confirmation Pattern](#confirmation-pattern)
+- [Selection Pattern](#selection-pattern)
+- [Form Input Pattern](#form-input-pattern)
+- [Multi-Step Workflow](#multi-step-workflow)
+- [Rating/Feedback Pattern](#ratingfeedback-pattern)
+- [Timeout/Auto-Cancel](#timeoutauto-cancel)
+
 ## Overview
 
-Human-in-the-loop tools pause execution waiting for user input. Use `status === "requires-action"` to detect this state and `submitResult` to provide the user's response.
+Human-in-the-loop tools pause execution waiting for user input. Detect the paused state with `status.type === "requires-action"`. The render props give three ways to respond:
+
+- `addResult(result)` — the renderer itself supplies the tool result (the pattern used throughout this page).
+- `resume(payload)` — resume a frontend tool that paused by calling `context.human(payload)` inside its `execute` function.
+- `respondToApproval({ approved, reason? })` — answer a server-side approval gate (a backend tool defined with `needsApproval`).
 
 ## Confirmation Pattern
 
@@ -24,9 +38,9 @@ const deleteTool = tool({
 // Frontend shows confirmation UI
 const DeleteToolUI = makeAssistantToolUI({
   toolName: "delete_file",
-  render: ({ args, result, status, submitResult }) => {
+  render: ({ args, result, status, addResult }) => {
     // Initial state - show confirmation
-    if (status === "requires-action" || !result?.confirmed) {
+    if (status.type === "requires-action" || !result?.confirmed) {
       return (
         <div className="p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
           <div className="flex items-center gap-2 mb-3">
@@ -36,13 +50,13 @@ const DeleteToolUI = makeAssistantToolUI({
           <p className="mb-4">Are you sure you want to delete <code>{args.path}</code>?</p>
           <div className="flex gap-2">
             <button
-              onClick={() => submitResult({ confirmed: true })}
+              onClick={() => addResult({ confirmed: true })}
               className="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600"
             >
               Delete
             </button>
             <button
-              onClick={() => submitResult({ confirmed: false })}
+              onClick={() => addResult({ confirmed: false })}
               className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300"
             >
               Cancel
@@ -78,8 +92,8 @@ Let user choose from options:
 ```tsx
 const SelectToolUI = makeAssistantToolUI({
   toolName: "select_option",
-  render: ({ args, result, status, submitResult }) => {
-    if (status !== "complete") {
+  render: ({ args, result, status, addResult }) => {
+    if (status.type !== "complete") {
       return (
         <div className="p-4 bg-blue-50 rounded-lg">
           <p className="mb-3">{args.prompt}</p>
@@ -87,7 +101,7 @@ const SelectToolUI = makeAssistantToolUI({
             {args.options.map((option: any) => (
               <button
                 key={option.id}
-                onClick={() => submitResult({ selected: option.id })}
+                onClick={() => addResult({ selected: option.id })}
                 className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
               >
                 {option.label}
@@ -114,15 +128,15 @@ Collect structured data from user:
 ```tsx
 const FormToolUI = makeAssistantToolUI({
   toolName: "collect_info",
-  render: ({ args, status, submitResult }) => {
+  render: ({ args, status, addResult }) => {
     const [formData, setFormData] = useState({});
 
-    if (status !== "complete") {
+    if (status.type !== "complete") {
       return (
         <form
           onSubmit={(e) => {
             e.preventDefault();
-            submitResult(formData);
+            addResult(formData);
           }}
           className="p-4 bg-gray-50 rounded-lg space-y-4"
         >
@@ -166,14 +180,14 @@ Chain multiple interactions:
 ```tsx
 const WizardToolUI = makeAssistantToolUI({
   toolName: "setup_wizard",
-  render: ({ args, result, status, submitResult }) => {
+  render: ({ args, result, status, addResult }) => {
     const [step, setStep] = useState(0);
     const [data, setData] = useState({});
 
     const steps = args.steps || [];
     const currentStep = steps[step];
 
-    if (status === "complete") {
+    if (status.type === "complete") {
       return <div>Setup complete!</div>;
     }
 
@@ -199,7 +213,7 @@ const WizardToolUI = makeAssistantToolUI({
                     if (step < steps.length - 1) {
                       setStep(step + 1);
                     } else {
-                      submitResult(newData);
+                      addResult(newData);
                     }
                   }}
                   className="w-full p-3 text-left border rounded hover:bg-gray-100"
@@ -230,11 +244,11 @@ const WizardToolUI = makeAssistantToolUI({
 ```tsx
 const RatingToolUI = makeAssistantToolUI({
   toolName: "request_rating",
-  render: ({ args, status, submitResult }) => {
+  render: ({ args, status, addResult }) => {
     const [rating, setRating] = useState(0);
     const [comment, setComment] = useState("");
 
-    if (status === "complete") {
+    if (status.type === "complete") {
       return <div>Thank you for your feedback!</div>;
     }
 
@@ -264,7 +278,7 @@ const RatingToolUI = makeAssistantToolUI({
         />
 
         <button
-          onClick={() => submitResult({ rating, comment })}
+          onClick={() => addResult({ rating, comment })}
           disabled={rating === 0}
           className="px-4 py-2 bg-blue-500 text-white rounded disabled:opacity-50"
         >
@@ -281,16 +295,16 @@ const RatingToolUI = makeAssistantToolUI({
 ```tsx
 const TimedToolUI = makeAssistantToolUI({
   toolName: "timed_action",
-  render: ({ args, status, submitResult }) => {
+  render: ({ args, status, addResult }) => {
     const [timeLeft, setTimeLeft] = useState(args.timeout || 30);
 
     useEffect(() => {
-      if (status !== "requires-action") return;
+      if (status.type !== "requires-action") return;
 
       const timer = setInterval(() => {
         setTimeLeft((t) => {
           if (t <= 1) {
-            submitResult({ timeout: true });
+            addResult({ timeout: true });
             return 0;
           }
           return t - 1;
@@ -298,9 +312,9 @@ const TimedToolUI = makeAssistantToolUI({
       }, 1000);
 
       return () => clearInterval(timer);
-    }, [status, submitResult]);
+    }, [status, addResult]);
 
-    if (status !== "requires-action") {
+    if (status.type !== "requires-action") {
       return <div>Action completed</div>;
     }
 
@@ -311,7 +325,7 @@ const TimedToolUI = makeAssistantToolUI({
           Auto-cancelling in {timeLeft}s
         </p>
         <button
-          onClick={() => submitResult({ confirmed: true })}
+          onClick={() => addResult({ confirmed: true })}
           className="mt-2 px-4 py-2 bg-blue-500 text-white rounded"
         >
           Confirm

--- a/assistant-ui/skills/tools/references/make-tool.md
+++ b/assistant-ui/skills/tools/references/make-tool.md
@@ -22,7 +22,6 @@ const WeatherTool = makeAssistantTool({
   },
 });
 
-// Use in app
 function App() {
   return (
     <AssistantRuntimeProvider runtime={runtime}>
@@ -40,15 +39,18 @@ interface MakeAssistantToolOptions<TArgs, TResult> {
   // Required
   toolName: string;
   parameters: ZodSchema<TArgs>;
-  execute: (args: TArgs, context: ToolContext) => Promise<TResult>;
+  execute: (args: TArgs, context: ToolExecutionContext) => Promise<TResult>;
 
   // Optional
-  description?: string;  // For frontend-only tools
+  description?: string;                     // For frontend-only tools
+  disabled?: boolean;                       // Skip registering the tool
+  render?: ToolCallMessagePartComponent;    // Inline tool UI for this tool
 }
 
-interface ToolContext {
+interface ToolExecutionContext {
   toolCallId: string;
   abortSignal: AbortSignal;
+  human: (payload: unknown) => Promise<unknown>;  // Request human input (HITL)
 }
 ```
 
@@ -61,8 +63,6 @@ import { useAssistantTool } from "@assistant-ui/react";
 import { z } from "zod";
 
 function MyComponent() {
-  // Tool registered when component mounts
-  // Unregistered when component unmounts
   useAssistantTool({
     toolName: "search",
     parameters: z.object({
@@ -128,7 +128,6 @@ const StreamingTool = makeAssistantTool({
 Tools that run entirely in the browser:
 
 ```tsx
-// Copy to clipboard
 const CopyTool = makeAssistantTool({
   toolName: "copy_to_clipboard",
   description: "Copy text to user's clipboard",
@@ -139,7 +138,6 @@ const CopyTool = makeAssistantTool({
   },
 });
 
-// Open URL
 const OpenURLTool = makeAssistantTool({
   toolName: "open_url",
   description: "Open URL in new tab",
@@ -150,7 +148,6 @@ const OpenURLTool = makeAssistantTool({
   },
 });
 
-// Local storage
 const StorageTool = makeAssistantTool({
   toolName: "save_preference",
   parameters: z.object({
@@ -168,7 +165,6 @@ const StorageTool = makeAssistantTool({
 
 ```tsx
 function ConditionalTools({ features }: { features: string[] }) {
-  // Only register tool if feature is enabled
   useAssistantTool({
     toolName: "premium_feature",
     parameters: z.object({ action: z.string() }),
@@ -178,7 +174,7 @@ function ConditionalTools({ features }: { features: string[] }) {
       }
       return performPremiumAction(action);
     },
-    enabled: features.includes("premium"),
+    disabled: !features.includes("premium"),
   });
 
   return <Thread />;

--- a/assistant-ui/skills/tools/references/mcp-server.md
+++ b/assistant-ui/skills/tools/references/mcp-server.md
@@ -1,0 +1,180 @@
+# MCP Server Tools
+
+Connect MCP servers as a server-side tool catalog: create a client in your AI SDK route, spread its tools into `streamText`, and render results with the existing tool-call UI.
+
+## Contents
+
+- [How it works](#how-it-works)
+- [Install](#install)
+- [Connect to a server](#connect-to-a-server)
+- [Wire tools into the route](#wire-tools-into-the-route)
+- [Combine multiple servers](#combine-multiple-servers)
+- [Render results](#render-results)
+- [Notes](#notes)
+
+## How it works
+
+MCP is an open protocol for exposing tools, resources, and prompts to LLMs. One server can publish many tools (file system, GitHub, Slack, your own service). The AI SDK ships a built-in MCP client that lives on the server inside your route handler:
+
+```
+client ──► /api/chat ──► MCP client ──► MCP server (HTTP, SSE, stdio)
+                              │
+                              └─ tools() ──► passed to streamText({ tools })
+```
+
+The client connects to one or more MCP servers, calls `tools()` to get a tool map, and hands that map to `streamText`. assistant-ui's existing tool-call UI (`ToolFallback`, `makeAssistantToolUI`) renders the results.
+
+Note: this is the server-side wiring guide. For a client where the user adds and manages their own MCP servers from the browser, see the react-mcp reference instead.
+
+## Install
+
+```
+npm install @ai-sdk/mcp
+```
+
+For stdio transports (local dev only), also install the official MCP SDK:
+
+```
+npm install @modelcontextprotocol/sdk
+```
+
+## Connect to a server
+
+Set the server URL and any auth token your server requires:
+
+```
+# .env.local
+MCP_SERVER_URL=https://your-mcp-server.example/mcp
+MCP_TOKEN=...
+```
+
+Create the client with the transport that matches your server. HTTP is the production transport; SSE is the legacy streaming transport; stdio spawns a local process and is dev-only.
+
+```ts
+// app/api/chat/route.ts
+import { createMCPClient } from "@ai-sdk/mcp";
+
+const mcpClient = await createMCPClient({
+  transport: {
+    type: "http",
+    url: process.env.MCP_SERVER_URL!,
+    headers: { Authorization: `Bearer ${process.env.MCP_TOKEN}` },
+  },
+});
+```
+
+For stdio:
+
+```ts
+import { createMCPClient } from "@ai-sdk/mcp";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const mcpClient = await createMCPClient({
+  transport: new StdioClientTransport({
+    command: "node",
+    args: ["./mcp-server/dist/index.js"],
+  }),
+});
+```
+
+## Wire tools into the route
+
+`mcpClient.tools()` returns an object shaped exactly like the `tools` argument of `streamText`. Spread it in alongside any of your own tools, and close the client when the response finishes:
+
+```ts
+// app/api/chat/route.ts
+import { createMCPClient } from "@ai-sdk/mcp";
+import { openai } from "@ai-sdk/openai";
+import { streamText, convertToModelMessages } from "ai";
+import type { UIMessage } from "ai";
+
+export const maxDuration = 60;
+
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json();
+
+  const mcpClient = await createMCPClient({
+    transport: {
+      type: "http",
+      url: process.env.MCP_SERVER_URL!,
+      headers: { Authorization: `Bearer ${process.env.MCP_TOKEN}` },
+    },
+  });
+
+  const tools = await mcpClient.tools();
+
+  const result = streamText({
+    model: openai("gpt-5.4-mini"),
+    messages: await convertToModelMessages(messages),
+    tools,
+    onFinish: async () => {
+      await mcpClient.close();
+    },
+  });
+
+  return result.toUIMessageStreamResponse();
+}
+```
+
+`onFinish` is the right place to call `close()`: it fires after the stream completes, so the connection stays open as long as the model is still calling tools.
+
+## Combine multiple servers
+
+Each server has its own client. Spread their tool maps together:
+
+```ts
+const githubClient = await createMCPClient({
+  transport: { type: "http", url: process.env.GITHUB_MCP_URL! },
+});
+const filesClient = await createMCPClient({
+  transport: { type: "http", url: process.env.FILES_MCP_URL! },
+});
+
+const tools = {
+  ...(await githubClient.tools()),
+  ...(await filesClient.tools()),
+};
+// remember to close both in onFinish
+```
+
+If two servers expose tools with the same name, the later spread wins. Rename or scope as needed.
+
+## Render results
+
+Tool calls flow through the existing assistant-ui tool-call rendering. With no setup, the bundled `<ToolFallback>` component renders the call name, arguments, and result. To customize the appearance for a specific tool, use `makeAssistantToolUI`:
+
+```tsx
+// app/components/GitHubIssueToolUI.tsx
+"use client";
+import { makeAssistantToolUI } from "@assistant-ui/react";
+
+type Args = { repo: string; number: number };
+type Result = { title: string; state: string; url: string };
+
+export const GitHubIssueToolUI = makeAssistantToolUI<Args, Result>({
+  toolName: "github_get_issue",
+  render: ({ args, result }) => (
+    <div className="rounded border p-3">
+      <div className="font-mono text-sm">
+        {args.repo}#{args.number}
+      </div>
+      {result && (
+        <a href={result.url} className="underline">
+          {result.title} ({result.state})
+        </a>
+      )}
+    </div>
+  ),
+});
+```
+
+Mount it once anywhere inside `<AssistantRuntimeProvider>`. The `toolName` must match the name your MCP server publishes. The same `makeAssistantToolUI` API ships from `@assistant-ui/react-native` and `@assistant-ui/react-ink` with platform-appropriate primitives.
+
+To verify: trigger a tool call and confirm the call appears with the expected arguments, the result renders (custom `ToolUI` or fallback), and connections do not accumulate. If they do, check `onFinish`.
+
+## Notes
+
+- Server-side only. The MCP client uses Node APIs (sockets, optionally child processes). Never instantiate it in client code.
+- Per-request lifecycle. A fresh client per request keeps connection state simple. For high-throughput servers, pool clients yourself with care: `tools()` assumes the connection is alive when `streamText` runs.
+- Sampling. If your MCP server uses `sampling/createMessage` (lets the server ask the LLM mid-call), assistant-cloud users can instrument it via `instrumentMcpSampling` for observability. This is independent of the wiring above.
+- Transport choice. HTTP for any networked server. SSE only if the server doesn't speak HTTP. stdio is for local development against an MCP server in your monorepo.

--- a/assistant-ui/skills/tools/references/registry-components.md
+++ b/assistant-ui/skills/tools/references/registry-components.md
@@ -1,0 +1,206 @@
+# Registry Renderers for Message Parts
+
+Prebuilt renderers for tool-call and image parts, added through the assistant-ui registry. These are not npm packages; `npx assistant-ui add` copies the component source into your project (under `components/assistant-ui/`), and `@assistant-ui/ui` is registry shorthand for those copied files, not an installable dependency. Types like `ToolCallMessagePartComponent` and `ImageMessagePart` come from `@assistant-ui/react`.
+
+## Contents
+
+- [Adding registry components](#adding-registry-components)
+- [ToolFallback](#toolfallback)
+- [ToolFallback sub-components](#toolfallback-sub-components)
+- [ToolGroup](#toolgroup)
+- [Grouping consecutive tool calls](#grouping-consecutive-tool-calls)
+- [Image](#image)
+- [Image.Actions and image generation](#imageactions-and-image-generation)
+
+## Adding registry components
+
+```bash
+npx assistant-ui add tool-fallback
+npx assistant-ui add tool-group   # also pulls tool-fallback
+npx assistant-ui add image
+```
+
+Each command writes a `.tsx` file into `components/assistant-ui/`. The equivalent shadcn invocation is `npx shadcn@latest add https://r.assistant-ui.com/<name>.json`. After adding, import from your local path (or the `@assistant-ui/ui` alias):
+
+```ts
+import { ToolFallback } from "@/components/assistant-ui/tool-fallback";
+import { ToolGroup } from "@/components/assistant-ui/tool-group";
+import { Image } from "@/components/assistant-ui/image";
+```
+
+## ToolFallback
+
+The default tool-call renderer: a collapsible card showing the tool name, status, arguments, and result. It implements `ToolCallMessagePartComponent`, so its props are the message part itself (`toolName`, `argsText`, `result`, `status`). Spread the part into it.
+
+```tsx
+import { MessagePrimitive } from "@assistant-ui/react";
+import { ToolFallback } from "@/components/assistant-ui/tool-fallback";
+
+<MessagePrimitive.Parts>
+  {({ part }) => {
+    if (part.type === "tool-call") return <ToolFallback {...part} />;
+    return null;
+  }}
+</MessagePrimitive.Parts>
+```
+
+Props (from `ToolCallMessagePartComponent`):
+
+```ts
+{
+  toolName: string;                       // name of the tool called
+  argsText?: string;                      // stringified arguments
+  result?: unknown;                       // execution result, undefined while running
+  status?: ToolCallMessagePartStatus;     // running | complete | incomplete | requires-action
+}
+```
+
+Status `type` drives the visuals: `"running"` shows a spinner and shimmer, `"complete"` a check icon, `"incomplete"` with reason `"cancelled"` a muted/strikethrough `XCircleIcon`, `"requires-action"` an alert icon.
+
+Prefer a tool's own UI when present, falling back to `ToolFallback` otherwise:
+
+```tsx
+{({ part }) => {
+  if (part.type === "tool-call") return part.toolUI ?? <ToolFallback {...part} />;
+  return null;
+}}
+```
+
+## ToolFallback sub-components
+
+`ToolFallback` is composable. Drop the pieces in to customize the layout while keeping the collapse and scroll-lock behavior.
+
+```tsx
+<ToolFallback.Root>
+  <ToolFallback.Trigger toolName="get_weather" status={status} />
+  <ToolFallback.Content>
+    <ToolFallback.Error status={status} />
+    <ToolFallback.Args argsText={argsText} />
+    <ToolFallback.Result result={result} />
+  </ToolFallback.Content>
+</ToolFallback.Root>
+```
+
+| Part | Role |
+|------|------|
+| `ToolFallback.Root` | Collapsible container with scroll lock; accepts `open`, `onOpenChange`, `defaultOpen` |
+| `ToolFallback.Trigger` | Header with tool name, status icon, shimmer |
+| `ToolFallback.Content` | Animated collapsible wrapper |
+| `ToolFallback.Args` | Renders the tool arguments |
+| `ToolFallback.Result` | Renders the execution result |
+| `ToolFallback.Error` | Renders error or cancellation info |
+
+The same parts are available as named exports: `ToolFallbackRoot`, `ToolFallbackTrigger`, `ToolFallbackContent`, `ToolFallbackArgs`, `ToolFallbackResult`, `ToolFallbackError`.
+
+## ToolGroup
+
+Collapses a run of consecutive tool calls into one expandable card. `ToolGroupRoot` wraps the run, `ToolGroupTrigger` shows the count, and `ToolGroupContent` holds the individual renderers.
+
+```ts
+import {
+  ToolGroup, ToolGroupRoot, ToolGroupTrigger, ToolGroupContent, toolGroupVariants,
+} from "@/components/assistant-ui/tool-group";
+```
+
+`ToolGroupRoot` props:
+
+```ts
+{
+  variant?: "outline" | "ghost" | "muted";   // default "outline"
+  open?: boolean;                             // controlled open state
+  onOpenChange?: (open: boolean) => void;
+  defaultOpen?: boolean;                      // default false
+}
+```
+
+`ToolGroupTrigger` props: `count: number` (drives the auto-pluralized `"N tool call(s)"` label) and `active?: boolean` (spinner + shimmer while a call in the group is running).
+
+## Grouping consecutive tool calls
+
+Use `MessagePrimitive.GroupedParts` with `groupPartByType` to fold every `"tool-call"` part into a synthetic `"group-tool"` part. The group exposes `indices` (the grouped part positions) and `status`; render its `children` inside `ToolGroupContent`, and fall back to `ToolFallback` for each `"tool-call"`.
+
+```tsx
+import { MessagePrimitive, groupPartByType } from "@assistant-ui/react";
+import { ToolGroupRoot, ToolGroupTrigger, ToolGroupContent } from "@/components/assistant-ui/tool-group";
+import { ToolFallback } from "@/components/assistant-ui/tool-fallback";
+
+<MessagePrimitive.GroupedParts
+  groupBy={groupPartByType({ "tool-call": ["group-tool"] })}
+>
+  {({ part, children }) => {
+    switch (part.type) {
+      case "group-tool":
+        return (
+          <ToolGroupRoot>
+            <ToolGroupTrigger
+              count={part.indices.length}
+              active={part.status.type === "running"}
+            />
+            <ToolGroupContent>{children}</ToolGroupContent>
+          </ToolGroupRoot>
+        );
+      case "tool-call":
+        return part.toolUI ?? <ToolFallback {...part} />;
+      default:
+        return null;
+    }
+  }}
+</MessagePrimitive.GroupedParts>
+```
+
+Note: a legacy `ToolGroup` wrapper with `startIndex`/`endIndex` props exists only for the deprecated `components.ToolGroup` prop on `MessagePrimitive.Parts`. New code should use `GroupedParts` with `group-tool`.
+
+## Image
+
+Renders an `ImageMessagePart`. It is an `ImageMessagePartComponent`, so spread the part into it. The component branches on `status`: `"running"` shows a spinner, `"incomplete"` with reason `"content-filter"` shows an error card (no `<img>`), and otherwise a zoomable image with an optional filename label.
+
+```tsx
+import { MessagePrimitive } from "@assistant-ui/react";
+import { Image } from "@/components/assistant-ui/image";
+
+<MessagePrimitive.Parts>
+  {({ part }) => {
+    if (part.type === "image") return <Image {...part} />;
+    return null;
+  }}
+</MessagePrimitive.Parts>
+```
+
+`Image.Root` (`ImageRootProps` = `ComponentProps<"div"> & VariantProps<typeof imageVariants>`) accepts:
+
+- `variant`: `"outline"` (default, border) | `"ghost"` (no border) | `"muted"` (background fill)
+- `size`: `"sm"` (`max-w-64`) | `"default"` (`max-w-96`) | `"lg"` (`max-w-[512px]`) | `"full"` (`w-full`)
+
+Sub-components and named exports: `Image.Root` / `ImageRoot`, `Image.Preview` / `ImagePreview`, `Image.Filename` / `ImageFilename`, `Image.Zoom` / `ImageZoom`, `Image.Actions` / `ImageActions`, `Image.Generating` / `ImageGenerating`, `Image.ContentFilterError` / `ImageContentFilterError`, plus `imageVariants`.
+
+## Image.Actions and image generation
+
+Generate images in a backend route with the AI SDK, then render the resulting data URL as an `ImageMessagePart`. Keep the part minimal: only `type` and `image` (a `data:`, `https://`, or `blob:` URL). Provenance like the prompt belongs in component state or message metadata, not the part.
+
+```ts
+// app/api/image/route.ts
+import { generateImage } from "ai";
+import { openai } from "@ai-sdk/openai";
+
+export async function POST(req: Request) {
+  const { prompt } = await req.json();
+  const result = await generateImage({ model: openai.image("gpt-image-1"), prompt });
+  return Response.json({
+    image: `data:${result.image.mediaType};base64,${result.image.base64}`,
+  });
+}
+```
+
+```tsx
+import { Image } from "@/components/assistant-ui/image";
+import type { ImageMessagePart } from "@assistant-ui/react";
+
+const imagePart: ImageMessagePart = { type: "image", image: result.image };
+
+<>
+  <Image {...imagePart} />
+  <Image.Actions part={imagePart} onRegenerate={() => regenerate(prompt)} />
+</>
+```
+
+`Image.Actions` (`ImageActionsProps`) renders download, copy, and an optional regenerate button. It takes `part: ImageMessagePart`, an optional `onRegenerate?: () => void | Promise<void>` (the regenerate button only appears when supplied), and an optional `className`. A full Next.js example lives at `examples/with-image-generation` in the assistant-ui repository.

--- a/assistant-ui/skills/tools/references/tool-ui.md
+++ b/assistant-ui/skills/tools/references/tool-ui.md
@@ -12,7 +12,7 @@ import { makeAssistantToolUI } from "@assistant-ui/react";
 const WeatherToolUI = makeAssistantToolUI({
   toolName: "get_weather",
   render: ({ args, result, status }) => {
-    if (status === "running") {
+    if (status.type === "running") {
       return <div className="animate-pulse">Loading weather...</div>;
     }
 
@@ -29,7 +29,6 @@ const WeatherToolUI = makeAssistantToolUI({
   },
 });
 
-// Register in app
 <AssistantRuntimeProvider runtime={runtime}>
   <WeatherToolUI />
   <Thread />
@@ -38,31 +37,37 @@ const WeatherToolUI = makeAssistantToolUI({
 
 ## Render Props
 
+The render component receives `ToolCallMessagePartProps`:
+
 ```tsx
-interface ToolUIRenderProps {
-  // Tool call identification
+interface ToolCallMessagePartProps {
   toolCallId: string;
   toolName: string;
 
-  // Arguments
   args: Record<string, unknown>;
-  argsText: string;  // Raw JSON string
+  argsText: string;  // Raw streamed JSON string
 
   // Result (undefined while running)
   result?: unknown;
+  isError?: boolean;
+  artifact?: unknown;  // UI-only artifact attached to the result
 
-  // Status
-  status: ToolCallStatus;
+  // Status is an OBJECT, not a string. Branch on status.type.
+  status: ToolCallMessagePartStatus;
 
-  // For interactive tools
-  submitResult: (result: unknown) => void;
+  // Supply a result from the renderer (instead of a tool execute function)
+  addResult: (result: unknown) => void;
+  // Resume a frontend tool paused via context.human(...)
+  resume: (payload: unknown) => void;
+  // Respond to a server-side approval gate
+  respondToApproval: (response: { approved: boolean; reason?: string }) => void;
 }
 
-type ToolCallStatus =
-  | "running"         // Tool executing
-  | "complete"        // Finished successfully
-  | "incomplete"      // Stopped early (cancelled)
-  | "requires-action" // Waiting for user input
+type ToolCallMessagePartStatus =
+  | { type: "running" }       // Tool executing
+  | { type: "complete" }      // Finished successfully
+  | { type: "incomplete"; reason: "cancelled" | "length" | "content-filter" | "other" | "error" }
+  | { type: "requires-action"; reason: "interrupt" };  // Waiting for input
 ```
 
 ## useAssistantToolUI
@@ -90,7 +95,7 @@ function DynamicToolUI({ toolConfig }) {
 const ComprehensiveToolUI = makeAssistantToolUI({
   toolName: "process_data",
   render: ({ args, result, status }) => {
-    switch (status) {
+    switch (status.type) {
       case "running":
         return (
           <div className="flex items-center gap-2">
@@ -136,15 +141,13 @@ const SearchToolUI = makeAssistantToolUI({
   toolName: "search",
   render: ({ args, result, status }) => (
     <div className="my-4 border rounded-lg overflow-hidden">
-      {/* Header */}
       <div className="px-4 py-2 bg-gray-100 border-b flex items-center gap-2">
         <SearchIcon className="w-4 h-4" />
         <span className="font-medium">Search: {args.query}</span>
       </div>
 
-      {/* Body */}
       <div className="p-4">
-        {status === "running" && (
+        {status.type === "running" && (
           <div className="space-y-2">
             {[1, 2, 3].map((i) => (
               <div key={i} className="h-16 bg-gray-100 animate-pulse rounded" />
@@ -152,7 +155,7 @@ const SearchToolUI = makeAssistantToolUI({
           </div>
         )}
 
-        {status === "complete" && result?.results && (
+        {status.type === "complete" && result?.results && (
           <div className="space-y-3">
             {result.results.map((item: any) => (
               <a
@@ -177,7 +180,9 @@ const SearchToolUI = makeAssistantToolUI({
 
 ## Generative UI
 
-Dynamic component rendering:
+For assistant-ui's declarative generative UI system (`MessagePrimitive.GenerativeUI` + the `render_gui` tool and `parseRenderGuiResult`), see [./generative-ui.md](./generative-ui.md).
+
+You can also map a tool's result to a component yourself with `makeAssistantToolUI`. The tool name below (`render_widget`) is your own, not a built-in:
 
 ```tsx
 import { Chart, Table, Form, Card } from "./components";
@@ -189,8 +194,8 @@ const componentMap: Record<string, React.ComponentType<any>> = {
   card: Card,
 };
 
-const GenerativeUI = makeAssistantToolUI({
-  toolName: "render_ui",
+const WidgetToolUI = makeAssistantToolUI({
+  toolName: "render_widget",
   render: ({ args, result }) => {
     const Component = componentMap[args.type];
 
@@ -237,21 +242,19 @@ function ToolUIWithState() {
 }
 ```
 
-## Accessing Parent Context
+## Tool Call Metadata
+
+The render props already carry the tool call metadata (`toolCallId`, `toolName`, `status`, `args`, `result`), so no extra context hook is needed:
 
 ```tsx
-import { useToolCallContext } from "@assistant-ui/react";
-
-// Inside custom components
-function ToolCallMetadata() {
-  const { toolCallId, toolName, status } = useToolCallContext();
-
-  return (
+const MetadataToolUI = makeAssistantToolUI({
+  toolName: "process_data",
+  render: ({ toolCallId, toolName, status }) => (
     <div className="text-xs text-gray-500">
-      {toolName} ({toolCallId.slice(0, 8)}) - {status}
+      {toolName} ({toolCallId.slice(0, 8)}) - {status.type}
     </div>
-  );
-}
+  ),
+});
 ```
 
 ## Multiple Tools

--- a/assistant-ui/skills/tools/references/toolkits.md
+++ b/assistant-ui/skills/tools/references/toolkits.md
@@ -1,0 +1,184 @@
+# Toolkits
+
+Declare a group of tools as a plain object and mount them with the `<Tools />` component.
+
+## Contents
+
+- [Toolkit type](#toolkit-type)
+- [ToolDefinition fields](#tooldefinition-fields)
+- [Mounting with Tools](#mounting-with-tools)
+- [Carrying render per tool](#carrying-render-per-tool)
+- [The tool helper](#the-tool-helper)
+- [mcpApp prop](#mcpapp-prop)
+- [Toolkit vs component tools](#toolkit-vs-component-tools)
+
+## Toolkit type
+
+A `Toolkit` is a record mapping tool name to definition. Write the object literal with `satisfies Toolkit` so each entry stays strongly typed while the keys remain known tool names.
+
+```tsx
+import type { Toolkit } from "@assistant-ui/react";
+
+type Toolkit = Record<string, ToolDefinition<any, any>>;
+```
+
+```tsx
+import type { Toolkit } from "@assistant-ui/react";
+
+const toolkit = {
+  get_weather: {
+    type: "frontend",
+    description: "Get the weather for a city.",
+    parameters: weatherSchema,
+    execute: async ({ city }: { city: string }) => fetchWeather(city),
+    render: WeatherToolUI,
+  },
+} satisfies Toolkit;
+```
+
+The object keys (`get_weather`) become the tool names the model receives and uses in tool calls.
+
+## ToolDefinition fields
+
+`ToolDefinition<TArgs, TResult>` carries the model-facing schema, the executor, and an optional renderer.
+
+```tsx
+interface ToolDefinition<TArgs, TResult> {
+  type: "frontend";                          // browser-executed tool
+  description?: string;                       // model-visible description
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;                         // hides the tool from the model when true
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
+  display?: ToolDisplay;                       // "inline" (default) or "standalone"
+  render?: ToolCallMessagePartComponent<TArgs, TResult>;
+}
+```
+
+Note: `render` is required for frontend and human tools that need a UI; tools that only run logic can omit it.
+
+## Mounting with Tools
+
+Mount `<Tools />` near an assistant subtree. Tool definitions register with model context; renderers register with the tools scope for message rendering.
+
+```tsx
+import { Tools } from "@assistant-ui/react";
+
+function App() {
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Tools toolkit={toolkit} />
+      <Thread />
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `toolkit` | `Toolkit` | Tools and optional renderers to install |
+| `mcpApp` | `ResourceElement<McpAppResourceOutput>` | MCP app whose tools merge into context |
+
+## Carrying render per tool
+
+Each definition can attach its own renderer through `render`. The component receives `args`, `result`, `status`, and `addResult`.
+
+```tsx
+import { tool } from "@assistant-ui/react";
+
+const weatherSchema = {
+  type: "object",
+  properties: { city: { type: "string" } },
+  required: ["city"],
+} as const;
+
+const toolkit = {
+  get_weather: tool<{ city: string }, WeatherResult>({
+    type: "frontend",
+    description: "Get the weather for a city.",
+    parameters: weatherSchema,
+    execute: async ({ city }) => fetchWeather(city),
+    render: ({ args, result, status }) => {
+      if (status.type !== "complete") return <div>Loading {args.city}...</div>;
+      return <div>{result.temperature}° in {args.city}</div>;
+    },
+  }),
+
+  confirm_action: tool<{ message: string }, { confirmed: boolean }>({
+    type: "frontend",
+    description: "Ask the user to confirm an action.",
+    parameters: {
+      type: "object",
+      properties: { message: { type: "string" } },
+      required: ["message"],
+    },
+    render: ({ args, status, addResult }) => {
+      if (status.type !== "requires-action") return <div>Done.</div>;
+      return (
+        <div>
+          <p>{args.message}</p>
+          <button onClick={() => addResult({ confirmed: true })}>Yes</button>
+          <button onClick={() => addResult({ confirmed: false })}>No</button>
+        </div>
+      );
+    },
+  }),
+} satisfies Toolkit;
+```
+
+## The tool helper
+
+`tool` defines a single typed model tool. It accepts the same fields as a `ToolDefinition` and returns one, so it slots directly into a toolkit literal while giving you inferred `args` and `result` types inside `execute` and `render`.
+
+```tsx
+import { tool } from "@assistant-ui/react";
+
+const getWeather = tool<{ city: string }, string>({
+  type: "frontend",
+  description: "Get the weather for a city.",
+  parameters: {
+    type: "object",
+    properties: { city: { type: "string" } },
+    required: ["city"],
+  },
+  execute: async ({ city }) => `Sunny in ${city}`,
+});
+
+const toolkit = { get_weather: getWeather } satisfies Toolkit;
+```
+
+## mcpApp prop
+
+`<Tools mcpApp={...} />` merges the tools of an MCP app into the same context. Build the resource element with `McpAppRenderer` and a host such as `McpAppsRemoteHost`.
+
+```tsx
+import {
+  Tools,
+  McpAppRenderer,
+  McpAppsRemoteHost,
+} from "@assistant-ui/react";
+
+function App() {
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Tools
+        toolkit={toolkit}
+        mcpApp={McpAppRenderer({
+          host: McpAppsRemoteHost({ url: "/api/mcp-apps" }),
+          hostInfo: { name: "my-app", version: "1.0.0" },
+          hostContext: { theme: "light" },
+        })}
+      />
+      <Thread />
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+The renderer activates for any tool-call part whose metadata carries a `ui://`-scheme resource URI. Per-tool renderers (the `render` field on a definition) take precedence over this fallback.
+
+## Toolkit vs component tools
+
+Use a toolkit and `<Tools />` when tool availability should follow the runtime or provider tree rather than a specific component's mount state. Reach for component tools (`makeAssistantTool`, `useAssistantTool`) when a tool should register and unregister with one component's lifecycle.

--- a/assistant-ui/skills/update/SKILL.md
+++ b/assistant-ui/skills/update/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: update
-description: Update assistant-ui and AI SDK to latest versions. Detects current versions, identifies breaking changes, and executes migrations.
-version: 0.0.1
+description: "Upgrades an existing assistant-ui project to current releases and executes the resulting migrations. Use when the user wants to update, upgrade, bump, or migrate @assistant-ui/react, @assistant-ui/react-ai-sdk, ai, or @ai-sdk/react, hits peer-dependency conflicts or post-upgrade type errors, or must apply renamed APIs after a version jump. Detects installed versus latest versions via npm ls / npm view, then routes through breaking-change references for each jump (AI SDK v4/v5 to v6; assistant-ui 0.8.x to 0.14.x): useAssistantApi to useAui, runtime.threadList to runtime.threads, ThreadPrimitive.ViewportSlack removal, the primitives components prop to children render functions, toDataStreamResponse to toUIMessageStreamResponse, maxSteps to stopWhen: stepCountIs(n). Runs npx assistant-ui@latest upgrade, pnpm/npm add @latest, and npx tsc --noEmit to verify. For a first-time install or fresh scaffold (not an upgrade) use setup instead."
 license: MIT
 ---
 
@@ -20,10 +19,8 @@ license: MIT
 ### Get Ground Truth
 
 ```bash
-# Installed versions
 npm ls @assistant-ui/react @assistant-ui/react-ai-sdk ai @ai-sdk/react 2>/dev/null
 
-# Latest from npm
 npm view @assistant-ui/react version
 npm view @assistant-ui/react-ai-sdk version
 npm view ai version
@@ -31,13 +28,17 @@ npm view ai version
 
 ### Version Analysis
 
+Current latest: `@assistant-ui/react` 0.14.x, `@assistant-ui/react-ai-sdk` 1.3.x, `assistant-stream` 0.3.x.
+
 | Package | Check For |
 |---------|-----------|
 | `ai` | < 6.0.0 → needs AI SDK v6 migration |
-| `@assistant-ui/react` | < 0.12.0 → needs unified state API migration |
-| `@assistant-ui/react` | < 0.11.0 → needs runtime migration |
-| `@assistant-ui/react` | < 0.10.0 → needs ESM migration |
-| `@assistant-ui/react` | < 0.8.0 → needs UI split migration |
+| `@assistant-ui/react` | < 0.14.0 → primitives `components` prop replaced by children render functions; deprecated hooks/aliases removed |
+| `@assistant-ui/react` | < 0.13.0 → `ThreadPrimitive.ViewportSlack` removed (top-anchor changes) |
+| `@assistant-ui/react` | < 0.12.0 → unified state API (`useAui`/`useAuiState`/`useAuiEvent`/`AuiIf`) |
+| `@assistant-ui/react` | < 0.11.0 → runtime rearchitecture |
+| `@assistant-ui/react` | < 0.10.0 → ESM only |
+| `@assistant-ui/react` | < 0.8.0 → UI split (shadcn registry) |
 | `@assistant-ui/react-ai-sdk` | < 1.0.0 → needs AI SDK v6 first |
 
 ## Phase 2: Route to Migration
@@ -62,10 +63,8 @@ AI SDK < 6.0.0?
 ### Update Packages
 
 ```bash
-# pnpm
 pnpm add @assistant-ui/react@latest @assistant-ui/react-ai-sdk@latest ai@latest @ai-sdk/react@latest
 
-# npm
 npm install @assistant-ui/react@latest @assistant-ui/react-ai-sdk@latest ai@latest @ai-sdk/react@latest
 ```
 
@@ -76,8 +75,8 @@ Based on version jump, apply relevant migrations from references.
 ### Verify
 
 ```bash
-npx tsc --noEmit  # Type check
-pnpm build        # Build check
+npx tsc --noEmit
+pnpm build
 ```
 
 ## Troubleshooting

--- a/assistant-ui/skills/update/references/ai-sdk-v6.md
+++ b/assistant-ui/skills/update/references/ai-sdk-v6.md
@@ -8,6 +8,32 @@ Migrate a codebase from AI SDK v4 or v5 to v6. This is a methodical, careful pro
 
 ---
 
+## Contents
+
+- [Critical Rules](#critical-rules)
+- [Phase 1: Deep Research (Use Agents)](#phase-1-deep-research-use-agents)
+- [Phase 2: Create Detailed Migration Plan](#phase-2-create-detailed-migration-plan)
+- [Phase 3: Execute Migration](#phase-3-execute-migration)
+- [Phase 4: Build Verification](#phase-4-build-verification)
+- [Phase 5: Test Verification](#phase-5-test-verification)
+- [Phase 6: Final Verification](#phase-6-final-verification)
+- [Rollback Plan](#rollback-plan)
+- [Package Updates](#package-updates)
+- [Automated Migration](#automated-migration)
+- [Core Breaking Changes](#core-breaking-changes)
+- [UI & React Changes](#ui--react-changes)
+- [Tool System Changes](#tool-system-changes)
+- [Streaming Architecture](#streaming-architecture)
+- [Structured Output Changes](#structured-output-changes)
+- [Provider-Specific Changes](#provider-specific-changes)
+- [assistant-ui Specific Changes](#assistant-ui-specific-changes)
+- [Complete Migration Examples](#complete-migration-examples)
+- [Environment Configuration](#environment-configuration)
+- [Test Utilities](#test-utilities)
+- [New Utilities in v6](#new-utilities-in-v6)
+- [v4-Specific Changes (v4 → v6 Direct Migration)](#v4-specific-changes-v4--v6-direct-migration)
+- [Migration Checklist](#migration-checklist)
+
 ## Critical Rules
 
 1. **NEVER make changes without reading files first** - Always read the full file before editing
@@ -383,8 +409,8 @@ Then re-analyze what went wrong before retrying.
   "@ai-sdk/react": "^3.0.0",
   "@ai-sdk/provider": "^3.0.0",
   "@ai-sdk/provider-utils": "^4.0.0",
-  "@assistant-ui/react": "^0.12.14",
-  "@assistant-ui/react-ai-sdk": "^1.3.10"
+  "@assistant-ui/react": "^0.14.13",
+  "@assistant-ui/react-ai-sdk": "^1.3.31"
 }
 ```
 
@@ -708,7 +734,6 @@ type MessagePart =
 ### 3. Reading Text from Messages
 
 ```typescript
-// Extract text content from UIMessage
 const extractText = (messages: UIMessage[]): string => {
   return messages
     .map((m) =>
@@ -966,7 +991,6 @@ type ToolInvocationState =
   | "output-available"  // Execution complete with result
   | "output-error";     // Execution failed
 
-// Access in message parts:
 message.parts.forEach(part => {
   if (isToolUIPart(part)) {
     console.log(part.state);       // One of the above states
@@ -1020,10 +1044,8 @@ const dangerousTool = tool({
 // Client: Handle approval
 const { addToolApprovalResponse } = useChat();
 
-// User approves
 addToolApprovalResponse({ toolCallId, approved: true });
 
-// User denies
 addToolApprovalResponse({ toolCallId, approved: false });
 ```
 
@@ -1034,7 +1056,6 @@ When forwarding tools defined in the frontend to your backend:
 ```typescript
 import { frontendTools } from "@assistant-ui/react-ai-sdk";
 
-// In API route
 export async function POST(req: Request) {
   const { messages, tools } = await req.json();
 
@@ -1042,9 +1063,7 @@ export async function POST(req: Request) {
     model: openai("gpt-4o"),
     messages: await convertToModelMessages(messages),
     tools: {
-      // Wrap frontend tools
       ...frontendTools(tools),
-      // Add backend-only tools
       myBackendTool: tool({ /* ... */ }),
     },
   });
@@ -1586,9 +1605,7 @@ export async function POST(req: Request) {
     messages: await convertToModelMessages(messages),
     stopWhen: stepCountIs(10),
     tools: {
-      // Frontend tools forwarded from client
       ...frontendTools(clientTools ?? {}),
-      // Backend-only tools
       search_database: tool({
         description: "Search the database",
         inputSchema: zodSchema(
@@ -1674,7 +1691,7 @@ function WeatherTool() {
       return response.json();
     },
     render: ({ args, result, status }) => {
-      if (status === "running") return <div>Loading weather...</div>;
+      if (status.type === "running") return <div>Loading weather...</div>;
       if (result) return <WeatherCard data={result} />;
       return null;
     },
@@ -1855,8 +1872,8 @@ npx @ai-sdk/codemod v6       # v5→v6 only
 - [ ] Update `@ai-sdk/provider-utils` to `^4.0.0`
 - [ ] Update all `@ai-sdk/*` provider packages to `^3.0.0`
 - [ ] Update `zod` to `^3.25.76` or `^4.1.8` (both supported)
-- [ ] Update `@assistant-ui/react` to `^0.12.14`
-- [ ] Update `@assistant-ui/react-ai-sdk` to `^1.3.10`
+- [ ] Update `@assistant-ui/react` to `^0.14.13`
+- [ ] Update `@assistant-ui/react-ai-sdk` to `^1.3.31`
 - [ ] If using MCP: Install `@ai-sdk/mcp` to `^1.0.0`
 
 ### Automated Migration

--- a/assistant-ui/skills/update/references/assistant-ui.md
+++ b/assistant-ui/skills/update/references/assistant-ui.md
@@ -2,12 +2,156 @@
 
 Migrations for upgrading between assistant-ui versions.
 
+## Contents
+
+- [Version Detection](#version-detection)
+- [Migration: → 0.14.x (Children API, deprecated removals)](#migration--014x-children-api-deprecated-removals)
+- [Migration: → 0.13.x (Top-turn anchoring)](#migration--013x-top-turn-anchoring)
+- [Migration: → 0.12.x (Unified State API)](#migration--012x-unified-state-api)
+- [Migration: → 0.11.x (Runtime Rearchitecture)](#migration--011x-runtime-rearchitecture)
+- [Migration: → 0.10.x (ESM Only)](#migration--010x-esm-only)
+- [Migration: → 0.9.x (Edge Split)](#migration--09x-edge-split)
+- [Migration: → 0.8.x (UI Split)](#migration--08x-ui-split)
+- [Migration: → 0.7.x (Thread API)](#migration--07x-thread-api)
+- [Migration: → 0.5.x (Runtime API)](#migration--05x-runtime-api)
+- [Migration: → 0.4.x (Message Types)](#migration--04x-message-types)
+- [Migration: → 0.3.x](#migration--03x)
+- [Migration: → 0.2.x](#migration--02x)
+- [Automated Search Commands](#automated-search-commands)
+- [Verification](#verification)
+
 ## Version Detection
 
 ```bash
 npm ls @assistant-ui/react
 npm view @assistant-ui/react version  # Latest
 ```
+
+## Migration: → 0.14.x (Children API, deprecated removals)
+
+### From 0.13.x
+
+Two themes: APIs deprecated in v0.11/v0.12 are removed, and list primitives move from a `components` prop to a children render function.
+
+**Automatic migration (hook renames):**
+```bash
+npx assistant-ui@latest upgrade
+```
+
+**Removed hook/adapter aliases (find-and-replace):**
+
+| Removed | Replacement |
+|---------|-------------|
+| `useAssistantApi` | `useAui` |
+| `useAssistantState` | `useAuiState` |
+| `useAssistantEvent` | `useAuiEvent` |
+| `AssistantIf` | `AuiIf` |
+| `useLocalThreadRuntime` | `useLocalRuntime` |
+| `unstable_useRemoteThreadListRuntime` | `useRemoteThreadListRuntime` |
+| `unstable_useCloudThreadListAdapter` | `useCloudThreadListAdapter` |
+| `unstable_RemoteThreadListAdapter` | `RemoteThreadListAdapter` |
+| `unstable_InMemoryThreadListAdapter` | `InMemoryThreadListAdapter` |
+
+**Runtime API cleanups:**
+
+```diff
+- runtime.threadList
++ runtime.threads
+
+- runtime.switchToThread(id)
++ runtime.threads.switchToThread(id)
+
+- runtime.registerModelConfigProvider(p)
++ runtime.registerModelContextProvider(p)
+
+- runtime.reset({ initialMessages })
++ runtime.thread.reset(initialMessages)
+
+- thread.startRun(parentId)
++ thread.startRun({ parentId })
+
+- thread.unstable_resumeRun(config)
++ thread.resumeRun(config)
+
+- thread.unstable_loadExternalState(state)
++ thread.importExternalState(state)
+
+- thread.getModelConfig()
++ thread.getModelContext()
+```
+
+**Custom `ChatModelAdapter`:** `options.config` removed, use `options.context`.
+
+```diff
+- async run({ messages, config }) { /* config.tools, config.config, ... */ }
++ async run({ messages, context }) { /* context.tools, context.config, ... */ }
+```
+
+**State and helpers:**
+
+```diff
+- useAuiState((s) => s.message.submittedFeedback)
++ useAuiState((s) => s.message.metadata.submittedFeedback)
+
+- const original = getExternalStoreMessage(threadMessage)
++ const [original] = getExternalStoreMessages(threadMessage)
+
+- import { toAISDKTools } from "@assistant-ui/react"
++ import { toToolsJSONSchema } from "assistant-stream"
+```
+
+**react-langgraph:** `useLangGraphRuntime`'s `onSwitchToThread` removed, use `load`.
+
+**Children render functions** (the `components` prop still works but is deprecated):
+
+```diff
+- <ThreadPrimitive.Messages components={{ UserMessage, AssistantMessage, EditComposer }} />
++ <ThreadPrimitive.Messages>
++   {({ message }) => {
++     if (message.composer.isEditing) return <EditComposer />;
++     if (message.role === "user") return <UserMessage />;
++     return <AssistantMessage />;
++   }}
++ </ThreadPrimitive.Messages>
+
+- <MessagePrimitive.Parts components={{ Text, tools: { Fallback: ToolFallback } }} />
++ <MessagePrimitive.Parts>
++   {({ part }) => {
++     if (part.type === "text") return <MarkdownText />;
++     if (part.type === "tool-call") return part.toolUI ?? <ToolFallback {...part} />;
++     return null;
++   }}
++ </MessagePrimitive.Parts>
+```
+
+The same change applies to `ThreadPrimitive.Suggestions`, `ThreadListPrimitive.Items`, and `ComposerPrimitive.Attachments`. Returning `null` from the render function still renders registered tool/data UIs; return `<></>` to render nothing.
+
+**Search for removed patterns:**
+```bash
+grep -rn "useAssistantApi\|useAssistantState\|useAssistantEvent\|AssistantIf\|unstable_useRemoteThreadListRuntime\|unstable_InMemoryThreadListAdapter\|getExternalStoreMessage\b\|toAISDKTools\|getModelConfig\|onSwitchToThread" --include="*.tsx" --include="*.ts"
+```
+
+---
+
+## Migration: → 0.13.x (Top-turn anchoring)
+
+### From 0.12.x
+
+`ThreadPrimitive.ViewportSlack` was removed; top-anchor registration is now automatic on `MessagePrimitive.Root` when `turnAnchor="top"`. Replace `fillClampThreshold` / `fillClampOffset` with `topAnchorMessageClamp` on `ThreadPrimitive.Viewport`:
+
+```diff
+- <ThreadPrimitive.ViewportSlack fillClampThreshold="10em" fillClampOffset="6em">
+-   ...
+- </ThreadPrimitive.ViewportSlack>
++ <ThreadPrimitive.Viewport
++   turnAnchor="top"
++   topAnchorMessageClamp={{ tallerThan: "10em", visibleHeight: "6em" }}
++ >
++   ...
++ </ThreadPrimitive.Viewport>
+```
+
+---
 
 ## Migration: → 0.12.x (Unified State API)
 
@@ -20,7 +164,7 @@ Unified state API replaces individual context hooks.
 npx assistant-ui@latest upgrade
 ```
 
-**Assistant API hooks renamed (deprecated until v0.13):**
+**Assistant API hooks renamed (the old names were removed in v0.14):**
 
 ```diff
 - import { useAssistantApi, useAssistantState, useAssistantEvent, AssistantIf } from "@assistant-ui/react";
@@ -90,7 +234,7 @@ Unchanged: `thread.initialize`, `composer.send`.
 - `"ctrlEnter"` — submit on Ctrl/Cmd+Enter, plain Enter for newlines
 - `"none"` — disable keyboard submission
 
-**Zod 4 required** — `@assistant-ui/react-ai-sdk` 1.3.x requires `zod@^4.3.6`
+**Zod**: AI SDK v6 (used by `@assistant-ui/react-ai-sdk` 1.3.x) requires `zod@^3.25.76 || ^4.1.8`; both Zod 3.25+ and Zod 4 work.
 
 **New primitives:**
 - `ChainOfThoughtPrimitive` (0.12.8)
@@ -125,12 +269,10 @@ import {
 const messages = useAssistantState(s => s.thread.messages);
 const isRunning = useAssistantState(s => s.thread.isRunning);
 
-// Actions
 const api = useAssistantApi();
 api.thread().append({ role: "user", content: [{ type: "text", text: "Hello" }] });
 api.thread().cancelRun();
 
-// Events
 useAssistantEvent("composer.send", (e) => {
   console.log("Message sent:", e.messageId);
 });

--- a/assistant-ui/skills/update/references/breaking-changes.md
+++ b/assistant-ui/skills/update/references/breaking-changes.md
@@ -6,7 +6,10 @@ Fast lookup for breaking changes by version.
 
 | Version | Breaking Change | Migration |
 |---------|-----------------|-----------|
-| **0.11.0** | Runtime rearchitecture | Use `useAui`, `useAuiState`, `useAuiEvent` |
+| **0.14.0** | `components` prop → children render functions; deprecated hooks/aliases removed | Children render functions; `useAui`/`useAuiState`/`useAuiEvent`/`AuiIf`; drop `unstable_` prefixes |
+| **0.13.0** | `ThreadPrimitive.ViewportSlack` removed | Use `topAnchorMessageClamp` on `ThreadPrimitive.Viewport` |
+| **0.12.0** | Unified state API | Use `useAui`, `useAuiState`, `useAuiEvent`, `AuiIf` |
+| **0.11.0** | Runtime rearchitecture | Use `useAssistantApi`/`useAssistantState` (renamed to `useAui`/`useAuiState` in 0.12) |
 | **0.10.0** | CommonJS dropped | Use ESM, set `"type": "module"` |
 | **0.8.18** | `setResult`/`setArtifact` merged | Use `setResponse({ result, artifact })` |
 | **0.8.0** | UI moved out of core | Use shadcn registry (recommended) or primitives |
@@ -100,10 +103,13 @@ See [./ai-sdk-v6.md](./ai-sdk-v6.md) for AI SDK specific migrations:
 
 ## Version Compatibility
 
+Current latest: `@assistant-ui/react` 0.14.x, `@assistant-ui/react-ai-sdk` 1.3.x.
+
 | @assistant-ui/react | react-ai-sdk | AI SDK | Zod |
 |---------------------|--------------|--------|-----|
-| 0.12.x | 1.3.x | 6.x | 4.x |
+| 0.14.x | 1.3.x | 6.x | 3.25+ or 4.x |
+| 0.12.x to 0.13.x | 1.3.x | 6.x | 3.25+ or 4.x |
 | 0.11.x | 1.2.x | 6.x | 3.25+ or 4.x |
-| 0.10.x | 0.x | 4.x-5.x | 3.x |
-| 0.8.x-0.9.x | 0.x | 4.x | 3.x |
+| 0.10.x | 0.x | 4.x to 5.x | 3.x |
+| 0.8.x to 0.9.x | 0.x | 4.x | 3.x |
 | < 0.8.0 | 0.x | 4.x | 3.x |


### PR DESCRIPTION
## summary

- update every skill to assistant-ui 0.14: tool-call `status` is now an object (`status.type`), `addResult` replaces `submitResult`, primitives use children render functions instead of the `components` prop, the `unstable_` thread-list prefixes are dropped, and the LangGraph and A2A runtime references are rewritten to the current API.
- add 4 new skills: `copilots` (instructions, context, makeAssistantVisible, interactables), `markdown` (MarkdownTextPrimitive, syntax highlighting, LaTeX, Mermaid, Streamdown), `observability` (Langfuse, LangSmith, Helicone, react-o11y), and `react-mcp` (user-managed MCP server UIs).
- add 19 new reference sections across the existing skills (runtime adapters and voice; tools toolkits, MCP, generative UI; setup framework runtimes and registry components; streaming resumable; cloud custom persistence and auth), and refresh the update skill migration guide to 0.13 and 0.14.
- conform every SKILL.md to the agent skills spec: trigger-style descriptions under 1024 chars, drop the non-spec `version` field, add tables of contents to long references, and trim restating comments plus cross-file duplication.

no test plan, documentation-only skills repo

## notes

- examples and API names were checked against the assistant-ui 0.14 source (`@assistant-ui/react` 0.14.13, `@assistant-ui/react-ai-sdk` 1.3.31, `assistant-stream` 0.3.19) and the live docs; all reference links resolve and the frontmatter validates against the agent skills spec.