### PR TITLE
feat: update skills for assistant-ui 0.15 and AI SDK v7

### DIFF
--- a/assistant-ui/skills/assistant-ui/SKILL.md
+++ b/assistant-ui/skills/assistant-ui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assistant-ui
-description: "Overview and router for assistant-ui, the React library for building AI chat interfaces from composable primitives. Use for high-level, cross-cutting, or architecture-overview questions: choosing packages, picking a runtime, or understanding the layered model (RuntimeCore, Runtime, context hooks, primitives) and message model. Covers the `@assistant-ui/react` core plus `@assistant-ui/react-ai-sdk`, `@assistant-ui/react-langgraph`, `assistant-stream`, and `assistant-cloud`; `AssistantRuntimeProvider`; the primitives `ThreadPrimitive`, `MessagePrimitive`, `ComposerPrimitive`; the hooks `useAui`, `useAuiState`, `useAuiEvent`; and runtime selection across `useChatRuntime`, `useExternalStoreRuntime`, `useLangGraphRuntime`, `useLocalRuntime`. For a specific area route to a focused sibling instead: setup, runtime, primitives, tools, streaming, cloud, thread-list, or update. Not for hands-on tasks already owned by those siblings."
+description: "Overview and router for assistant-ui, the React library for building AI chat interfaces from composable primitives. Use for high-level, cross-cutting, or architecture-overview questions: choosing packages, picking a runtime, or understanding the layered model (RuntimeCore, Runtime, the aui client, primitives) and message model. Covers the `@assistant-ui/react` core plus `@assistant-ui/react-ai-sdk`, `@assistant-ui/react-langchain`, `@assistant-ui/react-langgraph`, `assistant-stream`, and `assistant-cloud`, and the platform bindings `@assistant-ui/react-native` and `@assistant-ui/react-ink`; `AssistantRuntimeProvider`; the primitives `ThreadPrimitive`, `MessagePrimitive`, `ComposerPrimitive`; the hooks `useAui`, `useAuiState`, `useAuiEvent`; and runtime selection across `useChatRuntime`, `useExternalStoreRuntime`, `useLangGraphRuntime`, `useLocalRuntime`. Current line is `@assistant-ui/react` 0.15.x on AI SDK v7. For a specific area route to a focused sibling instead: setup, runtime, primitives, tools, streaming, cloud, thread-list, copilots, markdown, react-mcp, observability, or update. Not for hands-on tasks already owned by those siblings."
 license: MIT
 ---
 
@@ -34,8 +34,8 @@ React library for building AI chat interfaces with composable primitives.
 └─────────────────────────┬───────────────────────────────┘
                           │
 ┌─────────────────────────▼───────────────────────────────┐
-│                   Context Hooks                         │
-│   useAui, useAuiState, useAuiEvent │
+│                 aui client + hooks                      │
+│         useAui, useAuiState, useAuiEvent                │
 └─────────────────────────┬───────────────────────────────┘
                           │
 ┌─────────────────────────▼───────────────────────────────┐
@@ -67,11 +67,15 @@ Using AI SDK?
 | Package | Purpose |
 |---------|---------|
 | `@assistant-ui/react` | UI primitives & hooks |
-| `@assistant-ui/react-ai-sdk` | Vercel AI SDK v6 adapter |
-| `@assistant-ui/react-langgraph` | LangGraph adapter |
+| `@assistant-ui/core` | Framework-agnostic core runtime |
+| `@assistant-ui/store` | `useAui` / `AuiProvider` state layer |
+| `@assistant-ui/react-ai-sdk` | Vercel AI SDK v7 adapter |
+| `@assistant-ui/react-langchain` | LangChain / LangGraph `useStream` adapter |
 | `@assistant-ui/react-markdown` | Markdown rendering |
 | `assistant-stream` | Streaming protocol |
 | `assistant-cloud` | Cloud persistence |
+
+Non-web targets: `@assistant-ui/react-native` (Expo) and `@assistant-ui/react-ink` (terminal). See [./references/packages.md](./references/packages.md) for the full inventory.
 
 ## Quick Start
 
@@ -94,12 +98,15 @@ function App() {
 
 ## State Access
 
+Scope accessors on `aui` are properties (0.15+); methods on a scope keep their parentheses.
+
 ```tsx
 import { useAui, useAuiState } from "@assistant-ui/react";
 
-const api = useAui();
-api.thread().append({ role: "user", content: [{ type: "text", text: "Hi" }] });
-api.thread().cancelRun();
+const aui = useAui();
+aui.thread.append({ role: "user", content: [{ type: "text", text: "Hi" }] });
+aui.thread.cancelRun();
+aui.thread.composer().send();
 
 const messages = useAuiState(s => s.thread.messages);
 const isRunning = useAuiState(s => s.thread.isRunning);
@@ -114,4 +121,8 @@ const isRunning = useAuiState(s => s.thread.isRunning);
 - `/streaming` - Streaming protocols
 - `/cloud` - Persistence and auth
 - `/thread-list` - Multi-thread management
+- `/copilots` - Grounding the assistant in your app
+- `/markdown` - Markdown rendering
+- `/react-mcp` - User-managed MCP servers
+- `/observability` - Backend tracing and telemetry
 - `/update` - Version updates and migrations

--- a/assistant-ui/skills/assistant-ui/references/architecture.md
+++ b/assistant-ui/skills/assistant-ui/references/architecture.md
@@ -25,46 +25,52 @@ interface ThreadRuntimeCore {
 
 ### Layer 2: Runtime (Public API)
 
-Public API exposed via hooks:
+The object you hand to `AssistantRuntimeProvider`. `thread` and `threads` are properties:
 
 ```typescript
 type AssistantRuntime = {
-  thread(): ThreadRuntime;
-  threads(): ThreadListRuntime;
-  getState(): AssistantState;
-  subscribe(callback: () => void): Unsubscribe;
+  readonly thread: ThreadRuntime;
+  readonly threads: ThreadListRuntime;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
 };
 
 type ThreadRuntime = {
+  readonly path: ThreadRuntimePath;
+  readonly composer: ThreadComposerRuntime;
   getState(): ThreadState;
-  append(message: AppendMessage): void;
+  append(message: CreateAppendMessage): void;
+  startRun(config: CreateStartRunConfig): void;
+  resumeRun(config: CreateResumeRunConfig): void;
   cancelRun(): void;
-  message(index: number): MessageRuntime;
-  composer(): ComposerRuntime;
-};
-
-type MessageRuntime = {
-  getState(): MessageState;
-  edit(message: EditMessage): void;
-  reload(): void;
-  part(index: number): MessagePartRuntime;
+  getMessageByIndex(idx: number): MessageRuntime;
+  getMessageById(messageId: string): MessageRuntime;
+  subscribe(callback: () => void): Unsubscribe;
 };
 ```
 
-### Layer 3: Context Hooks
+### Layer 3: The aui client and hooks
 
-React hooks for accessing runtime:
+`useAui()` returns an `AssistantClient`: one property accessor per registered scope, plus `subscribe` and `on`. It is the API application code should use; `AssistantRuntime` is the object that backs it.
 
 ```tsx
-// Modern API (recommended)
 import { useAui, useAuiState, useAuiEvent } from "@assistant-ui/react";
 
-const api = useAui();
+const aui = useAui();
 
-const messages = useAuiState(s => s.thread.messages);
+// Scope accessors are properties (0.15+); methods on a scope keep their parens
+aui.thread.append({ role: "user", content: [{ type: "text", text: "Hi" }] });
+aui.thread.message({ index: 0 }).reload();
+aui.thread.composer().send();
+aui.threads.switchToNewThread();
 
-useAuiEvent("composer.send", (e) => console.log(e));
+const messages = useAuiState((s) => s.thread.messages);
+
+useAuiEvent("thread.modelContextUpdate", (e) => console.log(e));
 ```
+
+Scopes: `threads`, `threadListItem`, `thread`, `message`, `part`, `composer`, `attachment`, `modelContext`, `suggestions`, `suggestion`, `chainOfThought`, `queueItem`, `tools`, `dataRenderers`, `interactables`.
+
+An unavailable scope does not throw at selection time: `aui.thread` is always truthy, `source` is `null`, and any other read throws. Guard with `aui.thread.source != null`, or select through `s.optional.thread` in `useAuiState`.
 
 ### Layer 4: Primitives (UI)
 
@@ -111,51 +117,64 @@ type ThreadMessage =
   | ThreadAssistantMessage
   | ThreadSystemMessage;
 
-interface ThreadUserMessage {
+type ThreadUserMessage = {
   id: string;
   role: "user";
-  content: MessagePart[];
-  attachments?: Attachment[];
+  content: readonly ThreadUserMessagePart[];
+  attachments: readonly CompleteAttachment[];
+  metadata: { custom: Record<string, unknown>; isOptimistic?: boolean };
   createdAt: Date;
-}
+};
 
-interface ThreadAssistantMessage {
+type ThreadAssistantMessage = {
   id: string;
   role: "assistant";
-  content: MessagePart[];
-  // status is an object, not a string. Check status.type.
-  status: MessageStatus; // { type: "running" | "complete" | "incomplete" | "requires-action"; reason?: string }
+  content: readonly ThreadAssistantMessagePart[];
+  // status is an object, not a string. Branch on status.type.
+  status: MessageStatus;
+  metadata: {
+    steps: readonly ThreadStep[];
+    submittedFeedback?: { type: "positive" | "negative" };
+    timing?: MessageTiming;
+    custom: Record<string, unknown>;
+    // unstable_state / unstable_annotations / unstable_data
+  };
   createdAt: Date;
-}
+};
 
-type MessagePart =
-  | { type: "text"; text: string }
-  | { type: "image"; image: string }
+type MessageStatus =
+  | { type: "running" }
+  | { type: "requires-action"; reason: "interrupt" | "tool-calls" }
+  | { type: "complete"; reason: "stop" | "unknown" }
   | {
-      type: "tool-call";
-      toolCallId: string;
-      toolName: string;
-      args: unknown;
-      argsText: string;
-      result?: unknown;
-      isError?: boolean;
-      artifact?: unknown;
-    }
-  | { type: "reasoning"; text: string }
-  | {
-      type: "source";
-      sourceType: "url";
-      id: string;
-      url: string;
-      title?: string;
-    }
-  | {
-      type: "file";
-      filename?: string;
-      data: string;
-      mimeType: string;
+      type: "incomplete";
+      reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
+      error?: ReadonlyJSONValue;
     };
 ```
+
+The two roles carry different part unions:
+
+```typescript
+type ThreadUserMessagePart =
+  | TextMessagePart
+  | ImageMessagePart
+  | FileMessagePart
+  | DataMessagePart
+  | Unstable_AudioMessagePart;
+
+type ThreadAssistantMessagePart =
+  | TextMessagePart          // { type: "text"; text: string }
+  | ReasoningMessagePart     // { type: "reasoning"; text: string }
+  | ToolCallMessagePart      // { type: "tool-call"; toolCallId; toolName; args; argsText; result?; isError?; artifact? }
+  | SourceMessagePart        // { type: "source"; sourceType: "url"; id; url; title? }
+  | FileMessagePart          // { type: "file"; data; mimeType; filename?; sourceType?: "id" | "url" }
+  | ImageMessagePart         // { type: "image"; image: string; filename? }
+  | DataMessagePart          // { type: "data"; name: string; data: T }
+  | GenerativeUIMessagePart; // { type: "generative-ui"; spec: GenerativeUISpec }
+```
+
+In UI code you usually read `MessageState`, which is `ThreadMessage` plus `parentId`, `index`, `isLast`, `branchNumber`, `branchCount`, `parts` (`PartState[]`, part data plus per-part status), `composer` (the edit composer), `isCopied`, and `isHovering`.
 
 ## Branching Model
 

--- a/assistant-ui/skills/assistant-ui/references/packages.md
+++ b/assistant-ui/skills/assistant-ui/references/packages.md
@@ -5,54 +5,92 @@
 **To check latest version:** Run `npm view <package-name> version` or check the package on npmjs.com.
 
 - Most published packages only expose the `latest` dist-tag; always install from `latest`.
-- Monorepo-only: `@assistant-ui/x-buildutils` (not on npm).
+- Monorepo-only (not on npm): `@assistant-ui/x-buildutils`, `@assistant-ui/ui`.
+
+### Core
 
 | Package | Notes |
 |---------|-------|
-| @assistant-ui/react | Core UI library |
-| @assistant-ui/react-ai-sdk | AI SDK v6 integration |
-| @assistant-ui/react-langgraph | LangGraph integration |
-| @assistant-ui/react-data-stream | Data stream utilities |
-| @assistant-ui/react-markdown | Markdown rendering |
-| @assistant-ui/react-syntax-highlighter | Code highlighting |
-| @assistant-ui/store | State management |
-| @assistant-ui/react-devtools | Developer tools |
-| @assistant-ui/react-hook-form | React Hook Form integration |
-| @assistant-ui/react-mcp | User-managed MCP server tools |
-| @assistant-ui/react-a2a | Agent-to-Agent protocol for multi-agent systems |
-| @assistant-ui/react-ag-ui | AG-UI protocol adapter for agent backends |
-| @assistant-ui/cloud-ai-sdk | AI SDK hooks for assistant-cloud persistence |
-| @assistant-ui/core | Framework-agnostic core runtime |
-| @assistant-ui/react-native | React Native bindings |
-| @assistant-ui/react-o11y | Observability primitives |
-| @assistant-ui/react-streamdown | Streamdown-based markdown rendering |
-| @assistant-ui/tap | Reactive state management and testing |
-| @assistant-ui/mcp-docs-server | MCP server for IDE integration |
-| assistant-stream | Streaming protocol |
-| assistant-cloud | Cloud persistence/auth |
-| assistant-ui | CLI tool |
-| create-assistant-ui | Project scaffolding |
-| safe-content-frame | Sandboxed iframe content |
-| tw-shimmer | Tailwind shimmer effects |
-| tw-glass | Tailwind CSS v4 glass refraction effects |
+| `@assistant-ui/react` | Core UI library: primitives, hooks, runtimes |
+| `@assistant-ui/core` | Framework-agnostic core runtime shared by every binding |
+| `@assistant-ui/store` | Tap-based state management (`useAui`, `AuiProvider`) |
+| `@assistant-ui/tap` | Reactive state primitives inspired by React hooks |
+| `assistant-stream` | Streaming protocol and encoders/decoders |
+| `assistant-cloud` | Cloud persistence and auth client |
+| `assistant-ui` | CLI (`create`, `init`, `add`, `update`, `upgrade`, `doctor`, `mcp`, `agent`) |
+| `create-assistant-ui` | `npm create assistant-ui` scaffolding entry point |
+
+### Platform bindings
+
+| Package | Notes |
+|---------|-------|
+| `@assistant-ui/react-native` | React Native / Expo bindings |
+| `@assistant-ui/react-ink` | React Ink terminal-UI bindings |
+| `@assistant-ui/react-ink-markdown` | Terminal markdown rendering for react-ink |
+| `@assistant-ui/next` | Next.js integration: `withAui()` config wrapper, `"use generative"` compiler |
+| `@assistant-ui/vite` | Vite plugin for the `"use generative"` directive compiler |
+| `@assistant-ui/metro` | Metro / Expo integration for the `"use generative"` compiler |
+
+### Backend adapters
+
+| Package | Notes |
+|---------|-------|
+| `@assistant-ui/react-ai-sdk` | Vercel AI SDK adapter (v7 current; v6/v5 via pinned older releases) |
+| `@assistant-ui/react-langchain` | LangChain `useStream` adapter (the `langchain` CLI template uses this) |
+| `@assistant-ui/react-langgraph` | LangGraph adapter |
+| `@assistant-ui/react-ag-ui` | AG-UI protocol adapter |
+| `@assistant-ui/react-a2a` | A2A (Agent-to-Agent) v1.0 protocol adapter |
+| `@assistant-ui/react-google-adk` | Google ADK adapter |
+| `@assistant-ui/react-opencode` | OpenCode runtime adapter |
+| `@assistant-ui/react-pi` | Pi coding-agent runtime adapter |
+| `@assistant-ui/eve` | Eve runtime adapter |
+| `@assistant-ui/react-data-stream` | AI SDK v4 data-stream adapter (legacy path) |
+| `@assistant-ui/cloud-ai-sdk` | Standalone AI SDK hooks backed by Assistant Cloud persistence |
+
+### UI and rendering
+
+| Package | Notes |
+|---------|-------|
+| `@assistant-ui/react-markdown` | Markdown rendering (`MarkdownTextPrimitive`) |
+| `@assistant-ui/react-streamdown` | Streamdown rendering with built-in Shiki/KaTeX/Mermaid |
+| `@assistant-ui/react-syntax-highlighter` | Code block highlighting adapters |
+| `@assistant-ui/react-lexical` | Lexical rich-text composer with @-mention support |
+| `@assistant-ui/react-generative-ui` | Declarative generative UI (UISpec, A2UI, Slack/Teams converters) |
+| `@assistant-ui/react-hook-form` | React Hook Form integration |
+| `safe-content-frame` | Sandboxed iframe rendering for untrusted content |
+| `heat-graph` | Headless activity heatmap components |
+| `tw-shimmer` | Tailwind CSS v4 shimmer plugin |
+| `tw-glass` | Tailwind CSS v4 glass refraction plugin |
+
+### Tooling and integrations
+
+| Package | Notes |
+|---------|-------|
+| `@assistant-ui/react-mcp` | User-managed MCP server connection/config primitives |
+| `@assistant-ui/react-devtools` | DevTools panel and modal |
+| `@assistant-ui/react-o11y` | Span/trace rendering primitives |
+| `@assistant-ui/mcp-docs-server` | MCP server exposing assistant-ui docs to an IDE |
+| `@assistant-ui/agent-launcher` | Spawns the Claude Code CLI with a chosen plugin, skill, and prompt |
+| `@assistant-ui/x-generative-compiler` | Internal `"use generative"` compiler shared by next/vite/metro |
 
 ## Core Packages
 
 ### @assistant-ui/react
 
-Main UI library with primitives and hooks.
+Main UI library with primitives and hooks. Requires React 18 or 19.
 
 ```bash
 npm install @assistant-ui/react
 ```
 
 **Exports:**
-- Primitives: `ThreadPrimitive`, `MessagePrimitive`, `ComposerPrimitive`, `ActionBarPrimitive`, `BranchPickerPrimitive`, `AttachmentPrimitive`, `ThreadListPrimitive`
-- Pre-built components are added via project templates in:
-  `@/components/assistant-ui/thread` and `@/components/assistant-ui/thread-list`
-- Hooks: `useAui`, `useAuiState`, `useAuiEvent`
-- Runtime: `useLocalRuntime`, `useExternalStoreRuntime`
-- Tools: `makeAssistantTool`, `makeAssistantToolUI`, `useAssistantTool`, `useAssistantToolUI`
+- Primitives: `ThreadPrimitive`, `MessagePrimitive`, `ComposerPrimitive`, `ActionBarPrimitive`, `ActionBarMorePrimitive`, `BranchPickerPrimitive`, `AttachmentPrimitive`, `ThreadListPrimitive`, `ThreadListItemPrimitive`, `ThreadListItemMorePrimitive`, `MessagePartPrimitive`, `ChainOfThoughtPrimitive`, `SelectionToolbarPrimitive`, `SuggestionPrimitive`, `QueueItemPrimitive`, `ErrorPrimitive`, `AssistantModalPrimitive`
+- Pre-built components come from the registry (`npx assistant-ui@latest add thread`), landing in `@/components/assistant-ui/*`
+- Hooks: `useAui`, `useAuiState`, `useAuiEvent`, `useAuiToolOverrides`
+- Conditionals: `AuiIf`, `AuiProvider`
+- Runtimes: `useLocalRuntime`, `useExternalStoreRuntime`, `useRemoteThreadListRuntime`, `useAssistantTransportRuntime`
+- Tools: `tool`, `defineToolkit`, `Tools`, `makeAssistantTool`, `makeAssistantToolUI`, `useAssistantTool`, `useAssistantToolUI`, `hitl`, `humanTool`, `providerTool`, `externalTool`, `stubTool`
+- Copilots: `useAssistantInstructions`, `useAssistantContext`, `makeAssistantVisible`, `Interactables`
 - Provider: `AssistantRuntimeProvider`
 
 ### assistant-stream
@@ -64,10 +102,15 @@ npm install assistant-stream
 ```
 
 **Exports:**
-- `AssistantStream` - Core streaming abstraction
-- `DataStreamEncoder/Decoder` - AI SDK format
-- `AssistantTransportEncoder/Decoder` - Native format
-- `PlainTextEncoder/Decoder` - Simple text streaming
+- `AssistantStream`, `createAssistantStream`, `createAssistantStreamResponse` - Core streaming abstraction
+- `DataStreamEncoder` / `DataStreamDecoder` - AI SDK format
+- `AssistantTransportEncoder` / `AssistantTransportDecoder` - Native format
+- `PlainTextEncoder` / `PlainTextDecoder` - Simple text streaming
+- `UIMessageStreamDecoder`, `SSEEventDecoder` - AI SDK UI-message stream and raw SSE decoding
+- `createObjectStream`, `fromObjectStreamResponse`, `parsePartialJsonObject` - Object/state streaming
+- `toToolsJSONSchema` - Serialize a tool map to JSON Schema
+
+Subpaths: `assistant-stream/utils` (JSON helpers) and `assistant-stream/resumable` (plus `/resumable/redis` and `/resumable/ioredis` stores).
 
 ### assistant-cloud
 
@@ -79,23 +122,28 @@ npm install assistant-cloud
 
 **Exports:**
 - `AssistantCloud` - Main client class
-- Thread management, file uploads, auth
+- `cloud.threads` (list, get, create, update, delete, `messages(threadId)`), `cloud.projects`, `cloud.runs`, `cloud.files`, `cloud.auth`, `cloud.telemetry`
 
 ## Integration Packages
 
 ### @assistant-ui/react-ai-sdk
 
-Vercel AI SDK v6 integration.
+Vercel AI SDK adapter. 1.4.x targets AI SDK v7.
 
 ```bash
-npm install @assistant-ui/react-ai-sdk @ai-sdk/react
+npm install @assistant-ui/react-ai-sdk ai@^7 @ai-sdk/react@^4
 ```
 
 **Exports:**
-- `useChatRuntime` - Main hook (recommended)
-- `useAISDKRuntime` - Lower-level hook
-- `AssistantChatTransport` - Custom transport class
-- `frontendTools` - Forward frontend-registered tools to the backend route
+- `useChatRuntime` - Main hook (recommended); defaults to `AssistantChatTransport`
+- `useAISDKRuntime` - Wraps a `useChat` instance you own
+- `AssistantChatTransport` - Transport that forwards system messages and frontend tools
+- `frontendTools` - Materializes forwarded frontend tools in the backend route
+- `AISDKToolkit`, `generativeTools` - Toolkit and generative-UI tool bridges
+- `useThreadTokenUsage`, `getThreadMessageTokenUsage` - Token accounting
+- `useAISDKChat`, `useAISDKError` - Runtime extras accessors
+- `createResumableSessionStorage`, `RESUMABLE_STREAM_ID_HEADER` - Resumable streams
+- `injectQuoteContext` - Composer quote plumbing
 
 ### @assistant-ui/react-langgraph
 
@@ -110,8 +158,25 @@ npm install @assistant-ui/react-langgraph
 - `useLangGraphSend`, `useLangGraphSendCommand` - Manual send control
 - `useLangGraphInterruptState` - Interrupt state access
 - `useLangGraphMessages` - Message state management
+- `useLangGraphState`, `useLangGraphSetState` - Shared agent state
+- `useLangGraphUIMessages`, `useLangGraphMessageMetadata`, `useLangGraphStreamingTiming`
 - `convertLangChainMessages`, `appendLangChainChunk` - Message converters
 - `LangGraphMessageAccumulator` - Message accumulator
+
+### @assistant-ui/react-ag-ui
+
+AG-UI protocol adapter.
+
+```bash
+npm install @assistant-ui/react-ag-ui
+```
+
+**Exports:**
+- `useAgUiRuntime` - Main hook
+- `useAgUiState`, `useAgUiSetState` - Shared agent state
+- `useAgUiInterrupts`, `useAgUiSubmitInterruptResponses`, `useAgUiSteerAway` - Interrupt handling
+- `useAgUiSendA2uiAction` - A2UI surface actions
+- `fromAgUiMessages` - Message converter
 
 ## UI Enhancement Packages
 
@@ -127,6 +192,7 @@ npm install @assistant-ui/react-markdown
 - `MarkdownTextPrimitive` - Renders markdown content
 - `useIsMarkdownCodeBlock` - Check if code block is inside markdown
 - `unstable_memoizeMarkdownComponents` - Memoize markdown components for performance
+- `normalizeMathDelimiters`, `rewriteLatexBracketDelimiters`, `escapeCurrencyDollars` - Math preprocessing helpers
 
 ### @assistant-ui/react-syntax-highlighter
 
@@ -140,14 +206,17 @@ npm install @assistant-ui/react-syntax-highlighter
 
 | Scenario | Packages |
 |----------|----------|
-| Next.js + AI SDK | `@assistant-ui/react`, `@assistant-ui/react-ai-sdk`, `@ai-sdk/react` |
-| LangGraph | `@assistant-ui/react`, `@assistant-ui/react-langgraph` |
+| Next.js + AI SDK | `@assistant-ui/react`, `@assistant-ui/react-ai-sdk`, `ai@^7`, `@ai-sdk/react@^4` |
+| LangGraph | `@assistant-ui/react`, `@assistant-ui/react-langchain` (or `@assistant-ui/react-langgraph`) |
 | Custom backend | `@assistant-ui/react`, `assistant-stream` |
-| With markdown | Add `@assistant-ui/react-markdown` |
-| Production | Add `assistant-cloud` |
+| With markdown | Add `@assistant-ui/react-markdown` or `@assistant-ui/react-streamdown` |
+| Expo / React Native | `@assistant-ui/react-native`, `@assistant-ui/metro` |
+| Terminal UI | `@assistant-ui/react-ink`, `@assistant-ui/react-ink-markdown` |
+| Production persistence | Add `assistant-cloud` |
 
 ## Version Compatibility
 
 - `@assistant-ui/react` requires React 18 or 19 (`react@^18 || ^19`)
-- `@assistant-ui/react-ai-sdk` depends on AI SDK v6 (`ai@^6`), which requires `zod@^3.25.76 || ^4.1.8`
+- `@assistant-ui/react-ai-sdk` 1.4.x depends on AI SDK v7 (`ai@^7`, `@ai-sdk/react@^4`). Older AI SDK majors need a pinned adapter release: `1.3.40` for `ai@^6`, `1.1.21` for `ai@^5`, and `@assistant-ui/react-data-stream` for `ai@^4`.
+- AI SDK requires `zod@^3.25.76 || ^4.1.8`; both Zod 3.25+ and Zod 4 work
 - Node.js >=24 is only required to build the assistant-ui monorepo itself; consuming apps follow their framework's Node requirement

--- a/assistant-ui/skills/cloud/SKILL.md
+++ b/assistant-ui/skills/cloud/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cloud
-description: "Sets up assistant-ui Cloud persistence and authorization with the assistant-cloud package and AssistantCloud client. Use when adding cross-session thread/message persistence, multi-device chat history, file uploads, or auth to an assistant-ui app: passing the cloud option to useChatRuntime (with AssistantChatTransport from @assistant-ui/react-ai-sdk), configuring AssistantCloud with authToken (JWT), apiKey plus userId/workspaceId (server-side), or anonymous mode, and wiring auth providers like NextAuth, Clerk, or Firebase. Covers cloud.threads.list/get/create/update/delete, cloud.threads.messages(threadId), cloud.files.generatePresignedUploadUrl, the aui/v0 message format, custom adapters (CloudMessagePersistence, createFormattedPersistence, ThreadHistoryAdapter, RemoteThreadListAdapter), auto title generation, external_id/metadata mapping, and env vars NEXT_PUBLIC_ASSISTANT_BASE_URL and ASSISTANT_API_KEY. For the thread-list sidebar UI itself use thread-list."
+description: "Sets up assistant-ui Cloud persistence and authorization with the assistant-cloud package and AssistantCloud client. Use when adding cross-session thread/message persistence, multi-device chat history, file uploads, or auth to an assistant-ui app: passing the cloud option to useChatRuntime (with AssistantChatTransport from @assistant-ui/react-ai-sdk), configuring AssistantCloud with authToken (JWT), apiKey plus userId/workspaceId (server-side), or anonymous mode, and wiring auth providers like NextAuth, Clerk, or Firebase. Covers cloud.threads.list/get/create/update/delete, cloud.threads.messages.list/create/update(threadId, ...), cloud.files.generatePresignedUploadUrl and pdfToImages, cloud.projects, cloud.runs, the aui/v0 message format, custom adapters (CloudMessagePersistence, createFormattedPersistence, ThreadHistoryAdapter, RemoteThreadListAdapter), auto title generation, external_id/metadata mapping, and env vars NEXT_PUBLIC_ASSISTANT_BASE_URL and ASSISTANT_API_KEY. For the thread-list sidebar UI itself use thread-list."
 license: MIT
 ---
 
@@ -79,12 +79,16 @@ const cloud = new AssistantCloud({
 ## Cloud API
 
 ```tsx
-const threads = await cloud.threads.list();
-await cloud.threads.create({ title: "New Chat" });
+const { threads } = await cloud.threads.list();
+const { thread_id } = await cloud.threads.create({
+  title: "New Chat",
+  last_message_at: new Date(), // required
+});
 await cloud.threads.update(threadId, { title: "Updated" });
 await cloud.threads.delete(threadId);
 
-const messages = await cloud.threads.messages(threadId).list();
+// messages is a property on threads; every method takes threadId as its first argument
+const { messages } = await cloud.threads.messages.list(threadId);
 
 const { signedUrl, publicUrl } = await cloud.files.generatePresignedUploadUrl({
   filename: "document.pdf",

--- a/assistant-ui/skills/cloud/references/auth-integrations.md
+++ b/assistant-ui/skills/cloud/references/auth-integrations.md
@@ -40,7 +40,12 @@ Resolve the session server-side with `auth.api.getSession`. It takes the request
 import { auth } from "@/auth";
 import { headers } from "next/headers";
 import { openai } from "@ai-sdk/openai";
-import { streamText, convertToModelMessages } from "ai";
+import {
+  streamText,
+  convertToModelMessages,
+  createUIMessageStreamResponse,
+  toUIMessageStream,
+} from "ai";
 import type { UIMessage } from "ai";
 
 export async function POST(req: Request) {
@@ -52,7 +57,9 @@ export async function POST(req: Request) {
     model: openai("gpt-5.4-nano"),
     messages: await convertToModelMessages(messages),
   });
-  return result.toUIMessageStreamResponse();
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({ stream: result.stream }),
+  });
 }
 ```
 
@@ -110,7 +117,7 @@ export function ReloadOnAuth() {
   const aui = useAui();
   const { data: session, isPending } = authClient.useSession();
   useEffect(() => {
-    if (!isPending && session) aui.threads().reload();
+    if (!isPending && session) aui.threads.reload();
   }, [isPending, session?.user?.id]);
   return null;
 }
@@ -125,7 +132,12 @@ Clerk's `auth()` from `@clerk/nextjs/server` runs in any Next.js server context 
 ```ts title="app/api/chat/route.ts"
 import { auth } from "@clerk/nextjs/server";
 import { openai } from "@ai-sdk/openai";
-import { streamText, convertToModelMessages } from "ai";
+import {
+  streamText,
+  convertToModelMessages,
+  createUIMessageStreamResponse,
+  toUIMessageStream,
+} from "ai";
 import type { UIMessage } from "ai";
 
 export async function POST(req: Request) {
@@ -137,7 +149,9 @@ export async function POST(req: Request) {
     model: openai("gpt-5.4-nano"),
     messages: await convertToModelMessages(messages),
   });
-  return result.toUIMessageStreamResponse();
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({ stream: result.stream }),
+  });
 }
 ```
 
@@ -202,7 +216,7 @@ export function ReloadOnAuth() {
   const aui = useAui();
   const { isLoaded, isSignedIn, user } = useUser();
   useEffect(() => {
-    if (isLoaded && isSignedIn) aui.threads().reload();
+    if (isLoaded && isSignedIn) aui.threads.reload();
   }, [isLoaded, isSignedIn, user?.id]);
   return null;
 }

--- a/assistant-ui/skills/cloud/references/custom-persistence.md
+++ b/assistant-ui/skills/cloud/references/custom-persistence.md
@@ -291,7 +291,7 @@ export const threadListAdapter: RemoteThreadListAdapter = {
         async append() {},
         withFormat: (fmt) => ({
           async load() {
-            const { remoteId } = aui.threadListItem().getState();
+            const { remoteId } = aui.threadListItem.getState();
             if (!remoteId) return { messages: [] };
             const rows = await fetch(`/api/threads/${remoteId}/messages`).then((r) => r.json());
             return {
@@ -306,7 +306,7 @@ export const threadListAdapter: RemoteThreadListAdapter = {
             };
           },
           async append(item) {
-            const { remoteId } = await aui.threadListItem().initialize();
+            const { remoteId } = await aui.threadListItem.initialize();
             await fetch(`/api/threads/${remoteId}/messages`, {
               method: "POST",
               body: JSON.stringify({
@@ -330,7 +330,7 @@ export const threadListAdapter: RemoteThreadListAdapter = {
 };
 ```
 
-Note: `append` awaits `aui.threadListItem().initialize()` so the thread row exists before its first message is written; `load` uses `getState()` and bails out when there is no `remoteId` yet.
+Note: `append` awaits `aui.threadListItem.initialize()` so the thread row exists before its first message is written; `load` uses `getState()` and bails out when there is no `remoteId` yet.
 
 ## Runtime provider
 
@@ -369,7 +369,7 @@ export function MyProvider({ children }: { children: React.ReactNode }) {
 | `fmt.encode(item)` | `UIMessage` to stored `content` |
 | `fmt.getId(item.message)` | Extracts the message id |
 | `fmt.format` | Format string written to the `format` column (for example `"ai-sdk/v6"`) |
-| `aui.threadListItem().getState()` | Reads the active thread's `remoteId` for loading |
-| `aui.threadListItem().initialize()` | Awaited before appending to ensure the thread row exists |
+| `aui.threadListItem.getState()` | Reads the active thread's `remoteId` for loading |
+| `aui.threadListItem.initialize()` | Awaited before appending to ensure the thread row exists |
 | `useRemoteThreadListRuntime` | Combines the thread list adapter with a per-thread `runtimeHook` |
 | `RuntimeAdapterProvider` | Mounts `{ history }` for the active thread |

--- a/assistant-ui/skills/cloud/references/persistence.md
+++ b/assistant-ui/skills/cloud/references/persistence.md
@@ -45,11 +45,13 @@ function Chat() {
 
 ### List Threads
 
+Paging is cursor based (`after`), not offset based.
+
 ```tsx
-const threads = await cloud.threads.list({
-  status: "active",     // "active" | "archived" | "all"
+const { threads } = await cloud.threads.list({
+  is_archived: false,
   limit: 50,
-  offset: 0,
+  after: cursor,        // id of the last thread from the previous page
 });
 
 // threads: Array<{
@@ -59,8 +61,10 @@ const threads = await cloud.threads.list({
 //   updated_at: Date;
 //   last_message_at: Date;
 //   is_archived: boolean;
-//   external_id?: string;
-//   metadata?: unknown;
+//   external_id: string | null;
+//   metadata: unknown;
+//   project_id: string;
+//   workspace_id: string;
 // }>
 ```
 
@@ -72,8 +76,11 @@ const thread = await cloud.threads.get(threadId);
 
 ### Create Thread
 
+`last_message_at` is required; everything else is optional.
+
 ```tsx
 const { thread_id } = await cloud.threads.create({
+  last_message_at: new Date(),   // Required
   title: "My New Chat",
   external_id: "custom-id-123",  // Optional external reference
   metadata: {                     // Optional custom data
@@ -103,25 +110,30 @@ await cloud.threads.delete(threadId);
 
 ### List Messages
 
+`messages` is a property on `cloud.threads`, and each method takes `threadId` as its first argument.
+
 ```tsx
-const messages = await cloud.threads.messages(threadId).list({
+const { messages } = await cloud.threads.messages.list(threadId, {
   format: "aui/v0",
 });
 
 // messages: Array<{
 //   id: string;
 //   parent_id: string | null;
-//   format: string;
-//   content: object;
+//   format: "aui/v0" | string;
+//   content: ReadonlyJSONObject;
 //   height: number;
 //   created_at: Date;
+//   updated_at: Date;
 // }>
 ```
+
+`list` accepts only `{ format? }`; there is no paging on the message endpoint.
 
 ### Create Message
 
 ```tsx
-await cloud.threads.messages(threadId).create({
+await cloud.threads.messages.create(threadId, {
   parent_id: null,  // Or parent message ID for branching
   format: "aui/v0",
   content: {
@@ -197,8 +209,8 @@ Titles are auto-generated from conversation:
 
 ```tsx
 // Manual trigger
-const item = api.threads().item({ id: threadId });
-await item.generateTitle();
+const item = api.threads.item({ id: threadId });
+item.generateTitle();
 ```
 
 The cloud backend uses the conversation to generate a concise title.
@@ -209,10 +221,11 @@ Link threads to your system:
 
 ```tsx
 await cloud.threads.create({
+  last_message_at: new Date(),
   external_id: "your-system-id-123",
 });
 
-const threads = await cloud.threads.list();
+const { threads } = await cloud.threads.list();
 const thread = threads.find(t => t.external_id === "your-system-id-123");
 ```
 
@@ -222,6 +235,7 @@ Store custom data with threads:
 
 ```tsx
 await cloud.threads.create({
+  last_message_at: new Date(),
   metadata: {
     userId: user.id,
     category: "sales",
@@ -242,7 +256,7 @@ Messages are loaded on thread switch:
 ```tsx
 // Thread list is cached in memory
 // Messages loaded when switching threads
-api.threads().switchToThread(threadId);
+api.threads.switchToThread(threadId);
 ```
 
 For real-time sync across devices, implement webhook handlers on your backend.

--- a/assistant-ui/skills/copilots/SKILL.md
+++ b/assistant-ui/skills/copilots/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: copilots
-description: "Grounding an assistant in your app with assistant-ui copilots (@assistant-ui/react). Use when steering assistant behavior with useAssistantInstructions, feeding lazy app-state context via useAssistantContext({ getContext }), exposing rendered components with makeAssistantVisible(Component, { clickable, editable }), building two-way interactable state with useAssistantInteractable and Interactables(), or registering instructions and tools imperatively through useAui().modelContext().register({ getModelContext }). Reach for this when the assistant should read the current page, click or edit UI, or read and update component state through auto-generated update_{name} tools. For LLM tools and tool-call UI use the tools skill; for runtime and thread state use the runtime skill."
+description: "Grounding an assistant in your app with assistant-ui copilots (@assistant-ui/react). Use when steering assistant behavior with useAssistantInstructions, feeding lazy app-state context via useAssistantContext({ getContext }), exposing rendered components with makeAssistantVisible(Component, { clickable, editable }), building two-way interactable state with unstable_useInteractable / unstable_Interactables() / unstable_interactableTool (the legacy useAssistantInteractable and Interactables() are deprecated and scheduled for removal after 2026-09-14), or registering instructions and tools imperatively through useAui().modelContext.register({ getModelContext }). Reach for this when the assistant should read the current page, click or edit UI, or read and update component state through auto-generated update_{name} tools. For LLM tools and tool-call UI use the tools skill; for runtime and thread state use the runtime skill."
 license: MIT
 ---
 
@@ -26,11 +26,13 @@ What do you need the assistant to know or do?
 ├─ Steer behavior with a system prompt → useAssistantInstructions("...")
 ├─ Feed read-only app state (page, selection, cart) → useAssistantContext({ getContext })
 ├─ Let it read / click / edit a rendered component → makeAssistantVisible(Component, { clickable, editable })
-├─ Read AND write persistent component state via tools → useAssistantInteractable(name, config)
-└─ Register instructions + tools together imperatively → useAui().modelContext().register({ getModelContext })
+├─ Read AND write persistent component state via tools → unstable_useInteractable(name, config)
+└─ Register instructions + tools together imperatively → useAui().modelContext.register({ getModelContext })
 ```
 
 Instructions and context are the lightweight starting point. Reach for `makeAssistantVisible` when the assistant needs to perceive or drive existing DOM, and for interactables when it needs structured two-way state it can mutate through auto-generated `update_{name}` tools.
+
+Interactables have two generations. `unstable_useInteractable` / `unstable_Interactables()` / `unstable_interactableTool` is current. The legacy `useAssistantInteractable` / `Interactables()` / `useInteractableState` is deprecated as of 2026-06-14 and scheduled for removal on or after 2026-09-14. The two scopes are mutually exclusive in one `useAui` provider.
 
 ```tsx
 import { useAssistantInstructions, useAssistantContext } from "@assistant-ui/react";
@@ -51,7 +53,7 @@ import { useEffect } from "react";
 function SearchCopilot() {
   const aui = useAui();
   useEffect(() => {
-    return aui.modelContext().register({
+    return aui.modelContext.register({
       getModelContext: () => ({
         system: "You are a helpful search assistant.",
         tools: { search: mySearchTool },
@@ -68,7 +70,7 @@ function SearchCopilot() {
 
 **Assistant ignores instructions or context**
 - The hook or `register` call must run inside `AssistantRuntimeProvider`.
-- For `useAui().modelContext().register`, call it in `useEffect` and return the result so it unsubscribes; registering in render leaks providers.
+- For `useAui().modelContext.register`, call it in `useEffect` and return the result so it unsubscribes; registering in render leaks providers.
 
 **Context is stale**
 - Use the `getContext` callback form, not a captured value. It is re-read at send time, so closures over fresh state work; a precomputed string will not update.
@@ -77,7 +79,7 @@ function SearchCopilot() {
 - Without options the component is read-only (exposes its `outerHTML`). Pass `{ clickable: true }` to allow clicks and `{ editable: true }` for `<input>` / `<textarea>` editing. Nested visible components expose only the outermost.
 
 **Interactable resets its state on every render**
-- Define `stateSchema` and `initialState` outside the component (or memoize). A new schema each render re-registers the interactable and wipes its state. Register the scope with `useAui({ interactables: Interactables() })`.
+- Define `stateSchema` and `initialState` outside the component (or memoize). A new schema each render re-registers the interactable and wipes its state. Register the scope with `useAui({ unstable_interactables: unstable_Interactables() })` (legacy: `useAui({ interactables: Interactables() })`).
 
 **Partial updates drop fields**
 - The AI sends only the fields it changes and the merge is shallow (one level deep); nested objects are replaced, not deep-merged.

--- a/assistant-ui/skills/copilots/references/instructions.md
+++ b/assistant-ui/skills/copilots/references/instructions.md
@@ -135,7 +135,7 @@ import { useAui } from "@assistant-ui/react";
 function Provider() {
   const aui = useAui();
   useEffect(() => {
-    return aui.modelContext().register({
+    return aui.modelContext.register({
       getModelContext: () => ({ system: "You are a search assistant." }),
     });
   }, [aui]);

--- a/assistant-ui/skills/copilots/references/interactables.md
+++ b/assistant-ui/skills/copilots/references/interactables.md
@@ -91,6 +91,8 @@ const toolkit = defineToolkit({
 Register the scope (and the toolkit, for the thread-scoped form):
 
 ```tsx
+import { Tools, unstable_Interactables, useAui } from "@assistant-ui/react";
+
 const aui = useAui({
   unstable_interactables: unstable_Interactables(),
   tools: Tools({ toolkit }),

--- a/assistant-ui/skills/copilots/references/interactables.md
+++ b/assistant-ui/skills/copilots/references/interactables.md
@@ -2,8 +2,11 @@
 
 Persistent UI components whose state the AI can read and update through auto-generated tools.
 
+> **Two generations of this API exist.** The legacy one (`Interactables()`, `useAssistantInteractable`, `useInteractableState`) is deprecated as of 2026-06-14 and scheduled for removal on or after 2026-09-14. The current one is the `unstable_` family (`unstable_Interactables()`, `unstable_useInteractable`, `unstable_interactableTool`); it is marked unstable and may change in any release. The two scopes are **mutually exclusive**: mount only one per `useAui` provider. Write new code against the `unstable_` API; the rest of this page documents the legacy API for codebases still on it.
+
 ## Contents
 
+- [Current API (unstable_)](#current-api-unstable_)
 - [Overview](#overview)
 - [Register the scope](#register-the-scope)
 - [useAssistantInteractable](#useassistantinteractable)
@@ -16,11 +19,102 @@ Persistent UI components whose state the AI can read and update through auto-gen
 - [Export and import](#export-and-import)
 - [Schema evolution](#schema-evolution)
 
+## Current API (unstable_)
+
+Two shapes, depending on where the interactable lives.
+
+**App-scoped**: a component you mount anywhere. `unstable_useInteractable(name, config)` returns `[state, controls]`, where controls carry `id`, `version`, `setState`, `isPending`, `error`, and `flush`. State is shared across every thread and survives a reload only with a persistence adapter.
+
+```tsx
+import { unstable_useInteractable } from "@assistant-ui/react";
+import { z } from "zod";
+
+const taskBoardSchema = z.object({
+  tasks: z.array(z.object({ id: z.string(), title: z.string(), done: z.boolean() })),
+});
+
+function TaskBoard() {
+  const [state, { setState }] = unstable_useInteractable("taskBoard", {
+    description:
+      "A task board panel that lists tasks. Use update_taskBoard with tasks.add/update/remove/clear.",
+    stateSchema: taskBoardSchema,
+    initialState: { tasks: [] },
+  });
+
+  return (
+    <ul>
+      {state.tasks.map((task) => (
+        <li key={task.id}>
+          <input
+            type="checkbox"
+            checked={task.done}
+            onChange={() =>
+              setState((prev) => ({
+                tasks: prev.tasks.map((t) =>
+                  t.id === task.id ? { ...t, done: !t.done } : t,
+                ),
+              }))
+            }
+          />
+          {task.title}
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+**Thread-scoped**: an interactable tool UI the model calls in-thread. Define it with `unstable_interactableTool` inside `defineToolkit`; its state rides the thread history, so it survives a reload with nothing extra to persist.
+
+```tsx
+"use generative";
+
+import { defineToolkit, unstable_interactableTool } from "@assistant-ui/react";
+import { z } from "zod";
+
+const toolkit = defineToolkit({
+  notepad: unstable_interactableTool({
+    description: "A notepad with drafted text the user can read and edit.",
+    stateSchema: z.object({ title: z.string(), content: z.string() }),
+    render: ({ state, setState, version, streaming }) => (
+      <Notepad
+        value={state}
+        onChange={setState}
+        busy={streaming}
+        readOnly={version ? !version.isLatest : false}
+      />
+    ),
+  }),
+});
+```
+
+Register the scope (and the toolkit, for the thread-scoped form):
+
+```tsx
+const aui = useAui({
+  unstable_interactables: unstable_Interactables(),
+  tools: Tools({ toolkit }),
+});
+```
+
+On an AI SDK backend, `convertToModelMessages` drops message metadata, so interactable snapshots need to be injected explicitly:
+
+```ts
+import { unstable_injectInteractableContext } from "@assistant-ui/react-ai-sdk";
+
+const result = streamText({
+  model: openai("gpt-5.4"),
+  messages: await convertToModelMessages(unstable_injectInteractableContext(messages)),
+});
+```
+
+Related exports: `unstable_useInteractableState(id)`, `unstable_useInteractableVersions(id, name)`, `unstable_getInteractableSnapshots`, `unstable_getInteractableVersions`, `unstable_formatInteractableSnapshot`.
+
 ## Overview
 
 An interactable is a React component with state that is shared between the user and the AI. State persists across messages, supports partial updates, and the framework auto-registers a tool so the model can change it. Unlike a tool UI (which only renders a tool call), an interactable lives anywhere in your app and stays mounted across turns.
 
-All APIs come from `@assistant-ui/react`.
+Everything below documents the **legacy** API. All of it comes from `@assistant-ui/react`.
 
 ```tsx
 import {
@@ -276,7 +370,7 @@ function PersistenceSetup() {
   const aui = useAui();
 
   useEffect(() => {
-    aui.interactables().setPersistenceAdapter({
+    aui.interactables.setPersistenceAdapter({
       save: async (state) => {
         localStorage.setItem("interactables", JSON.stringify(state));
       },
@@ -284,7 +378,7 @@ function PersistenceSetup() {
 
     const saved = localStorage.getItem("interactables");
     if (saved) {
-      aui.interactables().importState(JSON.parse(saved));
+      aui.interactables.importState(JSON.parse(saved));
     }
   }, [aui]);
 
@@ -303,10 +397,10 @@ Read or replace the full snapshot directly through the scope.
 ```tsx
 const aui = useAui();
 
-const snapshot = aui.interactables().exportState();
+const snapshot = aui.interactables.exportState();
 // => { "note-1": { name: "note", state: { title: "Hello" } }, ... }
 
-aui.interactables().importState(snapshot);
+aui.interactables.importState(snapshot);
 ```
 
 ## Schema evolution

--- a/assistant-ui/skills/copilots/references/model-context.md
+++ b/assistant-ui/skills/copilots/references/model-context.md
@@ -6,7 +6,7 @@ Provide instructions, tools, and lazy app state to the assistant. Multiple provi
 
 - [useAssistantContext](#useassistantcontext) (lazy send-time string state)
 - [useAssistantInstructions](#useassistantinstructions) (static instructions)
-- [Imperative register](#imperative-register) (useAui().modelContext().register)
+- [Imperative register](#imperative-register) (useAui().modelContext.register)
 - [Provider shape](#provider-shape) (getModelContext return)
 - [ModelContextRegistry](#modelcontextregistry) (standalone addTool / addInstruction / addProvider)
 - [Handles](#handles) (update() and remove())
@@ -51,7 +51,7 @@ function Setup() {
 
 ## Imperative register
 
-`useAui().modelContext().register(provider)` returns an unsubscribe function. Register inside `useEffect` and return the result so the provider is cleaned up on unmount.
+`useAui().modelContext.register(provider)` returns an unsubscribe function. Register inside `useEffect` and return the result so the provider is cleaned up on unmount.
 
 ```tsx
 import { useAui, tool } from "@assistant-ui/react";
@@ -70,7 +70,7 @@ const myTool = tool({
 function MyComponent() {
   const aui = useAui();
   useEffect(() => {
-    return aui.modelContext().register({
+    return aui.modelContext.register({
       getModelContext: () => ({
         system: "You are a helpful search assistant...",
         tools: { myTool },
@@ -88,7 +88,7 @@ Because `getModelContext` runs at send-time, you can close over changing props o
 function SmartHistory({ userProfile }) {
   const aui = useAui();
   useEffect(() => {
-    return aui.modelContext().register({
+    return aui.modelContext.register({
       getModelContext: () => ({
         system: `User spending patterns:
 - Average transaction: ${userProfile.avgTransaction}
@@ -116,7 +116,7 @@ Minimal provider that injects model config:
 ```tsx
 useEffect(() => {
   const config = { config: { modelName } };
-  return aui.modelContext().register({
+  return aui.modelContext.register({
     getModelContext: () => config,
   });
 }, [aui, modelName]);

--- a/assistant-ui/skills/observability/SKILL.md
+++ b/assistant-ui/skills/observability/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: observability
-description: "Adds tracing, telemetry, and observability to an assistant-ui backend. Use when wiring an AI SDK route handler (streamText/generateText, toUIMessageStreamResponse) to a tracing backend: Langfuse via OpenTelemetry (LangfuseSpanProcessor and NodeSDK in instrumentation.ts, experimental_telemetry isEnabled, propagateAttributes with traceName/userId/sessionId, langfuseSpanProcessor.forceFlush on serverless), LangSmith via wrapAISDK(ai) from langsmith/experimental/vercel (createLangSmithProviderOptions, awaitPendingTraceBatches), or Helicone via createOpenAI baseURL https://oai.helicone.ai/v1 with the Helicone-Auth header. Also covers rendering collected spans with @assistant-ui/react-o11y headless primitives (SpanResource, SpanPrimitive Root/Indent/CollapseToggle/StatusIndicator/TypeBadge/Name/Children, SpanByIndexProvider, SpanData/SpanState) mounted via useAui/AuiProvider from @assistant-ui/store. Use for missing or empty traces, edge vs nodejs runtime telemetry, serverless flush issues, or trace waterfalls."
+description: "Adds tracing, telemetry, and observability to an assistant-ui backend. Use when wiring an AI SDK route handler (streamText/generateText, toUIMessageStream, createUIMessageStreamResponse) to a tracing backend: Langfuse via OpenTelemetry (LangfuseSpanProcessor and NodeSDK in instrumentation.ts, experimental_telemetry isEnabled, propagateAttributes with traceName/userId/sessionId, langfuseSpanProcessor.forceFlush on serverless), LangSmith via wrapAISDK(ai) from langsmith/experimental/vercel (createLangSmithProviderOptions, awaitPendingTraceBatches), or Helicone via createOpenAI baseURL https://oai.helicone.ai/v1 with the Helicone-Auth header. Also covers rendering collected spans with @assistant-ui/react-o11y headless primitives (SpanResource, SpanPrimitive Root/Indent/CollapseToggle/StatusIndicator/TypeBadge/Name/Children, SpanByIndexProvider, SpanData/SpanState) mounted via useAui/AuiProvider from @assistant-ui/store. Use for missing or empty traces, edge vs nodejs runtime telemetry, serverless flush issues, or trace waterfalls."
 license: MIT
 ---
 
@@ -52,7 +52,12 @@ Langfuse and any OTel backend reuse the AI SDK `experimental_telemetry` flag. En
 
 ```ts
 import { openai } from "@ai-sdk/openai";
-import { streamText, convertToModelMessages } from "ai";
+import {
+  streamText,
+  convertToModelMessages,
+  createUIMessageStreamResponse,
+  toUIMessageStream,
+} from "ai";
 import type { UIMessage } from "ai";
 
 export async function POST(req: Request) {
@@ -62,7 +67,9 @@ export async function POST(req: Request) {
     messages: await convertToModelMessages(messages),
     experimental_telemetry: { isEnabled: true },
   });
-  return result.toUIMessageStreamResponse();
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({ stream: result.stream }),
+  });
 }
 ```
 
@@ -95,7 +102,7 @@ const result = await propagateAttributes(
 );
 ```
 
-LangSmith skips OTel entirely; wrap the `ai` module instead. `convertToModelMessages` is not wrapped, so import it from `ai` directly:
+LangSmith skips OTel entirely; wrap the `ai` module instead. `convertToModelMessages` and the stream-response helpers are not wrapped, so call them off the `ai` namespace directly:
 
 ```ts
 import * as ai from "ai";
@@ -108,7 +115,9 @@ const result = streamText({
   model: openai("gpt-5.4-nano"),
   messages: await ai.convertToModelMessages(messages),
 });
-return result.toUIMessageStreamResponse();
+return ai.createUIMessageStreamResponse({
+  stream: ai.toUIMessageStream({ stream: result.stream }),
+});
 ```
 
 See the per provider reference files for env vars, metadata tagging, and serverless flushing.
@@ -157,7 +166,7 @@ function SpanRow() {
 }
 
 export function TraceView({ spans }: { spans: SpanData[] }) {
-  const aui = useAui({ resource: SpanResource({ spans }) });
+  const aui = useAui({ span: SpanResource({ spans }) });
   return (
     <AuiProvider value={aui}>
       <SpanPrimitive.Children components={{ Span: SpanRow }} />
@@ -184,7 +193,7 @@ export function TraceView({ spans }: { spans: SpanData[] }) {
 - Confirm requests go to `oai.helicone.ai`, not `api.openai.com`, and carry both `Helicone-Auth` and `Authorization` headers.
 
 **react-o11y renders nothing**
-- Primitives must render inside `AuiProvider`; the resource mounts through `useAui({ resource: SpanResource({ spans }) })`.
+- Primitives must render inside `AuiProvider`; the resource mounts through `useAui({ span: SpanResource({ spans }) })`.
 
 ## Related Skills
 

--- a/assistant-ui/skills/observability/references/helicone.md
+++ b/assistant-ui/skills/observability/references/helicone.md
@@ -21,7 +21,12 @@ Create the provider with `createOpenAI` from `@ai-sdk/openai`, override `baseURL
 
 ```ts
 import { createOpenAI } from "@ai-sdk/openai";
-import { streamText, convertToModelMessages } from "ai";
+import {
+  streamText,
+  convertToModelMessages,
+  createUIMessageStreamResponse,
+  toUIMessageStream,
+} from "ai";
 import type { UIMessage } from "ai";
 
 const openai = createOpenAI({
@@ -37,7 +42,9 @@ export async function POST(req: Request) {
     model: openai("gpt-5.4-mini"),
     messages: await convertToModelMessages(messages),
   });
-  return result.toUIMessageStreamResponse();
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({ stream: result.stream }),
+  });
 }
 ```
 

--- a/assistant-ui/skills/observability/references/langfuse.md
+++ b/assistant-ui/skills/observability/references/langfuse.md
@@ -77,7 +77,12 @@ Enable telemetry by setting `experimental_telemetry` directly on `streamText`. T
 
 ```ts
 import { openai } from "@ai-sdk/openai";
-import { streamText, convertToModelMessages } from "ai";
+import {
+  streamText,
+  convertToModelMessages,
+  createUIMessageStreamResponse,
+  toUIMessageStream,
+} from "ai";
 import type { UIMessage } from "ai";
 
 export async function POST(req: Request) {
@@ -85,11 +90,13 @@ export async function POST(req: Request) {
 
   const result = streamText({
     model: openai("gpt-4o"),
-    messages: convertToModelMessages(messages),
+    messages: await convertToModelMessages(messages),
     experimental_telemetry: { isEnabled: true },
   });
 
-  return result.toUIMessageStreamResponse();
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({ stream: result.stream }),
+  });
 }
 ```
 
@@ -99,7 +106,12 @@ Wrap the call in `propagateAttributes` from `@langfuse/tracing` to attach a trac
 
 ```ts
 import { openai } from "@ai-sdk/openai";
-import { streamText, convertToModelMessages } from "ai";
+import {
+  streamText,
+  convertToModelMessages,
+  createUIMessageStreamResponse,
+  toUIMessageStream,
+} from "ai";
 import type { UIMessage } from "ai";
 import { propagateAttributes } from "@langfuse/tracing";
 
@@ -113,12 +125,14 @@ export async function POST(req: Request) {
     async () =>
       streamText({
         model: openai("gpt-4o"),
-        messages: convertToModelMessages(messages),
+        messages: await convertToModelMessages(messages),
         experimental_telemetry: { isEnabled: true },
       }),
   );
 
-  return result.toUIMessageStreamResponse();
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({ stream: result.stream }),
+  });
 }
 ```
 

--- a/assistant-ui/skills/observability/references/langsmith.md
+++ b/assistant-ui/skills/observability/references/langsmith.md
@@ -41,11 +41,13 @@ export async function POST(req: Request) {
     model: openai("gpt-5.4-nano"),
     messages: await ai.convertToModelMessages(messages),
   });
-  return result.toUIMessageStreamResponse();
+  return ai.createUIMessageStreamResponse({
+    stream: ai.toUIMessageStream({ stream: result.stream }),
+  });
 }
 ```
 
-Note: `convertToModelMessages` is not part of the wrapper, so import it from `ai` directly.
+Note: `convertToModelMessages`, `toUIMessageStream`, and `createUIMessageStreamResponse` are not part of the wrapper; call them off the `ai` namespace directly.
 
 ## Metadata for grouping (optional)
 

--- a/assistant-ui/skills/observability/references/react-o11y.md
+++ b/assistant-ui/skills/observability/references/react-o11y.md
@@ -48,7 +48,7 @@ type SpanData = {
 A Tap resource that ingests raw spans and produces reactive, tree-aware state. Mount it with `useAui`, then provide the result through `AuiProvider`.
 
 ```tsx
-const aui = useAui({ resource: SpanResource({ spans }) });
+const aui = useAui({ span: SpanResource({ spans }) });
 ```
 
 ## SpanState
@@ -130,7 +130,7 @@ function SpanRow() {
 }
 
 export function TraceView({ spans }: { spans: SpanData[] }) {
-  const aui = useAui({ resource: SpanResource({ spans }) });
+  const aui = useAui({ span: SpanResource({ spans }) });
   return (
     <AuiProvider value={aui}>
       <SpanPrimitive.Children components={{ Span: SpanRow }} />

--- a/assistant-ui/skills/primitives/SKILL.md
+++ b/assistant-ui/skills/primitives/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: primitives
-description: "Builds and customizes assistant-ui chat UI from composable, unstyled @assistant-ui/react primitives that follow Radix-style part composition. Use when assembling or styling a custom Thread, Composer, message rendering, action bar, or branch picker from building blocks: ThreadPrimitive (.Root, .Viewport, .Messages, .Empty, .ScrollToBottom), ComposerPrimitive (.Input, .Send, .Cancel, .Attachments), MessagePrimitive (.Parts/.Content, .Error), ActionBarPrimitive (.Copy, .Edit, .Reload, .Speak, feedback, .ExportMarkdown), BranchPickerPrimitive, AttachmentPrimitive, ThreadListPrimitive, ThreadListItemPrimitive. Covers MessagePrimitive.Parts children render functions for text, image, reasoning, and tool-call parts; conditional rendering with AuiIf (deprecated .If); and gotchas like wrapping in AssistantRuntimeProvider and adding className since primitives ship unstyled. For prebuilt drop-in UI and scaffolding use setup; for multi-thread sidebar behavior use thread-list."
+description: "Builds and customizes assistant-ui chat UI from composable, unstyled @assistant-ui/react primitives that follow Radix-style part composition. Use when assembling or styling a custom Thread, Composer, message rendering, action bar, or branch picker from building blocks: ThreadPrimitive (.Root, .Viewport, .ViewportFooter, .Messages, .Empty, .ScrollToBottom, .Suggestions), ComposerPrimitive (.Input, .Send, .Cancel, .Attachments, .AddAttachment, .AttachmentDropzone, .Quote, .Dictate, .Queue), MessagePrimitive (.Parts/.Content, .GroupedParts, .Attachments, .Quote, .GenerativeUI, .Error), ActionBarPrimitive (.Copy, .Edit, .Reload, .Speak, .StopSpeaking, feedback, .ExportMarkdown), BranchPickerPrimitive, AttachmentPrimitive, ThreadListPrimitive, ThreadListItemPrimitive, plus ChainOfThoughtPrimitive, SelectionToolbarPrimitive, SuggestionPrimitive, QueueItemPrimitive, ErrorPrimitive, and AssistantModalPrimitive. Covers MessagePrimitive.Parts children render functions for text, image, reasoning, tool-call, data, and generative-ui parts; part grouping with groupPartByType (the \"mcp-app\" key was removed in 0.15, use \"standalone-tool-call\"); conditional rendering with AuiIf (deprecated .If); and gotchas like wrapping in AssistantRuntimeProvider and adding className since primitives ship unstyled. For prebuilt drop-in UI and scaffolding use setup; for multi-thread sidebar behavior use thread-list."
 license: MIT
 ---
 
@@ -39,11 +39,16 @@ import {
 
 | Primitive | Key Parts |
 |-----------|-----------|
-| `ThreadPrimitive` | `.Root`, `.Viewport`, `.Messages`, `.Empty`, `.ScrollToBottom` |
-| `ComposerPrimitive` | `.Root`, `.Input`, `.Send`, `.Cancel`, `.Attachments` |
-| `MessagePrimitive` | `.Root`, `.Parts`/`.Content`, `.If`, `.Error` |
-| `ActionBarPrimitive` | `.Copy`, `.Edit`, `.Reload`, `.Speak`, `.FeedbackPositive`, `.FeedbackNegative`, `.ExportMarkdown` |
-| `BranchPickerPrimitive` | `.Previous`, `.Next`, `.Number`, `.Count` |
+| `ThreadPrimitive` | `.Root`, `.Viewport`, `.ViewportFooter`, `.Messages`, `.Empty`, `.ScrollToBottom`, `.Suggestions`, `.Suggestion` |
+| `ComposerPrimitive` | `.Root`, `.Input`, `.Send`, `.Cancel`, `.Attachments`, `.AddAttachment`, `.AttachmentDropzone`, `.Quote`, `.QuoteText`, `.QuoteDismiss`, `.Dictate`, `.StopDictation`, `.DictationTranscript`, `.Queue` |
+| `MessagePrimitive` | `.Root`, `.Parts` (`.Content` is a deprecated alias), `.GroupedParts`, `.Attachments`, `.Quote`, `.GenerativeUI`, `.Error` |
+| `ActionBarPrimitive` | `.Root`, `.Copy`, `.Edit`, `.Reload`, `.Speak`, `.StopSpeaking`, `.FeedbackPositive`, `.FeedbackNegative`, `.ExportMarkdown` |
+| `BranchPickerPrimitive` | `.Root`, `.Previous`, `.Next`, `.Number`, `.Count` |
+| `ThreadListPrimitive` | `.Root`, `.New`, `.Items`, `.LoadMore` |
+| `ThreadListItemPrimitive` | `.Root`, `.Trigger`, `.Title`, `.Archive`, `.Unarchive`, `.Delete` |
+| `AttachmentPrimitive` | `.Root`, `.Name`, `.Remove`, `.unstable_Thumb` |
+
+Also exported, each covered by its own reference or skill: `ChainOfThoughtPrimitive`, `SelectionToolbarPrimitive`, `SuggestionPrimitive`, `QueueItemPrimitive`, `ErrorPrimitive`, `MessagePartPrimitive`, `AssistantModalPrimitive`, `ActionBarMorePrimitive`, `ThreadListItemMorePrimitive`.
 
 ## Custom Thread Example
 

--- a/assistant-ui/skills/primitives/references/action-bar.md
+++ b/assistant-ui/skills/primitives/references/action-bar.md
@@ -148,7 +148,7 @@ const runtime = useChatRuntime({
 });
 ```
 
-Use `AuiIf` for copy/speech conditional rendering instead of `ActionBarPrimitive.If`.
+`ActionBarPrimitive` has no `.If` part. Use `AuiIf` for copy/speech conditional rendering.
 
 ## Complete Example
 

--- a/assistant-ui/skills/primitives/references/composer.md
+++ b/assistant-ui/skills/primitives/references/composer.md
@@ -225,4 +225,4 @@ function CustomComposer() {
 
 ## Accessing Composer State
 
-Read composer state with `useAuiState((s) => s.composer...)` (e.g. `s.composer.text`, `s.composer.attachments`) and act via `useAui().composer()` (e.g. `.setText("")`). See the `/runtime` skill for the full state API.
+Read composer state with `useAuiState((s) => s.composer...)` (e.g. `s.composer.text`, `s.composer.attachments`) and act via `useAui().composer` (e.g. `.setText("")`). See the `/runtime` skill for the full state API.

--- a/assistant-ui/skills/primitives/references/message.md
+++ b/assistant-ui/skills/primitives/references/message.md
@@ -193,4 +193,4 @@ Use `MessagePrimitive.Error` to render a fallback UI only when the message has a
 
 ## Accessing Message State
 
-Read message state with `useAuiState((s) => s.message...)` and act via `useAui().message()` (e.g. `.reload()`). On assistant messages `s.message.status` is an object; branch on `status.type`. See the `/runtime` skill for the full state API.
+Read message state with `useAuiState((s) => s.message...)` and act via `useAui().message` (e.g. `.reload()`). On assistant messages `s.message.status` is an object; branch on `status.type`. See the `/runtime` skill for the full state API.

--- a/assistant-ui/skills/primitives/references/part-grouping.md
+++ b/assistant-ui/skills/primitives/references/part-grouping.md
@@ -303,7 +303,15 @@ const toolkit = {
 </MessagePrimitive.GroupedParts>
 ```
 
-Note: `"mcp-app"` is a deprecated key superseded by `"standalone-tool-call"`.
+Note: the `"mcp-app"` key was **removed in 0.15**. Use `"standalone-tool-call"`, a superset that matches MCP-app tool calls plus any tool call whose registered UI opts into standalone display.
+
+```diff
+  groupPartByType({
+    "tool-call": ["group-tool"],
+-   "mcp-app": [],
++   "standalone-tool-call": [],
+  })
+```
 
 ## Legacy: Unstable_PartsGrouped
 

--- a/assistant-ui/skills/primitives/references/thread.md
+++ b/assistant-ui/skills/primitives/references/thread.md
@@ -188,4 +188,4 @@ function CustomThread() {
 
 ## Accessing Thread State
 
-Read thread state with `useAuiState((s) => s.thread...)` (e.g. `s.thread.messages`, `s.thread.isRunning`) and act via `useAui().thread()`. See the `/runtime` skill for the full state API.
+Read thread state with `useAuiState((s) => s.thread...)` (e.g. `s.thread.messages`, `s.thread.isRunning`) and act via `useAui().thread`. See the `/runtime` skill for the full state API.

--- a/assistant-ui/skills/react-mcp/SKILL.md
+++ b/assistant-ui/skills/react-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-mcp
-description: "Lets end users add, authenticate, and manage MCP servers from the browser in assistant-ui apps with @assistant-ui/react-mcp. Use when building user-managed MCP server UIs: mounting McpManagerResource via useAui({ mcp }), declaring presets with defineConnector, dropping in McpConfigDialog, or composing McpManagerPrimitive (Root, Connectors, CustomServers, AddCustomTrigger), McpServerPrimitive (Root, Name, Icon, Status, ConnectButton, DisconnectButton, OAuthLink, RemoveButton, Error), and McpAddFormPrimitive (NameField, UrlField, AuthSelect, AuthFields, Submit, Cancel). Covers auth modes none/bearer/oauth, the OAuth flow with McpOAuthCallback, connection states, storage via McpLocalStorage/McpMemoryStorage/McpCustomStorage, reading state with useAuiState (s.mcp, s.mcpServer), and imperative addCustomServer/connect/callTool. Distinct from developer-defined backend @ai-sdk/mcp tools in the tools skill. Reach for this when connected-server tools are missing, OAuth never completes, or servers do not persist."
+description: "Lets end users add, authenticate, and manage MCP servers from the browser in assistant-ui apps with @assistant-ui/react-mcp. Use when building user-managed MCP server UIs: mounting McpManagerResource via useAui({ mcp }), declaring presets with defineConnector, dropping in McpConfigDialog, or composing McpManagerPrimitive (Root, Connectors, CustomServers, AddCustomTrigger), McpServerPrimitive (Root, Name, Icon, Status, ConnectButton, DisconnectButton, OAuthLink, RemoveButton, Error, Tools, ToolName), McpAddFormPrimitive (NameField, UrlField, AuthSelect, AuthFields, Submit, Cancel), and McpElicitationPrimitive (Root, Message, Fields, Items, Accept, Decline, Cancel, Error) for server-initiated input requests. Covers auth modes none/bearer/oauth, the OAuth flow with McpOAuthCallback and useMcpOAuthCallback, connection states, storage via McpLocalStorage/McpMemoryStorage/McpCustomStorage, reading state with useAuiState (s.mcp, s.mcpServer) and useMcpElicitation/useMcpElicitationField/useMcpServerTool, and imperative addCustomServer/connect/callTool. Distinct from developer-defined backend @ai-sdk/mcp tools in the tools skill. Reach for this when connected-server tools are missing, OAuth never completes, an elicitation prompt does not render, or servers do not persist."
 license: MIT
 ---
 
@@ -12,7 +12,7 @@ Let end users add, authenticate, and manage MCP servers from the browser with `@
 
 ## Contents
 
-- [References](#references) | [Routes vs tools](#routes-vs-tools) | [Mount the manager](#mount-the-manager) | [Drop-in dialog](#drop-in-dialog) | [Compose from primitives](#compose-from-primitives) | [OAuth connect flow](#oauth-connect-flow) | [Custom storage](#custom-storage) | [Imperative API](#imperative-api) | [Common Gotchas](#common-gotchas) | [Related Skills](#related-skills)
+- [References](#references) | [Routes vs tools](#routes-vs-tools) | [Mount the manager](#mount-the-manager) | [Drop-in dialog](#drop-in-dialog) | [Compose from primitives](#compose-from-primitives) | [OAuth connect flow](#oauth-connect-flow) | [Custom storage](#custom-storage) | [Elicitation](#elicitation) | [Imperative API](#imperative-api) | [Common Gotchas](#common-gotchas) | [Related Skills](#related-skills)
 
 ## References
 
@@ -160,15 +160,38 @@ const aui = useAui({
 });
 ```
 
+## Elicitation
+
+A connected server can ask the user for structured input mid-run. Render the request with `McpElicitationPrimitive`; the parts read the active request and its JSON Schema, so no manual form wiring is needed.
+
+```tsx
+import { McpElicitationPrimitive } from "@assistant-ui/react-mcp";
+
+<McpElicitationPrimitive.Root>
+  <McpElicitationPrimitive.Message />
+  <McpElicitationPrimitive.Fields>
+    <McpElicitationPrimitive.Items />
+  </McpElicitationPrimitive.Fields>
+  <McpElicitationPrimitive.Error />
+  <McpElicitationPrimitive.Accept>Submit</McpElicitationPrimitive.Accept>
+  <McpElicitationPrimitive.Decline>Decline</McpElicitationPrimitive.Decline>
+  <McpElicitationPrimitive.Cancel>Cancel</McpElicitationPrimitive.Cancel>
+</McpElicitationPrimitive.Root>;
+```
+
+`useMcpElicitation()` returns the active `MCPElicitation` (`id`, `message`, `requestedSchema`, and a validation `error` when the server rejects a submission). Inside a field, `useMcpElicitationField()` gives `{ name, schema, value, setValue }` for a fully custom input. Drafts are seeded from the schema's defaults.
+
+The three responses are distinct: `accept` sends `content`, `decline` refuses this request, `cancel` dismisses it without answering.
+
 ## Imperative API
 
-Inside event handlers, drive the manager through `useAui().mcp()`.
+Inside event handlers, drive the manager through `useAui().mcp`.
 
 ```ts
 const aui = useAui();
-await aui.mcp().addCustomServer({ name, url, auth: { type: "bearer", token } });
-await aui.mcp().server({ id }).connect();
-await aui.mcp().server({ id }).callTool("echo", { text: "hi" });
+await aui.mcp.addCustomServer({ name, url, auth: { type: "bearer", token } });
+await aui.mcp.server({ id }).connect();
+await aui.mcp.server({ id }).callTool("echo", { text: "hi" });
 ```
 
 Read reactive state with `useAuiState`, scoped under `s.mcp` (manager) and `s.mcpServer` (current item inside a `McpServerPrimitive` subtree):
@@ -194,8 +217,11 @@ const connectionState = useAuiState((s) => s.mcpServer.connectionState);
 **Custom server cannot be removed**
 - `RemoveButton` hides on connector presets by design; only user-added servers are removable.
 
+**Elicitation prompt never renders**
+- `McpElicitationPrimitive.Root` renders nothing when there is no active request; mount it inside the same provider as the manager and check `useMcpElicitation()`.
+
 **Transport**
-- Only StreamableHTTP is supported; resources, prompts, sampling, and auto-reconnect are not yet wired.
+- Only StreamableHTTP is supported. `listResources()` supports pagination; prompts, sampling, and auto-reconnect are not yet wired.
 
 ## Related Skills
 

--- a/assistant-ui/skills/react-mcp/references/oauth.md
+++ b/assistant-ui/skills/react-mcp/references/oauth.md
@@ -126,7 +126,7 @@ export default function McpPage() {
 
 ## Imperative connect and auth
 
-`aui.mcp().server({ id }).connect()`, called from an event handler, triggers the OAuth flow when the server needs it. See [./setup.md](./setup.md) for the full imperative API (`addCustomServer`, `connect`, `callTool`).
+`aui.mcp.server({ id }).connect()`, called from an event handler, triggers the OAuth flow when the server needs it. See [./setup.md](./setup.md) for the full imperative API (`addCustomServer`, `connect`, `callTool`).
 
 ## Reading connection state
 

--- a/assistant-ui/skills/react-mcp/references/setup.md
+++ b/assistant-ui/skills/react-mcp/references/setup.md
@@ -1,6 +1,6 @@
 # MCP manager setup
 
-Mount user-managed MCP servers on the `aui` instance with `@assistant-ui/react-mcp`. Connectors are presets, storage persists servers and tokens, and `aui.mcp()` drives the manager imperatively.
+Mount user-managed MCP servers on the `aui` instance with `@assistant-ui/react-mcp`. Connectors are presets, storage persists servers and tokens, and `aui.mcp` drives the manager imperatively.
 
 ## Contents
 
@@ -135,14 +135,14 @@ const aui = useAui({
 
 ## Imperative API
 
-Drive the manager through `useAui().mcp()` from inside event handlers, never during render. `addCustomServer` registers a user server with its own auth; `server({ id })` scopes to one server for `connect` and `callTool`.
+Drive the manager through `useAui().mcp` from inside event handlers, never during render. `addCustomServer` registers a user server with its own auth; `server({ id })` scopes to one server for `connect` and `callTool`.
 
 ```ts
 const aui = useAui();
 // inside an event handler:
-await aui.mcp().addCustomServer({ name, url, auth: { type: "bearer", token } });
-await aui.mcp().server({ id }).connect();
-const result = await aui.mcp().server({ id }).callTool("echo", { text: "hi" });
+await aui.mcp.addCustomServer({ name, url, auth: { type: "bearer", token } });
+await aui.mcp.server({ id }).connect();
+const result = await aui.mcp.server({ id }).callTool("echo", { text: "hi" });
 ```
 
 Read reactive state with `useAuiState` from `@assistant-ui/store`, scoped under `s.mcp` (manager) and `s.mcpServer` (current item inside a `McpServerPrimitive` subtree).

--- a/assistant-ui/skills/runtime/SKILL.md
+++ b/assistant-ui/skills/runtime/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: runtime
-description: "Guide to the assistant-ui runtime system, single-thread state, and the imperative runtime API in @assistant-ui/react. Use when creating a runtime (useLocalRuntime with a ChatModelAdapter, useExternalStoreRuntime for Redux/Zustand, useRemoteThreadListRuntime), wiring AssistantRuntimeProvider, or reading/mutating thread, message, and composer state and events. Covers the unified hooks useAui, useAuiState, useAuiEvent (composer.send, thread.runStart, thread.runEnd), legacy hooks (useAssistantRuntime, useThreadRuntime, useMessageRuntime, useComposerRuntime, useThread, useThreadMessages), the AssistantRuntime/ThreadRuntime/MessageRuntime/ComposerRuntime hierarchy, thread operations (append, cancelRun, message().edit/reload), capabilities, and types (ThreadMessage, MessagePart, MessageStatus, ChatModelRunResult). Use for provider \"Cannot read property of undefined\" errors or state not updating. For multi-thread list UI and switching between conversations use thread-list instead."
+description: "Guide to the assistant-ui runtime system, single-thread state, and the imperative aui client API in @assistant-ui/react. Use when creating a runtime (useLocalRuntime with a ChatModelAdapter, useExternalStoreRuntime for Redux/Zustand, useRemoteThreadListRuntime, useAssistantTransportRuntime), wiring AssistantRuntimeProvider, or reading/mutating thread, message, composer, and attachment state. Covers the unified hooks useAui, useAuiState, useAuiEvent and the v0.15 property accessors (aui.thread, aui.threads, aui.message, aui.composer, aui.part; availability via aui.thread.source != null), the s.optional.<scope> state view, scope methods (append, cancelRun, startRun, resumeRun, message({index}), part({index}), composer().send), capabilities, adapters (attachment, speech, dictation, suggestion, feedback, history), realtime voice, and types (ThreadMessage, MessageState, MessagePart, MessageStatus, ChatModelRunResult). The v0.12-era legacy context hooks (useAssistantRuntime, useThreadRuntime, useThread, useMessage, useComposer, useMessagePart, useAttachment) were removed in 0.15; route those to update. Use for provider \"Cannot read property of undefined\" errors or state not updating. For multi-thread list UI and switching between conversations use thread-list instead."
 license: MIT
 ---
 
@@ -48,64 +48,122 @@ function ChatControls() {
 
   return (
     <div>
-      <button onClick={() => api.thread().append({
+      <button onClick={() => api.thread.append({
         role: "user",
         content: [{ type: "text", text: "Hello!" }],
       })}>
         Send
       </button>
       {isRunning && (
-        <button onClick={() => api.thread().cancelRun()}>Cancel</button>
+        <button onClick={() => api.thread.cancelRun()}>Cancel</button>
       )}
     </div>
   );
 }
 ```
 
+## Scope Accessors Are Properties
+
+As of 0.15, `aui.<scope>` is a property, not a call. Calling it still works but is deprecated. Methods *on* a scope keep their parentheses.
+
+```tsx
+const aui = useAui();
+
+aui.thread.getState();            // property accessor
+aui.threads.switchToNewThread();
+aui.thread.composer().send();     // composer() is a method of the thread scope
+aui.thread.message({ index: 0 }); // selector object, not a bare index
+```
+
+Selecting an unavailable scope no longer throws; `aui.message` is always truthy. Check availability before use:
+
+```tsx
+if (aui.message.source != null) {
+  aui.message.reload();
+}
+```
+
+`source`, `query`, and `name` are reserved accessor properties and never resolve to scope methods.
+
 ## Thread Operations
 
 ```tsx
-const api = useAui();
-const thread = api.thread();
+const aui = useAui();
+const thread = aui.thread;
 
 thread.append({ role: "user", content: [{ type: "text", text: "Hello" }] });
-
+thread.startRun({ parentId: null });
 thread.cancelRun();
 
-const state = thread.getState();  // { messages, isRunning, ... }
+const state = thread.getState();  // { messages, isRunning, capabilities, composer, ... }
 ```
 
 ## Message Operations
 
-```tsx
-const message = api.thread().message(0);
+`message()` takes a selector object of `{ index }` or `{ id }`.
 
-message.edit({ role: "user", content: [{ type: "text", text: "Updated" }] });
+```tsx
+const message = aui.thread.message({ index: 0 });
+
 message.reload();
+message.switchToBranch({ position: "next" });
+message.submitFeedback({ type: "positive" });
+
+// Editing goes through the message's edit composer
+const editComposer = message.composer();
+editComposer.beginEdit();
+editComposer.setText("Updated");
+editComposer.send();
 ```
 
 ## Events
 
+Almost every event is now deprecated as state-derivable: derive from `useAuiState` instead of listening.
+
 ```tsx
-useAuiEvent("thread.runStart", () => {});
-useAuiEvent("thread.runEnd", () => {});
-useAuiEvent("composer.send", ({ threadId }) => {
-  console.log("Sent in thread:", threadId);
-});
-useAuiEvent("thread.modelContextUpdate", () => {});
+// Preferred: derive from state
+const isRunning = useAuiState((s) => s.thread.isRunning);
+
+// Still non-deprecated
+useAuiEvent("thread.modelContextUpdate", ({ threadId }) => {});
+useAuiEvent("composer.attachmentAddError", (e) => {});
+```
+
+| Event | Status |
+|-------|--------|
+| `thread.modelContextUpdate` | Current (model context lives in a provider, not in state) |
+| `composer.attachmentAddError` | Current |
+| `composer.send`, `composer.attachmentAdd` | Deprecated: observe composer `text` / `attachments` |
+| `thread.runStart`, `thread.runEnd` | Deprecated: observe `s.thread.isRunning` |
+| `thread.initialize` | Deprecated: observe `s.thread.messages` becoming non-empty |
+| `threadListItem.switchedTo`, `threadListItem.switchedAway` | Deprecated: compare `s.threads.mainThreadId` |
+
+## Optional Scopes
+
+`s.optional.<scope>` resolves to `undefined` instead of throwing when a scope is not mounted, which is the safe way to read a scope from a component that renders both inside and outside it:
+
+```tsx
+const partType = useAuiState((s) => s.optional.part?.type);
 ```
 
 ## Capabilities
 
 ```tsx
 const caps = useAuiState(s => s.thread.capabilities);
-// { cancel, edit, reload, copy, speak, attachments }
 ```
+
+`RuntimeCapabilities`: `switchToBranch`, `switchBranchDuringRun`, `edit`, `reload`, `delete`, `cancel`, `unstable_copy`, `speech`, `dictation`, `voice`, `attachments`, `feedback`, `queue`. Note `unstable_copy` and `speech`, not `copy` and `speak`.
+
+Runtimes derive most of these from what you supply (a callback, an adapter) rather than from an explicit option.
 
 ## Common Gotchas
 
 **"Cannot read property of undefined"**
 - Ensure hooks are called inside `AssistantRuntimeProvider`
+- For a scope that may not be mounted, read `s.optional.<scope>` or guard on `aui.<scope>.source != null`
+
+**A legacy hook import fails to resolve**
+- `useAssistantRuntime`, `useThreadRuntime`, `useThread`, `useMessage`, `useComposer`, `useMessagePart`, `useAttachment`, `useThreadListItem`, `useThreadList` and friends were removed in 0.15. See the `/update` skill for the mapping table.
 
 **State not updating**
 - Use selectors with `useAuiState` to prevent unnecessary re-renders

--- a/assistant-ui/skills/runtime/references/adapters.md
+++ b/assistant-ui/skills/runtime/references/adapters.md
@@ -23,7 +23,7 @@ Optional capability adapters you register on the runtime `adapters` map: attachm
 Every adapter is registered under a named key on the runtime's `adapters` option. The same map works across runtime factories (`useChatRuntime`, `useLocalRuntime`, `useAISDKRuntime`).
 
 ```ts
-import { useChatRuntime } from "@assistant-ui/react";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
 
 const runtime = useChatRuntime({
   adapters: {
@@ -260,14 +260,14 @@ const runtime = useChatRuntime({
 });
 ```
 
-`ActionBarPrimitive.Speak` is automatically disabled when no speech adapter is configured. Toggle speak and stop buttons with `useMessageTTS`, which reports whether the current message is being spoken.
+`ActionBarPrimitive.Speak` is automatically disabled when no speech adapter is configured. Toggle speak and stop buttons off the message's `speech` state, which is `undefined` unless this message is the one being spoken.
 
 ```tsx
-import { ActionBarPrimitive, useMessageTTS } from "@assistant-ui/react";
+import { ActionBarPrimitive, useAuiState } from "@assistant-ui/react";
 import { AudioLinesIcon, StopCircleIcon } from "lucide-react";
 
 const AssistantActionBar = () => {
-  const isSpeaking = useMessageTTS();
+  const isSpeaking = useAuiState((s) => s.message.speech != null);
   return (
     <ActionBarPrimitive.Root>
       {!isSpeaking && (

--- a/assistant-ui/skills/runtime/references/external-store.md
+++ b/assistant-ui/skills/runtime/references/external-store.md
@@ -74,14 +74,17 @@ interface ExternalStoreRuntimeOptions<T = ThreadMessage> {
   // Message conversion (for custom message formats)
   convertMessage?: (message: T) => ThreadMessage;
 
-  // Capabilities override
-  capabilities?: Partial<RuntimeCapabilities>;
+  // The only settable capability; everything else is derived (see below)
+  unstable_capabilities?: { copy?: boolean };
 
   // Adapters
   adapters?: {
     attachments?: AttachmentAdapter;
-    feedback?: FeedbackAdapter;
     speech?: SpeechSynthesisAdapter;
+    dictation?: DictationAdapter;
+    voice?: RealtimeVoiceAdapter;
+    feedback?: FeedbackAdapter;
+    threadList?: ExternalStoreThreadListAdapter;
   };
 }
 ```
@@ -314,19 +317,34 @@ const runtime = useExternalStoreRuntime({
 
 ## Capabilities
 
+There is no `capabilities` option. `ExternalStoreRuntime` derives every capability from which callbacks and adapters you supply, so a capability turns on by implementing it:
+
+| Capability | Turned on by |
+|------------|--------------|
+| `edit` | `onEdit` |
+| `reload` | `onReload` |
+| `cancel` | `onCancel` |
+| `delete` | `onDelete` or `setMessages` |
+| `switchToBranch` | `setMessages` |
+| `attachments` | `adapters.attachments` |
+| `feedback` | `adapters.feedback` |
+| `speech` | `adapters.speech` |
+| `dictation` | `adapters.dictation` |
+| `voice` | `adapters.voice` |
+| `queue` | `queue` |
+| `unstable_copy` | on unless `unstable_capabilities.copy === false` |
+| `switchBranchDuringRun` | always `false` |
+
 ```tsx
 const runtime = useExternalStoreRuntime({
   messages,
   isRunning,
   onNew: handleNew,
-  // Only enable capabilities you implement
-  capabilities: {
-    edit: false,   // Disable edit if onEdit not provided
-    reload: true,
-    cancel: true,
-    copy: true,
-    speak: false,
-    attachments: false,
-  },
+  onReload: handleReload,   // enables `reload`
+  onCancel: handleCancel,   // enables `cancel`
+  // omit onEdit to leave `edit` disabled
+  unstable_capabilities: { copy: false },  // the one capability you can force off
 });
 ```
+
+Read the resolved set with `useAuiState((s) => s.thread.capabilities)`.

--- a/assistant-ui/skills/runtime/references/state-hooks.md
+++ b/assistant-ui/skills/runtime/references/state-hooks.md
@@ -12,28 +12,30 @@ Get the runtime API for imperative actions.
 import { useAui } from "@assistant-ui/react";
 
 function Controls() {
-  const api = useAui();
+  const aui = useAui();
 
-  // Thread operations
-  const thread = api.thread();
+  // Thread operations (scope accessors are properties as of 0.15)
+  const thread = aui.thread;
   thread.append({ role: "user", content: [{ type: "text", text: "Hi" }] });
   thread.cancelRun();
-  thread.startRun();
+  thread.startRun({ parentId: null });
 
-  // Message operations
-  const message = thread.message(0);
-  message.edit({ ... });
+  // Message operations - selector object, not a bare index
+  const message = thread.message({ index: 0 });
   message.reload();
+  message.composer().beginEdit();
 
   // Thread list operations
-  const threads = api.threads();
+  const threads = aui.threads;
   threads.switchToThread(threadId);
   threads.switchToNewThread();
 
-  // Get state snapshot
-  const state = api.getState();
+  // State snapshots come from a scope, not from the client
+  const state = thread.getState();
 }
 ```
+
+There is no `aui.getState()`. The client exposes only the scope accessors plus `subscribe(listener)` and `on(selector, callback)`; read state through `aui.<scope>.getState()` or, in React, `useAuiState`.
 
 ### useAuiState
 
@@ -96,104 +98,149 @@ function Analytics() {
 }
 ```
 
-Available events:
-- `composer.send` - Message submitted from composer
-- `composer.attachmentAdd` - Attachment added in composer
-- `thread.runStart` - Generation started
-- `thread.runEnd` - Generation ended
-- `thread.initialize` - Thread is initialized
-- `thread.modelContextUpdate` - Thread model context updated
-- `threadListItem.switchedTo` - Active thread changed
-- `threadListItem.switchedAway` - Active thread changed away
+Available events. Nearly all are deprecated as state-derivable: prefer observing the equivalent state with `useAuiState`, which is correct on first render and on replay, where an event handler is not.
+
+| Event | Payload | Status |
+|-------|---------|--------|
+| `thread.modelContextUpdate` | `{ threadId }` | Current: model context lives in a provider, so there is no state equivalent |
+| `composer.attachmentAddError` | error details | Current |
+| `composer.send` | `{ threadId, messageId? }` | Deprecated: observe composer `text` clearing |
+| `composer.attachmentAdd` | `{ threadId, messageId? }` | Deprecated: observe composer `attachments` |
+| `thread.runStart` | `{ threadId }` | Deprecated: observe `s.thread.isRunning` flipping to `true` |
+| `thread.runEnd` | `{ threadId }` | Deprecated: observe `s.thread.isRunning` flipping to `false` |
+| `thread.initialize` | `{ threadId }` | Deprecated: observe `s.thread.messages` becoming non-empty |
+| `threadListItem.switchedTo` | `{ threadId }` | Deprecated: compare `s.threads.mainThreadId` |
+| `threadListItem.switchedAway` | `{ threadId }` | Deprecated: compare `s.threads.mainThreadId` |
 
 ## State Shape
 
+`AssistantState` is the union of every registered scope's state, plus an `optional` view of the same scopes:
+
 ```typescript
-interface AssistantState {
-  thread: {
-    messages: ThreadMessage[];
-    isRunning: boolean;
-    capabilities: RuntimeCapabilities;
-    composer: {
-      text: string;
-      attachments: Attachment[];
-    };
-  };
-  threads: {
-    mainThreadId: string;
-    newThreadId: string | null;
-    threadIds: readonly string[];
-    archivedThreadIds: readonly string[];
-    isLoading: boolean;
-    threadItems: readonly ThreadListItemState[];
-    main: ThreadState;
-  };
-  threadListItem: {
-    id: string;
-    remoteId?: string;
-    externalId?: string;
-    title?: string;
-    status: "archived" | "regular" | "new" | "deleted";
-  };
+type AssistantState = ScopeStates & {
+  readonly optional: { readonly [K in keyof ScopeStates]: ScopeStates[K] | undefined };
+};
+```
+
+Registered scopes: `threads`, `threadListItem`, `thread`, `message`, `part`, `composer`, `attachment`, `modelContext`, `suggestions`, `suggestion`, `chainOfThought`, `queueItem`, plus `tools`, `dataRenderers`, and `interactables` from the React layer. `on`, `optional`, and `subscribe` are reserved names and cannot be scopes.
+
+```typescript
+// s.thread
+{
+  isEmpty: boolean;
+  isDisabled: boolean;
+  isLoading: boolean;
+  isRunning: boolean;
+  capabilities: RuntimeCapabilities;
+  messages: readonly MessageState[];
+  suggestions: readonly ThreadSuggestion[];
+  extras: unknown;
+  speech: SpeechState | undefined;
+  voice: VoiceSessionState | undefined;
+  composer: ComposerState;
+}
+
+// s.threads
+{
+  mainThreadId: string;
+  newThreadId: string | null;
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  hasMore: boolean;
+  threadIds: readonly string[];
+  archivedThreadIds: readonly string[];
+  threadItems: readonly ThreadListItemState[];
+  main: ThreadState;
+}
+
+// s.composer (thread composer or edit composer, depending on scope)
+{
+  text: string;
+  role: MessageRole;
+  attachments: readonly Attachment[];
+  runConfig: RunConfig;
+  isEditing: boolean;
+  canCancel: boolean;
+  canSend: boolean;
+  attachmentAccept: string;
+  isEmpty: boolean;
+  type: "thread" | "edit";
+  dictation: DictationState | undefined;
+  quote: QuoteInfo | undefined;
+  queue: readonly QueueItemState[];
+}
+
+// s.message = ThreadMessage & { ... }
+{
+  parentId: string | null;
+  isLast: boolean;
+  index: number;
+  branchNumber: number;
+  branchCount: number;
+  composer: ComposerState;   // the edit composer
+  parts: readonly PartState[];
+  isCopied: boolean;
+  isHovering: boolean;
+  speech: SpeechState | undefined;
 }
 ```
 
-## Legacy Hooks
+## Optional Scope Reads
 
-These are deprecated. They still work (and the CLI `upgrade` codemod migrates them) but emit deprecation warnings and will be removed in a future release. Prefer the modern unified API above.
+`s.optional.<scope>` yields `undefined` rather than throwing when the scope is not mounted. Use it in a component that renders both inside and outside a scope:
 
 ```tsx
-// Runtime access
-import {
-  useAssistantRuntime,
-  useThreadRuntime,
-  useMessageRuntime,
-  useComposerRuntime,
-} from "@assistant-ui/react";
-
-const assistantRuntime = useAssistantRuntime();
-const threadRuntime = useThreadRuntime();
-const messageRuntime = useMessageRuntime();  // Needs message context
-const composerRuntime = useComposerRuntime();
-
-// State subscriptions
-import {
-  useThread,
-  useThreadMessages,
-  useComposer,
-  useMessage,
-  useThreadList,
-} from "@assistant-ui/react";
-
-const thread = useThread();           // { messages, isRunning, ... }
-const messages = useThreadMessages(); // ThreadMessage[]
-const composer = useComposer();       // { text, attachments, ... }
-const message = useMessage();         // Current message (needs context)
-const threadList = useThreadList();   // Thread list state
+const partType = useAuiState((s) => s.optional.part?.type);
+const inThread = useAuiState((s) => s.optional.thread != null);
 ```
+
+Imperatively, the equivalent guard is `aui.<scope>.source != null`.
+
+## Removed Legacy Hooks
+
+The v0.12-era context hooks were **removed in 0.15**. They no longer exist as exports; importing one is a build error, not a deprecation warning.
+
+| Removed | Replacement |
+|---------|-------------|
+| `useAssistantRuntime()` | `useAui()` |
+| `useThreadRuntime()` | `useAui().thread` |
+| `useThread(selector)` | `useAuiState((s) => s.thread)` |
+| `useThreadList(selector)` | `useAuiState((s) => s.threads)` |
+| `useThreadComposer(selector)` | `useAuiState((s) => s.thread.composer)` |
+| `useThreadModelContext(selector)` | `useAuiState((s) => s.modelContext)` |
+| `useMessageRuntime()` | `useAui().message` |
+| `useMessage(selector)` | `useAuiState((s) => s.message)` |
+| `useEditComposer(selector)` | `useAuiState((s) => s.message.composer)` |
+| `useComposerRuntime()` | `useAui().composer` |
+| `useComposer(selector)` | `useAuiState((s) => s.composer)` |
+| `useMessagePartRuntime()` | `useAui().part` |
+| `useMessagePart(selector)` | `useAuiState((s) => s.part)` |
+| `useAttachmentRuntime()` | `useAui().attachment` |
+| `useAttachment(selector)` | `useAuiState((s) => s.attachment)` |
+| `useThreadListItemRuntime()` | `useAui().threadListItem` |
+| `useThreadListItem(selector)` | `useAuiState((s) => s.threadListItem)` |
+
+`useThreadMessages` was removed earlier and has no current export; use `useAuiState((s) => s.thread.messages)` (or `unstable_useThreadMessageIds()` when you only need ids and want to avoid re-rendering on content changes).
+
+Still present but deprecated: `useMessagePartText`, `useMessagePartReasoning`, `useMessagePartSource`, `useMessagePartImage`, `useMessagePartFile`, `useMessagePartData`. Replace them by selecting and narrowing `s.part`.
 
 ## Context Requirements
 
-Some hooks require being inside specific contexts:
-
 ```tsx
-// These work anywhere inside AssistantRuntimeProvider
+// Work anywhere inside AssistantRuntimeProvider
 useAui()
 useAuiState()
 useAuiEvent()
-useAssistantRuntime()
-useThreadRuntime()
-useThread()
-useThreadMessages()
-useComposer()
 
-// These require message context (inside ThreadPrimitive.Messages)
-useMessageRuntime()
-useMessage()
-
-// These require message part context
-useMessagePartRuntime()
+// Scopes that require a surrounding provider before they resolve:
+//   s.message / aui.message        - inside ThreadPrimitive.Messages
+//   s.part / aui.part              - inside MessagePrimitive.Parts
+//   s.attachment / aui.attachment  - inside a ComposerPrimitive.Attachments or
+//                                    MessagePrimitive.Attachments render function
+//   s.threadListItem               - inside ThreadListPrimitive.Items
 ```
+
+Reading one of those outside its provider throws. Use `s.optional.<scope>` or `aui.<scope>.source != null` when the component can render in both places.
 
 ## Performance Tips
 
@@ -264,20 +311,18 @@ function RunningIndicator() {
 
 ## Direct Subscription
 
-For non-React contexts:
+`subscribe` and `on` live on the client itself, not on the scope accessors. Read the scope's state inside the callback:
 
 ```tsx
-const api = useAui();
+const aui = useAui();
 
 useEffect(() => {
-  const runtime = api.thread();
-
-  // Subscribe to changes
-  const unsubscribe = runtime.subscribe(() => {
-    const state = runtime.getState();
-    console.log("State changed:", state);
+  const unsubscribe = aui.subscribe(() => {
+    console.log("State changed:", aui.thread.getState());
   });
 
   return unsubscribe;
-}, [api]);
+}, [aui]);
 ```
+
+`aui.on(selector, callback)` is the imperative form of `useAuiEvent`; both take the same event selectors and return an unsubscribe function.

--- a/assistant-ui/skills/runtime/references/thread-list.md
+++ b/assistant-ui/skills/runtime/references/thread-list.md
@@ -74,11 +74,11 @@ function ThreadListComponent() {
   );
 
   const handleSwitch = (threadId: string) => {
-    api.threads().switchToThread(threadId);
+    api.threads.switchToThread(threadId);
   };
 
   const handleNew = () => {
-    api.threads().switchToNewThread();
+    api.threads.switchToNewThread();
   };
 
   return (
@@ -99,7 +99,7 @@ function ThreadListComponent() {
 ```tsx
 function ThreadItem({ threadId }: { threadId: string }) {
   const api = useAui();
-  const item = api.threads().item({ id: threadId });
+  const item = api.threads.item({ id: threadId });
 
   const handleRename = async () => {
     await item.rename("New Title");
@@ -178,7 +178,7 @@ function SidebarWithThreadList() {
     <aside className="w-64 bg-gray-50 h-full">
       <div className="p-4">
         <button
-          onClick={() => api.threads().switchToNewThread()}
+          onClick={() => api.threads.switchToNewThread()}
           className="w-full p-2 bg-blue-500 text-white rounded"
         >
           New Chat
@@ -191,7 +191,7 @@ function SidebarWithThreadList() {
           return (
             <button
               key={threadId}
-              onClick={() => api.threads().switchToThread(threadId)}
+              onClick={() => api.threads.switchToThread(threadId)}
               className={`w-full p-2 text-left rounded ${
                 isActive ? "bg-blue-100" : "hover:bg-gray-100"
               }`}

--- a/assistant-ui/skills/runtime/references/voice.md
+++ b/assistant-ui/skills/runtime/references/voice.md
@@ -21,7 +21,7 @@ Connect a realtime voice backend (ElevenLabs, LiveKit, OpenAI Realtime, etc.) to
 Pass an adapter via `adapters.voice`. When provided, `capabilities.voice` is automatically set to `true`.
 
 ```ts
-import { useChatRuntime } from "@assistant-ui/react";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
 
 const runtime = useChatRuntime({
   adapters: {

--- a/assistant-ui/skills/setup/SKILL.md
+++ b/assistant-ui/skills/setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup
-description: "Installs and configures assistant-ui in a project via the CLI, and picks the right runtime for a backend. Use for first-time install, scaffold, or config: `npx assistant-ui@latest create my-app` (templates default, minimal, cloud, cloud-clerk, langgraph, mcp), `npx assistant-ui@latest init [--yes] [--overwrite]` in an existing Next.js app, or `npx assistant-ui@latest add` registry components (markdown-text, thread-list). Also use to choose a runtime hook for a backend: useChatRuntime (AI SDK), useLangGraphRuntime, useAgUiRuntime, useA2ARuntime, useLocalRuntime (custom streaming API), or useExternalStoreRuntime (Redux/Zustand). Covers Vite/TanStack Start setup, shadcn styling, the playground --preset flag, and avoiding the deprecated @assistant-ui/styles and @assistant-ui/react-ui packages. For upgrading an existing install or post-upgrade breakage use update; for building UI from raw parts use primitives."
+description: "Installs and configures assistant-ui in a project via the CLI, and picks the right runtime for a backend. Use for first-time install, scaffold, or config: `npx assistant-ui@latest create my-app` (templates default, minimal, cloud, cloud-clerk, langchain, mcp, eve), `npx assistant-ui@latest init [--yes] [--overwrite]` in an existing Next.js app, or `npx assistant-ui@latest add` registry components (thread, markdown-text, thread-list, tool-fallback). Also covers the other CLI verbs: doctor, info, update, upgrade, mcp, and agent. Use to choose a runtime hook for a backend: useChatRuntime (AI SDK v7), useLangGraphRuntime, useAgUiRuntime, useA2ARuntime, useLocalRuntime (custom streaming API), or useExternalStoreRuntime (Redux/Zustand). Covers Vite/TanStack Start setup, Expo (--native) and React Ink (--ink) scaffolds, shadcn and Base UI registry styles, the playground --preset flag, and avoiding the deprecated @assistant-ui/styles and @assistant-ui/react-ui packages. For upgrading an existing install or post-upgrade breakage use update; for building UI from raw parts use primitives."
 license: MIT
 ---
 
@@ -16,16 +16,18 @@ license: MIT
 - Existing app in CI/agent/non-interactive shell: use `npx assistant-ui@latest init --yes`
 - Existing app + force overwrite of conflicts: add `--overwrite`
 - New app / empty directory: use `npx assistant-ui@latest create <name>`
-- Need specific starter template: add `-t <default|minimal|cloud|cloud-clerk|langgraph|mcp>`
+- Need specific starter template: add `-t <default|minimal|cloud|cloud-clerk|langchain|mcp|eve>`
 - Need a curated example: use `npx assistant-ui@latest create <name> --example <example>`
-- Need playground preset config: use `npx assistant-ui@latest create <name> --preset <url>`
+- Need playground preset config: use `npx assistant-ui@latest create <name> --preset <name-or-url>`
+- Expo / React Native app: `npx assistant-ui@latest create <name> --native`
+- Terminal (React Ink) app: `npx assistant-ui@latest create <name> --ink`
 
 ### New Project (`create`)
 
 ```bash
 npx assistant-ui@latest create my-app -t minimal
 npx assistant-ui@latest create my-app -t cloud-clerk
-npx assistant-ui@latest create my-app --preset "https://www.assistant-ui.com/playground/init?preset=chatgpt"
+npx assistant-ui@latest create my-app --preset chatgpt
 ```
 
 Templates:
@@ -36,8 +38,15 @@ Templates:
 | `minimal` | Bare-bones starting point |
 | `cloud` | Cloud-backed persistence starter |
 | `cloud-clerk` | Cloud-backed starter with Clerk auth |
-| `langgraph` | LangGraph starter template |
-| `mcp` | MCP starter template |
+| `langchain` | LangGraph starter using the `@assistant-ui/react-langchain` adapter |
+| `mcp` | MCP tools + MCP Apps renderer starter |
+| `eve` | Eve agent + Next.js starter |
+
+There is no `langgraph` template; that path is now the `langchain` template (or the `with-langgraph` example for the `@assistant-ui/react-langgraph` adapter directly).
+
+Examples (`--example <name>`) currently include: `with-ag-ui`, `with-ai-sdk-v7`, `with-artifacts`, `with-assistant-transport`, `with-chain-of-thought`, `with-cloud`, `with-custom-thread-list`, `with-elevenlabs-conversational`, `with-elevenlabs-scribe`, `with-eve`, `with-expo`, `with-external-store`, `with-ffmpeg`, `with-google-adk`, `with-interactables`, `with-langgraph`, `with-livekit`, `with-react-hook-form`, `with-react-ink`, `with-react-router`, `with-resumable-stream`, `with-tanstack`.
+
+Other `create` flags: `--use-npm` / `--use-pnpm` / `--use-yarn` / `--use-bun`, `--skip-install`, and `--skills` / `--no-skills` (installs the assistant-ui agent skills for AI coding assistants; defaults to on in a non-TTY shell).
 
 When `-t` is omitted:
 - Interactive shell (TTY): an interactive template picker is shown.
@@ -60,11 +69,25 @@ The `--yes` flag runs non-interactively (no prompts).
 ### Add Registry Components
 
 ```bash
+npx assistant-ui@latest add thread
 npx assistant-ui@latest add markdown-text
 npx assistant-ui@latest add thread-list
 ```
 
 Registry: `https://r.assistant-ui.com/{name}.json`
+
+See [references/registry-components.md](./references/registry-components.md) for the full item list.
+
+### Other CLI Commands
+
+| Command | Purpose |
+|---------|---------|
+| `assistant-ui doctor` | Diagnose an existing install (version drift, misconfiguration); `--no-network` skips the registry check |
+| `assistant-ui info` | Print environment and package information for bug reports |
+| `assistant-ui update` | Bump assistant-ui packages to their latest versions (`--dry` prints the command) |
+| `assistant-ui upgrade` | Run the version codemods (`-d` dry run, `-p` print transformed files) |
+| `assistant-ui mcp` | Install the MCP docs server for Cursor, Windsurf, VSCode, Zed, Claude Code, or Claude Desktop |
+| `assistant-ui agent "<prompt>"` | Launch Claude Code preloaded with the assistant-ui skills (`--dry` prints the command) |
 
 ---
 
@@ -81,26 +104,36 @@ For runtimes other than AI SDK or frameworks other than Next.js, consult the ref
 | Setup | Runtime Hook | Reference |
 |-------|-------------|-----------|
 | AI SDK advanced (tools, cloud, options) | `useChatRuntime` | [references/ai-sdk.md](./references/ai-sdk.md) |
-| Styling and UI customization (shadcn pattern) | — | [references/styling.md](./references/styling.md) |
+| Styling and UI customization (shadcn / Base UI pattern) | n/a | [references/styling.md](./references/styling.md) |
 | LangGraph agents | `useLangGraphRuntime` | [references/langgraph.md](./references/langgraph.md) |
 | AG-UI protocol | `useAgUiRuntime` | [references/ag-ui.md](./references/ag-ui.md) |
 | A2A protocol | `useA2ARuntime` | [references/a2a.md](./references/a2a.md) |
 | Custom streaming API | `useLocalRuntime` | [references/custom-backend.md](./references/custom-backend.md) |
 | Existing state (Redux/Zustand) | `useExternalStoreRuntime` | [references/custom-backend.md](./references/custom-backend.md) |
-| Vite / TanStack Start | — | [references/tanstack.md](./references/tanstack.md) |
+| Vite / TanStack Start | n/a | [references/tanstack.md](./references/tanstack.md) |
 | LangChain agents | `useStreamRuntime` | [references/langchain.md](./references/langchain.md) |
 | Google ADK agents | `useAdkRuntime` | [references/google-adk.md](./references/google-adk.md) |
 | Mastra agents | `useChatRuntime` | [references/mastra.md](./references/mastra.md) |
 | Cloudflare Agents | `useAISDKRuntime` | [references/cloudflare-agents.md](./references/cloudflare-agents.md) |
-| Legacy AI SDK v4/v5 | `useVercelUseChatRuntime` / `useDataStreamRuntime` | [references/ai-sdk-legacy.md](./references/ai-sdk-legacy.md) |
+| Legacy AI SDK v4/v5/v6 | pinned adapter release | [references/ai-sdk-legacy.md](./references/ai-sdk-legacy.md) |
 | Registry UI components (modal, sidebar, model selector) | registry | [references/registry-components.md](./references/registry-components.md) |
 | DevTools inspector | dev only | [references/devtools.md](./references/devtools.md) |
+
+Runtime adapters with no reference file here (consult the docs site): `@assistant-ui/react-opencode` (`useOpenCodeRuntime`), `@assistant-ui/react-pi`, and `@assistant-ui/eve` (the `eve` template).
+
+### Platform targets
+
+| Target | Package | Scaffold |
+|--------|---------|----------|
+| Web (React) | `@assistant-ui/react` | `create` |
+| Expo / React Native | `@assistant-ui/react-native` + `@assistant-ui/metro` | `create <name> --native` |
+| Terminal | `@assistant-ui/react-ink` + `@assistant-ui/react-ink-markdown` | `create <name> --ink` |
 
 ---
 
 ## Deprecated Packages
 
-NEVER install `@assistant-ui/styles` or `@assistant-ui/react-ui` — both are deprecated and deleted.
+NEVER install `@assistant-ui/styles` or `@assistant-ui/react-ui`; both are deprecated and deleted.
 
 ---
 
@@ -108,5 +141,5 @@ NEVER install `@assistant-ui/styles` or `@assistant-ui/react-ui` — both are de
 
 For issues not covered by the reference files, use the docs website:
 
-1. **Fetch the index**: `https://www.assistant-ui.com/llms.txt` — compact table of contents
+1. **Fetch the index**: `https://www.assistant-ui.com/llms.txt` (compact table of contents)
 2. **Fetch specific pages**: Append `.mdx` to the docs URL, e.g. `https://www.assistant-ui.com/docs/runtimes/ai-sdk.mdx`

--- a/assistant-ui/skills/setup/references/ai-sdk-legacy.md
+++ b/assistant-ui/skills/setup/references/ai-sdk-legacy.md
@@ -1,14 +1,20 @@
-# AI SDK Legacy (v5 and v4)
+# AI SDK Legacy (v6, v5, and v4)
 
-Keep an app on a legacy AI SDK release instead of migrating to v6. v5 stays on `@assistant-ui/react-ai-sdk@0.x` + `ai@^5` with `useVercelUseChatRuntime`; v4 uses `useDataStreamRuntime` from `@assistant-ui/react-data-stream` + `ai@^4`. For new projects on `ai@^6`, see `ai-sdk.md` instead.
+Keep an app on a legacy AI SDK release instead of migrating to v7. Each older AI SDK major needs a pinned adapter release, because `@assistant-ui/react-ai-sdk@latest` (1.4.x) depends on `ai@^7`. For new projects, see `ai-sdk.md` instead.
+
+| AI SDK | Adapter package to install | Runtime hook |
+|---|---|---|
+| `ai@^7` + `@ai-sdk/react@^4` | `@assistant-ui/react-ai-sdk@latest` | `useChatRuntime` |
+| `ai@^6` + `@ai-sdk/react@^3` | `@assistant-ui/react-ai-sdk@1.3.40` | `useChatRuntime` |
+| `ai@^5` + `@ai-sdk/react@^2` | `@assistant-ui/react-ai-sdk@1.1.21` | `useChatRuntime` |
+| `ai@^4` | `@assistant-ui/react-data-stream` | `useDataStreamRuntime` |
+
+These pins receive no new features and have known compatibility gaps against current `@assistant-ui/react`.
 
 ## Contents
 
+- [AI SDK v6 (legacy)](#ai-sdk-v6-legacy)
 - [AI SDK v5 (legacy)](#ai-sdk-v5-legacy)
-  - [Install](#install)
-  - [Backend route](#backend-route)
-  - [Frontend with useVercelUseChatRuntime](#frontend-with-usevercelusechatruntime)
-  - [Note on 0.11.3+](#note-on-0113)
 - [AI SDK v4 (legacy)](#ai-sdk-v4-legacy)
   - [Install](#install-1)
   - [Backend route](#backend-route-1)
@@ -16,14 +22,42 @@ Keep an app on a legacy AI SDK release instead of migrating to v6. v5 stays on `
   - [useDataStreamRuntime options](#usedatastreamruntime-options)
 - [Why these are legacy](#why-these-are-legacy)
 
+## AI SDK v6 (legacy)
+
+Pin `@assistant-ui/react-ai-sdk@1.3.40` with `ai@^6` and `@ai-sdk/react@^3`.
+
+```bash
+npm install @assistant-ui/react @assistant-ui/react-ai-sdk@1.3.40 ai@^6 @ai-sdk/react@^3 @ai-sdk/openai@^3 zod
+```
+
+The wiring is the same as v7 except the route response:
+
+```ts
+import { openai } from "@ai-sdk/openai";
+import { streamText, convertToModelMessages, type UIMessage } from "ai";
+
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json();
+
+  const result = streamText({
+    model: openai("gpt-5.4-nano"),
+    messages: await convertToModelMessages(messages),
+  });
+
+  return result.toUIMessageStreamResponse();
+}
+```
+
+In v7 that method is deprecated in favor of `createUIMessageStreamResponse({ stream: toUIMessageStream({ stream: result.stream }) })`.
+
 ## AI SDK v5 (legacy)
 
-Stays on `@assistant-ui/react-ai-sdk@0.x` paired with `ai@^5`. Tools use `parameters:` (not `inputSchema:`), and the route returns `toDataStreamResponse()`.
+Pin `@assistant-ui/react-ai-sdk@1.1.21` with `ai@^5`. Tools use `parameters:` (not `inputSchema:`), and the route returns `toDataStreamResponse()`.
 
 ### Install
 
 ```bash
-npm install @assistant-ui/react @assistant-ui/react-ai-sdk@0.x ai@^5 @ai-sdk/openai@^1 zod
+npm install @assistant-ui/react @assistant-ui/react-ai-sdk@1.1.21 ai@^5 @ai-sdk/react@^2 @ai-sdk/openai@^1 zod
 ```
 
 ### Backend route
@@ -58,21 +92,21 @@ export async function POST(req: Request) {
 
 Note: in v5 `streamText` takes `messages` directly (no `convertToModelMessages`), tools use `parameters:`, and the response is `toDataStreamResponse()`.
 
-### Frontend with useVercelUseChatRuntime
+### Frontend
 
-Drive the AI SDK `useChat` hook yourself, then hand the chat helpers to `useVercelUseChatRuntime`. The `useChat` import comes from `ai/react` in v5.
+`@assistant-ui/react-ai-sdk@1.1.21` exposes `useChatRuntime` and `useAISDKRuntime`. Prefer `useChatRuntime`; reach for `useAISDKRuntime` when you need to own the `useChat` instance.
 
 ```tsx
 "use client";
 
-import { useChat } from "ai/react";
-import { useVercelUseChatRuntime } from "@assistant-ui/react-ai-sdk";
+import { useChat } from "@ai-sdk/react";
+import { useAISDKRuntime } from "@assistant-ui/react-ai-sdk";
 import { AssistantRuntimeProvider } from "@assistant-ui/react";
 import { Thread } from "@/components/assistant-ui/thread";
 
 export default function Home() {
   const chat = useChat({ api: "/api/chat" });
-  const runtime = useVercelUseChatRuntime(chat);
+  const runtime = useAISDKRuntime(chat);
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
@@ -84,9 +118,7 @@ export default function Home() {
 }
 ```
 
-### Note on 0.11.3+
-
-`useVercelUseChatRuntime` is the wiring for `@assistant-ui/react-ai-sdk` older than 0.11.3. On 0.11.3 and later (still within the `0.x` line) you can call `useChatRuntime` directly instead of managing `useChat` yourself.
+`useVercelUseChatRuntime` was the pre-0.11.3 name for this wiring and no longer exists on any current release line.
 
 ## AI SDK v4 (legacy)
 
@@ -151,16 +183,17 @@ Note: human in the loop tools (`human()` interrupts) are not supported by the da
 
 ## Why these are legacy
 
-AI SDK v6 introduced breaking API changes, and `@assistant-ui/react-ai-sdk` follows v6 going forward. Differences that show up when these legacy stacks are upgraded:
+Each AI SDK major introduced breaking API changes, and `@assistant-ui/react-ai-sdk` tracks the newest one. Differences that show up when a legacy stack is upgraded:
 
-| Area | v4 | v5 | v6 (current) |
-|---|---|---|---|
-| `ai` package | `ai@^4` | `ai@^5` | `ai@^6` |
-| `@ai-sdk/openai` | any | `^1` | `^3` |
-| Runtime package | `@assistant-ui/react-data-stream` | `@assistant-ui/react-ai-sdk@0.x` | `@assistant-ui/react-ai-sdk` |
-| Runtime hook | `useDataStreamRuntime` | `useVercelUseChatRuntime` | `useChatRuntime` |
-| `convertToModelMessages` | not used | sync | async (`await`) |
-| Tool schema key | n/a | `parameters:` | `inputSchema:` |
-| Response method | `toDataStreamResponse()` | `toDataStreamResponse()` | `toUIMessageStreamResponse()` |
+| Area | v4 | v5 | v6 | v7 (current) |
+|---|---|---|---|---|
+| `ai` package | `ai@^4` | `ai@^5` | `ai@^6` | `ai@^7` |
+| `@ai-sdk/react` | `ai/react` | `^2` | `^3` | `^4` |
+| `@ai-sdk/openai` | any | `^1` | `^3` | `^4` |
+| Adapter package | `@assistant-ui/react-data-stream` | `@assistant-ui/react-ai-sdk@1.1.21` | `@assistant-ui/react-ai-sdk@1.3.40` | `@assistant-ui/react-ai-sdk@latest` |
+| Runtime hook | `useDataStreamRuntime` | `useChatRuntime` | `useChatRuntime` | `useChatRuntime` |
+| `convertToModelMessages` | not used | sync | async (`await`) | async (`await`) |
+| Tool schema key | n/a | `parameters:` | `inputSchema:` | `inputSchema: zodSchema(...)` |
+| Response | `toDataStreamResponse()` | `toDataStreamResponse()` | `toUIMessageStreamResponse()` | `createUIMessageStreamResponse({ stream: toUIMessageStream({ stream: result.stream }) })` |
 
-To move off legacy, switch the runtime hook to `useChatRuntime`, update the backend to v6 `streamText`, and apply the AI SDK codemods at `ai-sdk.dev/docs/migration-guides`.
+To move off legacy, switch the runtime hook to `useChatRuntime`, update the backend to v7 `streamText`, and apply the AI SDK codemods at `ai-sdk.dev/docs/migration-guides`.

--- a/assistant-ui/skills/setup/references/ai-sdk.md
+++ b/assistant-ui/skills/setup/references/ai-sdk.md
@@ -142,7 +142,9 @@ const runtime = useChatRuntime({
 
 ## Tools (AI SDK v7 shape)
 
-Use `tool({ inputSchema })` and `stopWhen: stepCountIs(...)` for multi-step tool loops. Wrapping the schema in `zodSchema()` is the documented v7 form.
+Use `tool({ inputSchema })` and `stopWhen: stepCountIs(...)` for multi-step tool loops.
+
+`inputSchema` is typed `FlexibleSchema`, which accepts a raw Zod schema, a Standard Schema, or the result of `zodSchema()` / `jsonSchema()`. Passing `z.object({ ... })` directly is valid; `zodSchema(z.object({ ... }))` is the explicit form the upstream quickstart uses. Both work, so pick one and stay consistent within a project.
 
 ```ts
 import { openai } from "@ai-sdk/openai";
@@ -184,7 +186,9 @@ Without a `stopWhen`, AI SDK runs a single inference step; set `stepCountIs(n)` 
 
 ## Server-Side Tool Approval
 
-AI SDK v7 gates tool execution with the call-level `toolApproval` option. The server pauses, emits an `approval-requested` part, and resumes once the client posts a response. assistant-ui surfaces the gate as `approval` on the tool part and passes `respondToApproval` into the renderer.
+AI SDK v7 gates tool execution either with `needsApproval` on the tool definition or with the call-level `toolApproval` option; both exist and can be used together. The server pauses, emits an `approval-requested` part, and resumes once the client posts a response. assistant-ui surfaces the gate as `approval` on the tool part and passes `respondToApproval` into the renderer.
+
+`toolApproval` is the per-call form, which is what the example below uses because the decision depends on the input:
 
 ```ts
 const result = streamText({

--- a/assistant-ui/skills/setup/references/ai-sdk.md
+++ b/assistant-ui/skills/setup/references/ai-sdk.md
@@ -1,19 +1,28 @@
-# AI SDK v6 Integration
+# AI SDK v7 Integration
 
-Use this when the app uses `@assistant-ui/react-ai-sdk` and an `/api/chat` route powered by `ai@^6`.
+Use this when the app uses `@assistant-ui/react-ai-sdk` and an `/api/chat` route powered by `ai@^7`.
 
-## What Changed in AI SDK v6
+`@assistant-ui/react-ai-sdk` 1.4.x targets AI SDK v7 (`ai@^7`, `@ai-sdk/react@^4`). Projects still on an older AI SDK major must pin an older adapter release; see [ai-sdk-legacy.md](./ai-sdk-legacy.md).
+
+```bash
+npm install @assistant-ui/react @assistant-ui/react-ai-sdk ai@^7 @ai-sdk/react@^4 @ai-sdk/openai zod
+```
+
+## What Changed in AI SDK v7
 
 Agents trained on older AI SDK versions will use outdated patterns. These are **AI SDK** breaking changes (not assistant-ui changes):
 
-| Concept | Old (v4/v5) | Current (v6) |
-|---------|-------------|--------------|
-| useChat import | `import { useChat } from "ai/react"` | `import { useChat } from "@ai-sdk/react"` |
-| assistant-ui wiring | `useAISDKRuntime(chat)` | `useChatRuntime({ transport })` |
-| Message conversion | Pass messages directly to `streamText` | `await convertToModelMessages(messages)` |
-| Stream response | `result.toDataStreamResponse()` | `result.toUIMessageStreamResponse()` |
-| Tool schema key | `parameters: z.object({...})` | `inputSchema: z.object({...})` |
-| Multi-step tools | `maxSteps: n` | `stopWhen: stepCountIs(n)` |
+| Concept | Old (v4/v5) | v6 | Current (v7) |
+|---------|-------------|----|--------------|
+| `ai` package | `ai@^4` / `ai@^5` | `ai@^6` | `ai@^7` |
+| `@ai-sdk/react` | `ai/react` / `@ai-sdk/react@^2` | `@ai-sdk/react@^3` | `@ai-sdk/react@^4` |
+| assistant-ui wiring | `useAISDKRuntime(chat)` | `useChatRuntime({ transport })` | `useChatRuntime()` |
+| Message conversion | Pass messages directly | `await convertToModelMessages(messages)` | `await convertToModelMessages(messages)` |
+| Stream response | `result.toDataStreamResponse()` | `result.toUIMessageStreamResponse()` | `createUIMessageStreamResponse({ stream: toUIMessageStream({ stream: result.stream }) })` |
+| Tool schema key | `parameters: z.object({...})` | `inputSchema: z.object({...})` | `inputSchema: zodSchema(z.object({...}))` |
+| Multi-step tools | `maxSteps: n` | `stopWhen: stepCountIs(n)` | `stopWhen: stepCountIs(n)` |
+
+`result.toUIMessageStreamResponse()` still compiles in v7 but is deprecated and scheduled for removal in the next major; write new routes with the standalone helpers.
 
 ## Standard Setup
 
@@ -42,12 +51,20 @@ export function Assistant() {
 }
 ```
 
+`useChatRuntime()` defaults to `AssistantChatTransport` pointing at `/api/chat`, so the no-argument form is the common case.
+
 **Backend** route (`app/api/chat/route.ts`):
 
 ```ts
 import { openai } from "@ai-sdk/openai";
 import { frontendTools } from "@assistant-ui/react-ai-sdk";
-import { streamText, convertToModelMessages, type UIMessage } from "ai";
+import {
+  streamText,
+  convertToModelMessages,
+  createUIMessageStreamResponse,
+  toUIMessageStream,
+  type UIMessage,
+} from "ai";
 
 export async function POST(req: Request) {
   const {
@@ -61,7 +78,7 @@ export async function POST(req: Request) {
   } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-4o"),
+    model: openai("gpt-5.4-mini"),
     system,
     messages: await convertToModelMessages(messages),
     tools: {
@@ -69,21 +86,23 @@ export async function POST(req: Request) {
     },
   });
 
-  return result.toUIMessageStreamResponse();
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({ stream: result.stream }),
+  });
 }
 ```
 
 `AssistantChatTransport` (the default transport for `useChatRuntime`) automatically forwards `system` and `tools` from the frontend to the backend:
 
-- **`system`** — set via `useAssistantInstructions()` on the frontend, sent as a string in the request body.
-- **`tools`** — registered via `makeAssistantTool()` or `useAssistantTool()` on the frontend, sent as JSON Schema definitions in the request body.
-- **`frontendTools()`** — converts those JSON Schema definitions into the AI SDK tool format so `streamText` can use them alongside backend-defined tools.
+- **`system`**: set via `useAssistantInstructions()` on the frontend, sent as a string in the request body.
+- **`tools`**: registered via `makeAssistantTool()` or `useAssistantTool()` on the frontend, sent as JSON Schema definitions in the request body.
+- **`frontendTools()`**: converts those JSON Schema definitions into the AI SDK tool format so `streamText` can use them alongside backend-defined tools.
 
 The route must destructure and use both `system` and `tools` for frontend tool forwarding to work.
 
 ## Runtime Options
 
-`useChatRuntime` supports the underlying AI SDK chat options plus assistant-ui extensions like `cloud`, `adapters`, and `toCreateMessage`.
+`useChatRuntime` supports the underlying AI SDK chat options plus assistant-ui extensions like `cloud`, `adapters`, `onThreadIdChange`, `joinStrategy`, and `onResume`.
 
 ```tsx
 import { useChatRuntime, AssistantChatTransport } from "@assistant-ui/react-ai-sdk";
@@ -93,7 +112,7 @@ const runtime = useChatRuntime({
   transport: new AssistantChatTransport({
     api: "/api/chat",
     headers: { "X-Workspace": "acme" },
-    body: { model: "gpt-4o-mini" },
+    body: { model: "gpt-5.4-mini" },
   }),
   messages: [
     { id: "1", role: "assistant", parts: [{ type: "text", text: "Hello! How can I help?" }] },
@@ -121,17 +140,20 @@ const runtime = useChatRuntime({
 });
 ```
 
-## Tools (AI SDK v6 shape)
+## Tools (AI SDK v7 shape)
 
-Use `tool({ inputSchema: z.object({...}) })` and `stopWhen: stepCountIs(...)` for multi-step tool loops.
+Use `tool({ inputSchema })` and `stopWhen: stepCountIs(...)` for multi-step tool loops. Wrapping the schema in `zodSchema()` is the documented v7 form.
 
 ```ts
 import { openai } from "@ai-sdk/openai";
 import {
   streamText,
   tool,
+  zodSchema,
   stepCountIs,
   convertToModelMessages,
+  createUIMessageStreamResponse,
+  toUIMessageStream,
   type UIMessage,
 } from "ai";
 import { z } from "zod";
@@ -140,21 +162,49 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-4o"),
+    model: openai("gpt-5.4-mini"),
     messages: await convertToModelMessages(messages),
     stopWhen: stepCountIs(10),
     tools: {
       get_weather: tool({
         description: "Get weather by city",
-        inputSchema: z.object({ city: z.string() }),
+        inputSchema: zodSchema(z.object({ city: z.string() })),
         execute: async ({ city }) => ({ city, temperature: 22, unit: "C" }),
       }),
     },
   });
 
-  return result.toUIMessageStreamResponse();
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({ stream: result.stream }),
+  });
 }
 ```
+
+Without a `stopWhen`, AI SDK runs a single inference step; set `stepCountIs(n)` when tools chain.
+
+## Server-Side Tool Approval
+
+AI SDK v7 gates tool execution with the call-level `toolApproval` option. The server pauses, emits an `approval-requested` part, and resumes once the client posts a response. assistant-ui surfaces the gate as `approval` on the tool part and passes `respondToApproval` into the renderer.
+
+```ts
+const result = streamText({
+  model: openai("gpt-5.4-mini"),
+  messages: await convertToModelMessages(messages),
+  tools: {
+    deploy: tool({
+      description: "Deploy the current build to an environment.",
+      inputSchema: z.object({ target: z.string() }),
+      execute: async ({ target }) => ({ deployed: target }),
+    }),
+  },
+  toolApproval: {
+    deploy: (input) =>
+      input.target === "production" ? "user-approval" : "not-applicable",
+  },
+});
+```
+
+On the client, use `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses` so the decision is posted back automatically. See the `/tools` skill for the renderer side.
 
 ## Frontend Tool UI
 
@@ -183,9 +233,21 @@ const WeatherToolUI = makeAssistantToolUI({
 </AssistantRuntimeProvider>
 ```
 
+## Token Usage
+
+`@assistant-ui/react-ai-sdk` exposes per-thread token accounting:
+
+```tsx
+import { useThreadTokenUsage } from "@assistant-ui/react-ai-sdk";
+
+const usage = useThreadTokenUsage(); // ThreadTokenUsage | undefined
+```
+
+`getThreadMessageTokenUsage(message)` reads usage off a single message outside React.
+
 ## Using Different Providers
 
-Swap the model in `streamText()` — any `@ai-sdk/*` provider works:
+Swap the model in `streamText()`; any `@ai-sdk/*` provider works:
 
 ```ts
 import { anthropic } from "@ai-sdk/anthropic";
@@ -207,7 +269,7 @@ Pass the model name from the frontend via `body`, then select the provider on th
 const runtime = useChatRuntime({
   transport: new AssistantChatTransport({
     api: "/api/chat",
-    body: { model: "gpt-4o-mini" },
+    body: { model: "gpt-5.4-mini" },
   }),
 });
 ```
@@ -231,7 +293,8 @@ const result = streamText({
 Pass a `cloud` instance to `useChatRuntime` to enable thread persistence and history. Use `ThreadList` to display saved threads.
 
 ```tsx
-import { AssistantCloud, AssistantRuntimeProvider } from "@assistant-ui/react";
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { AssistantCloud } from "assistant-cloud";
 import { Thread } from "@/components/assistant-ui/thread";
 import { ThreadList } from "@/components/assistant-ui/thread-list";
 import { useChatRuntime, AssistantChatTransport } from "@assistant-ui/react-ai-sdk";
@@ -262,14 +325,13 @@ See the `/cloud` skill for authentication and configuration details.
 
 **"Module not found: @ai-sdk/react"**
 ```bash
-npm install @ai-sdk/react
+npm install @ai-sdk/react@^4
 ```
 
 **"useChat is not a function"**
-Mixing v5 and v6. Remove old imports:
+Mixing AI SDK majors. Align `ai`, `@ai-sdk/react`, and the provider packages:
 ```bash
-npm uninstall ai/react  # if present
-npm install @ai-sdk/react@latest ai@latest
+npm install ai@^7 @ai-sdk/react@^4 @ai-sdk/openai@latest
 ```
 
 **Streaming stops mid-response**
@@ -280,8 +342,9 @@ Ensure you return from tool.execute(), not just mutate state.
 
 ## Known Pitfalls
 
-- `convertToModelMessages` is async in AI SDK v6: always `await` it.
-- Use `toUIMessageStreamResponse()` for route responses, NOT `toDataStreamResponse()`.
-- In v6 tool definitions, use `inputSchema`, NOT `parameters`.
+- `convertToModelMessages` is async: always `await` it.
+- Build route responses with `createUIMessageStreamResponse({ stream: toUIMessageStream({ stream: result.stream }) })`. `toDataStreamResponse()` is gone; `result.toUIMessageStreamResponse()` is deprecated.
+- In v6+ tool definitions, use `inputSchema`, NOT `parameters`.
 - `stopWhen: stepCountIs(n)` replaces `maxSteps: n` for multi-step tool loops.
 - If you replace the transport, use `AssistantChatTransport` unless you intentionally want to disable assistant-tool/system forwarding.
+- `@ai-sdk/openai@^4` pairs with `ai@^7`; provider packages have their own major line.

--- a/assistant-ui/skills/setup/references/custom-backend.md
+++ b/assistant-ui/skills/setup/references/custom-backend.md
@@ -14,7 +14,7 @@ For backends that return streaming responses. Emit `ChatModelRunResult` chunks (
 
 ### Basic Setup
 
-Plain-text streaming only. For AI SDK Data Stream responses, use `toUIMessageStreamResponse()` + `useChatRuntime` or decode with `DataStreamDecoder`.
+Plain-text streaming only. For AI SDK UI-message responses, build the route with `toUIMessageStream` + `createUIMessageStreamResponse` and use `useChatRuntime`, or decode with `DataStreamDecoder`.
 
 ```tsx
 import { useLocalRuntime, AssistantRuntimeProvider } from "@assistant-ui/react";

--- a/assistant-ui/skills/setup/references/devtools.md
+++ b/assistant-ui/skills/setup/references/devtools.md
@@ -8,7 +8,7 @@ Inspect assistant-ui runtime state, context, and events in the browser without `
 npm install @assistant-ui/react-devtools
 ```
 
-The package peer-depends on `@assistant-ui/react` (`^0.14.12`); it reads from the same Assistant API context, so it only works inside a runtime provider.
+The package peer-depends on `@assistant-ui/react` (`^0.15.0`) and `@assistant-ui/tap` (`^0.9.0`); it reads from the same Assistant API context, so it only works inside a runtime provider.
 
 ## Basic Setup
 
@@ -18,6 +18,7 @@ Render `<DevToolsModal />` as a child of `AssistantRuntimeProvider`, alongside y
 "use client";
 
 import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
 import { DevToolsModal } from "@assistant-ui/react-devtools";
 import { Thread } from "@/components/assistant-ui/thread";
 
@@ -48,23 +49,44 @@ Note: the guard keys off `process.env.NODE_ENV`. If your bundler does not define
 {process.env.NODE_ENV !== "production" && <DevToolsModal />}
 ```
 
-## Inline Frame
+## Inline Panel
 
-`DevToolsFrame` embeds the same inspector inline instead of behind a modal button. Use it to dock DevTools into a panel of your own layout. It accepts standard iframe props such as `style`.
+`DevToolsPanel` embeds the same inspector inline instead of behind a modal button. Use it to dock DevTools into a panel of your own layout.
 
 ```tsx
-import { DevToolsFrame } from "@assistant-ui/react-devtools";
+import { DevToolsPanel } from "@assistant-ui/react-devtools";
 
 <div className="h-96 w-full">
-  <DevToolsFrame style={{ width: "100%", height: "100%", border: "none" }} />
+  <DevToolsPanel theme="dark" onClose={() => setOpen(false)} />
 </div>
 ```
 
-`DevToolsModal` itself wraps a `DevToolsFrame`, so both surfaces show the same event log, context viewer, and runtime inspector.
+`DevToolsModal` wraps a `DevToolsPanel`, so both surfaces show the same event log, context viewer, and runtime inspector.
 
-## Dark Mode
+## Theme
 
-The modal reads dark mode from the `dark` class on `<html>` or `<body>` and reacts to changes via a `MutationObserver`, matching the shadcn class-based dark mode used by registry components. No configuration is required.
+Both surfaces take a `theme` prop. `DevToolsModal` accepts `"dark" | "light" | "system"` and defaults to following the page; `DevToolsPanel` takes an explicit `"dark" | "light"`. Styles are isolated inside a `ShadowRoot`, so the inspector does not inherit or leak your app's CSS.
+
+## Custom Tabs
+
+The panel's tab list is a plugin array. `builtinPlugins` is the default set; `createDevToolsPlugin` types a custom entry.
+
+```tsx
+import {
+  DevToolsModal,
+  builtinPlugins,
+  createDevToolsPlugin,
+} from "@assistant-ui/react-devtools";
+
+const myTab = createDevToolsPlugin({
+  id: "my-tab",
+  label: "My Tab",
+  order: 100,
+  Component: ({ client }) => <pre>{JSON.stringify(client, null, 2)}</pre>,
+});
+
+<DevToolsModal plugins={[...builtinPlugins, myTab]} />;
+```
 
 ## Chrome Extension
 
@@ -74,7 +96,11 @@ A standalone Chrome extension consumes the same package and connects to any page
 
 | Export | Purpose |
 |-------|-------|
-| `DevToolsModal` | Floating button plus modal overlay; dev-only, no props |
-| `DevToolsFrame` | Inline iframe host for the inspector; accepts iframe props |
+| `DevToolsModal` | Floating button plus modal overlay; dev-only. Props: `plugins`, `theme`, `client` |
+| `DevToolsPanel` | Inline inspector surface. Props: `plugins`, `theme`, `onClose`, `client` |
+| `ShadowRoot` | Style-isolated container the panel renders into |
+| `builtinPlugins` / `createDevToolsPlugin` | Default tab set and helper for custom tabs |
+| `DevToolsClient` / `createInProcessClient` / `inProcessClient` | Client the panel reads from; swap it to inspect a remote page |
+| `serializeModelContext` / `normalizeToolList` | Serialization helpers used by custom hosts such as the Chrome extension |
 
-Lower-level host and frame bridges (`FrameHost`, `DevToolsHost`, `ExtensionHost`, `FrameClient`) and serialization helpers (`sanitizeForMessage`, `serializeModelContext`, `normalizeToolList`) are also exported for building custom hosts such as the Chrome extension. Most apps only need `DevToolsModal`.
+Most apps only need `DevToolsModal`.

--- a/assistant-ui/skills/setup/references/langchain.md
+++ b/assistant-ui/skills/setup/references/langchain.md
@@ -167,7 +167,7 @@ const runtime = useStreamRuntime({
 
 Both packages connect assistant-ui to LangGraph backends and both build on `useExternalStoreRuntime`. They are independent adapters for different upstream libraries; one is not a successor to the other. `react-langgraph` wraps the raw `@langchain/langgraph-sdk` (~7,500 lines); `react-langchain` wraps `useStream` from `@langchain/react` (~600 lines).
 
-Pick `react-langchain` when your app already depends on `@langchain/react`, when you want to read custom state keys reactively with `useLangChainState<T>(key)`, or when you prefer a thin wrapper pinned to upstream behavior. Pick `react-langgraph` when scaffolding via `npx create-assistant-ui -t langgraph` (the template uses it), or when you need per-message metadata, generative UI messages, subgraph/namespaced stream events, or end-to-end cancellation today. Features absent from `react-langchain` have not been ported, not deprecated.
+Pick `react-langchain` when your app already depends on `@langchain/react`, when you want to read custom state keys reactively with `useLangChainState<T>(key)`, or when you prefer a thin wrapper pinned to upstream behavior. Pick `react-langgraph` for the `with-langgraph` example (`npx assistant-ui@latest create <name> --example with-langgraph`), or when you need per-message metadata, generative UI messages, subgraph/namespaced stream events, or end-to-end cancellation today. Features absent from `react-langchain` have not been ported, not deprecated.
 
 Hook name mapping:
 

--- a/assistant-ui/skills/setup/references/mastra.md
+++ b/assistant-ui/skills/setup/references/mastra.md
@@ -18,7 +18,7 @@ Wire Mastra agents into assistant-ui. There is no `@assistant-ui/react-mastra` p
 | Full-stack | Next.js API route in the same app | `agent.stream()` + `toAISdkStream` + `createUIMessageStream` | default (`AssistantChatTransport` to `/api/chat`) |
 | Separate server | Standalone Mastra server | `chatRoute({ path })` from `@mastra/ai-sdk` | `AssistantChatTransport` pointed at the Mastra URL |
 
-Both modes use `useChatRuntime` from `@assistant-ui/react-ai-sdk`. Mastra never exposes a dedicated assistant-ui package; the integration rides the AI SDK v6 runtime. Do not reach for `@mastra/client-js` for the chat stream; the browser talks to the Mastra HTTP route directly through `AssistantChatTransport`.
+Both modes use `useChatRuntime` from `@assistant-ui/react-ai-sdk`. Mastra never exposes a dedicated assistant-ui package; the integration rides the AI SDK runtime. Do not reach for `@mastra/client-js` for the chat stream; the browser talks to the Mastra HTTP route directly through `AssistantChatTransport`.
 
 ## Full-Stack (agent in a Next.js route)
 
@@ -188,7 +188,7 @@ For auth, `AssistantChatTransport` accepts `headers` and `credentials` options; 
 - No `@assistant-ui/react-mastra` exists. Anything claiming such an import is wrong.
 - `toAISdkStream(stream, { from: "agent" })` adapts the Mastra-native stream from `agent.stream()` into AI SDK parts; `from: "agent"` tags the source.
 - Mastra runs its own server with `.env.development`; the assistant-ui frontend uses `.env.local`. Keep them separate.
-- Because the integration is the AI SDK v6 runtime, the AI SDK reference (frontend tool forwarding, attachments, cloud persistence) applies unchanged. See the AI SDK reference.
+- Because the integration is the AI SDK runtime, the AI SDK reference (frontend tool forwarding, attachments, cloud persistence) applies unchanged. See the AI SDK reference.
 
 ## Troubleshooting
 

--- a/assistant-ui/skills/setup/references/registry-components.md
+++ b/assistant-ui/skills/setup/references/registry-components.md
@@ -4,10 +4,39 @@ Optional UI components installed via `npx assistant-ui add <name>`. Like all reg
 
 ## Contents
 
+- [Available items](#available-items)
+- [Radix vs Base UI flavors](#radix-vs-base-ui-flavors)
 - [AssistantModal](#assistantmodal)
 - [AssistantSidebar](#assistantsidebar)
 - [ModelSelector](#modelselector)
 - [Attachment UI](#attachment-ui)
+
+## Available items
+
+`npx assistant-ui@latest add <name>` currently serves:
+
+| Group | Items |
+|-------|-------|
+| Chat surfaces | `thread`, `thread-list`, `threadlist-sidebar`, `assistant-modal`, `assistant-sidebar`, `eve-chat` |
+| Message rendering | `markdown-text`, `shiki-highlighter`, `syntax-highlighter`, `mermaid-diagram`, `reasoning`, `sources`, `quote`, `message-timing`, `directive-text` |
+| Tools and generative UI | `tool-fallback`, `tool-group`, `generative-ui`, `generative-ui-style`, `mcp-config`, `context-display` |
+| Composer and input | `composer-trigger-popover`, `attachment`, `file`, `image`, `voice`, `follow-up-suggestions` |
+| Backend routes | `ai-sdk-backend`, `ai-sdk-backend-resumable` |
+| Shared UI | `accordion`, `badge`, `select`, `tabs`, `tooltip-icon-button`, `dot-matrix`, `number-roll`, `diff-viewer`, `heat-graph`, `logos`, `shimmer-style`, `direction`, `model-selector` |
+
+## Radix vs Base UI flavors
+
+The registry ships both a Radix and a Base UI flavor of each component. Point `components.json` at the style-aware URL so installs follow your shadcn style:
+
+```json
+{
+  "registries": {
+    "@assistant-ui": "https://r.assistant-ui.com/styles/{style}/{name}.json"
+  }
+}
+```
+
+`{style}` comes from the `style` field in `components.json`. A style whose name starts with `base-` resolves to the Base UI components; every other style resolves to Radix. Existing Radix projects can keep the flat `https://r.assistant-ui.com/{name}.json` URL as a fallback.
 
 ## AssistantModal
 
@@ -128,7 +157,7 @@ Render it inside `AssistantRuntimeProvider`. Each `ModelOption` is `{ id, name, 
 
 ### How registration works
 
-The component subscribes the selected model into the model context via `useAui().modelContext().register`. The `register` callback returns its own unsubscribe function, so returning it from `useEffect` cleans up on change:
+The component subscribes the selected model into the model context via `useAui().modelContext.register`. The `register` callback returns its own unsubscribe function, so returning it from `useEffect` cleans up on change:
 
 ```tsx
 import { useEffect } from "react";
@@ -138,7 +167,7 @@ const api = useAui();
 
 useEffect(() => {
   const config = { config: { modelName: value } };
-  return api.modelContext().register({
+  return api.modelContext.register({
     getModelContext: () => config,
   });
 }, [api, value]);
@@ -151,15 +180,22 @@ The `config` object rides along in the request body. With the AI SDK route the r
 ```ts
 // app/api/chat/route.ts
 import { openai } from "@ai-sdk/openai";
-import { streamText, convertToModelMessages } from "ai";
+import {
+  streamText,
+  convertToModelMessages,
+  createUIMessageStreamResponse,
+  toUIMessageStream,
+} from "ai";
 
 export async function POST(req: Request) {
   const { messages, config } = await req.json();
   const result = streamText({
     model: openai(config?.modelName ?? "gpt-5.4-nano"),
-    messages: convertToModelMessages(messages),
+    messages: await convertToModelMessages(messages),
   });
-  return result.toUIMessageStreamResponse();
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({ stream: result.stream }),
+  });
 }
 ```
 

--- a/assistant-ui/skills/setup/references/styling.md
+++ b/assistant-ui/skills/setup/references/styling.md
@@ -88,4 +88,4 @@ For building entirely custom layouts, compose directly with `ThreadPrimitive`, `
 ## Legacy / Deprecated
 
 - Never install `@assistant-ui/styles` or `@assistant-ui/react-ui`, they are deprecated legacy packages.
-- Existing `aui-*` classes in registry components are legacy identifiers — they do not impact styling and can be safely ignored.
+- Existing `aui-*` classes in registry components are legacy identifiers; they do not impact styling and can be safely ignored.

--- a/assistant-ui/skills/streaming/SKILL.md
+++ b/assistant-ui/skills/streaming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: streaming
-description: "Streaming backends and wire protocols for assistant-ui via the assistant-stream package. Use when building a custom (non-AI-SDK) streaming endpoint with createAssistantStreamResponse or createAssistantStreamController, emitting parts through appendText/appendReasoning/appendSource/appendFile/addToolCallPart and setResponse; choosing between the AI SDK Data Stream format (toUIMessageStreamResponse) and the native Assistant Transport format; encoding or decoding streams with DataStreamEncoder/DataStreamDecoder, AssistantTransportEncoder/AssistantTransportDecoder, PlainTextEncoder, or UIMessageStreamDecoder; or wiring streamed chunks into useLocalRuntime or useChatRuntime. Use specifically for debugging stream wire issues: text-delta, part-start, result events, text/event-stream content-type, SSE format, tool calls not rendering, or partial text not showing. For general non-stream debugging route to the relevant focused skill, not the parent overview."
+description: "Streaming backends and wire protocols for assistant-ui via the assistant-stream package. Use when building a custom (non-AI-SDK) streaming endpoint with createAssistantStreamResponse or createAssistantStreamController, emitting parts through appendText/appendReasoning/appendSource/appendFile/addToolCallPart and setResponse; choosing between the AI SDK UI-message format (toUIMessageStream + createUIMessageStreamResponse) and the native Assistant Transport format; encoding or decoding streams with DataStreamEncoder/DataStreamDecoder, AssistantTransportEncoder/AssistantTransportDecoder, PlainTextEncoder, or UIMessageStreamDecoder; or wiring streamed chunks into useLocalRuntime or useChatRuntime. Use specifically for debugging stream wire issues: text-delta, part-start, result events, text/event-stream content-type, SSE format, tool calls not rendering, or partial text not showing. For general non-stream debugging route to the relevant focused skill, not the parent overview."
 license: MIT
 ---
 
@@ -21,7 +21,7 @@ The `assistant-stream` package handles streaming from AI backends.
 
 ```
 Using Vercel AI SDK?
-├─ Yes → toUIMessageStreamResponse() (no assistant-stream needed)
+├─ Yes → createUIMessageStreamResponse + toUIMessageStream (no assistant-stream needed)
 └─ No → assistant-stream for custom backends
 ```
 

--- a/assistant-ui/skills/streaming/references/data-stream.md
+++ b/assistant-ui/skills/streaming/references/data-stream.md
@@ -4,7 +4,7 @@ AI SDK compatible streaming format.
 
 ## Overview
 
-Data Stream is the underlying format used by Vercel AI SDK. For assistant-ui, use `toUIMessageStreamResponse()` (preferred) which builds on Data Stream with additional features.
+Data Stream is the underlying format used by Vercel AI SDK. For assistant-ui, build the response with `toUIMessageStream` + `createUIMessageStreamResponse`, which layer the UI-message protocol on top of Data Stream.
 
 ## Usage
 
@@ -12,23 +12,28 @@ Data Stream is the underlying format used by Vercel AI SDK. For assistant-ui, us
 
 ```ts
 import { openai } from "@ai-sdk/openai";
-import { streamText } from "ai";
+import {
+  streamText,
+  convertToModelMessages,
+  createUIMessageStreamResponse,
+  toUIMessageStream,
+} from "ai";
 
 export async function POST(req: Request) {
   const { messages } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-4o"),
-    messages,
+    model: openai("gpt-5.4-nano"),
+    messages: await convertToModelMessages(messages),
   });
 
-  // Preferred for assistant-ui
-  return result.toUIMessageStreamResponse();
-
-  // Or use toDataStreamResponse() for raw Data Stream
-  // return result.toDataStreamResponse();
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({ stream: result.stream }),
+  });
 }
 ```
+
+`result.toUIMessageStreamResponse()` is the older equivalent; it still compiles in `ai@7` but is deprecated. `toDataStreamResponse()` was removed after v5.
 
 ### Custom Backend (Data Stream SSE)
 

--- a/assistant-ui/skills/streaming/references/encoders.md
+++ b/assistant-ui/skills/streaming/references/encoders.md
@@ -6,13 +6,13 @@ Encode and decode streaming formats.
 
 | Encoder | Format | Use Case |
 |---------|--------|----------|
-| `DataStreamEncoder` | AI SDK Data Stream | Default (used by `toUIMessageStreamResponse`) |
+| `DataStreamEncoder` | AI SDK Data Stream | Default (the wire format behind `toUIMessageStream`) |
 | `AssistantTransportEncoder` | Native SSE (`data: {chunk}`) | Custom backends that want all chunk types |
 | `PlainTextEncoder` | Text-only | Very simple demos |
 
 ## DataStreamEncoder
 
-AI SDK compatible format. You normally don't call it directly—wrap an `AssistantStream`:
+AI SDK compatible format. You normally don't call it directly. Wrap an `AssistantStream`:
 
 ```ts
 import { AssistantStream, DataStreamEncoder, DataStreamDecoder } from "assistant-stream";

--- a/assistant-ui/skills/streaming/references/resumable.md
+++ b/assistant-ui/skills/streaming/references/resumable.md
@@ -49,7 +49,11 @@ Wrap the response body in `ctx.run(streamId, makeStream)`. The first caller for 
 
 ```ts
 // /app/api/chat/route.ts
-import { streamText } from "ai";
+import {
+  streamText,
+  createUIMessageStreamResponse,
+  toUIMessageStream,
+} from "ai";
 import { RESUMABLE_STREAM_ID_HEADER } from "assistant-stream/resumable";
 import { resumableContext } from "@/lib/resumable-context";
 
@@ -58,7 +62,9 @@ export async function POST(req: Request) {
   const streamId = crypto.randomUUID();
 
   const result = streamText({ /* model, messages, tools, ... */ });
-  const sourceBody = result.toUIMessageStreamResponse().body!;
+  const sourceBody = createUIMessageStreamResponse({
+    stream: toUIMessageStream({ stream: result.stream }),
+  }).body!;
 
   const stream = await resumableContext.run(streamId, () => sourceBody);
 

--- a/assistant-ui/skills/thread-list/SKILL.md
+++ b/assistant-ui/skills/thread-list/SKILL.md
@@ -59,14 +59,14 @@ const { threadIds, mainThreadId } = useAuiState((s) => ({
   mainThreadId: s.threads.mainThreadId,
 }));
 
-api.threads().switchToThread(threadId);
+api.threads.switchToThread(threadId);
 
-api.threads().switchToNewThread();
+api.threads.switchToNewThread();
 
-const item = api.threads().item({ id: threadId });
-await item.rename("New Title");
-await item.archive();
-await item.delete();
+const item = api.threads.item({ id: threadId });
+item.rename("New Title");
+item.archive();
+item.delete();
 ```
 
 ## Custom Thread List

--- a/assistant-ui/skills/thread-list/references/custom-ui.md
+++ b/assistant-ui/skills/thread-list/references/custom-ui.md
@@ -88,7 +88,7 @@ function FullyCustomThreadList() {
     <div className="w-64 h-full bg-gray-50">
       <div className="p-4 border-b">
         <button
-          onClick={() => api.threads().switchToNewThread()}
+          onClick={() => api.threads.switchToNewThread()}
           className="w-full py-2 bg-blue-500 text-white rounded-lg"
         >
           New Chat
@@ -127,13 +127,13 @@ function ThreadItem({
   archived?: boolean;
 }) {
   const api = useAui();
-  const item = api.threads().item({ id });
+  const item = api.threads.item({ id });
   const state = item.getState();
   const [isEditing, setIsEditing] = useState(false);
   const [title, setTitle] = useState(state.title || "");
 
   const handleRename = async () => {
-    await item.rename(title);
+    item.rename(title);
     setIsEditing(false);
   };
 
@@ -222,7 +222,7 @@ function SearchableThreadList() {
 
   const filteredThreads = threads.filter((id) => {
     if (!search) return true;
-    const item = api.threads().item({ id }).getState();
+    const item = api.threads.item({ id }).getState();
     return item.title?.toLowerCase().includes(search.toLowerCase());
   });
 
@@ -238,7 +238,7 @@ function SearchableThreadList() {
       </div>
 
       <button
-        onClick={() => api.threads().switchToNewThread()}
+        onClick={() => api.threads.switchToNewThread()}
         className="mx-2 py-2 bg-blue-500 text-white rounded-lg"
       >
         + New Chat
@@ -340,7 +340,7 @@ function ThreadDropdown() {
         <div className="absolute top-full left-0 mt-1 w-64 bg-white border rounded-lg shadow-lg z-50">
           <button
             onClick={() => {
-              api.threads().switchToNewThread();
+              api.threads.switchToNewThread();
               setOpen(false);
             }}
             className="w-full px-4 py-2 text-left hover:bg-gray-100 border-b"
@@ -349,12 +349,12 @@ function ThreadDropdown() {
           </button>
           <div className="max-h-64 overflow-y-auto">
             {threads.map((id) => {
-              const item = api.threads().item({ id }).getState();
+              const item = api.threads.item({ id }).getState();
               return (
                 <button
                   key={id}
                   onClick={() => {
-                    api.threads().switchToThread(id);
+                    api.threads.switchToThread(id);
                     setOpen(false);
                   }}
                   className={`w-full px-4 py-2 text-left hover:bg-gray-100 ${
@@ -381,7 +381,7 @@ function CategorizedThreadList() {
   const { threads } = useAuiState((s) => ({ threads: s.threads.threadIds }));
 
   const grouped = threads.reduce((acc, id) => {
-    const item = api.threads().item({ id }).getState();
+    const item = api.threads.item({ id }).getState();
     const category = (item.title || "Untitled").charAt(0).toUpperCase();
     if (!acc[category]) acc[category] = [];
     acc[category].push(id);

--- a/assistant-ui/skills/thread-list/references/management.md
+++ b/assistant-ui/skills/thread-list/references/management.md
@@ -19,7 +19,7 @@ function ThreadManager() {
   const api = useAui();
 
   // Get thread list API
-  const threads = api.threads();
+  const threads = api.threads;
 
   // Get current state
   const { threadIds, mainThreadId } = useAuiState(
@@ -39,7 +39,7 @@ function ThreadManager() {
 const api = useAui();
 
 // Switch to a new empty thread
-await api.threads().switchToNewThread();
+api.threads.switchToNewThread();
 
 // Thread is created when first message is sent
 ```
@@ -48,25 +48,25 @@ await api.threads().switchToNewThread();
 
 ```tsx
 // By thread ID
-await api.threads().switchToThread(threadId);
+api.threads.switchToThread(threadId);
 
 // Using item
-const item = api.threads().item({ id: threadId });
-await item.switchTo();
+const item = api.threads.item({ id: threadId });
+item.switchTo();
 ```
 
 ### Rename Thread
 
 ```tsx
-const item = api.threads().item({ id: threadId });
-await item.rename("New Chat Title");
+const item = api.threads.item({ id: threadId });
+item.rename("New Chat Title");
 ```
 
 ### Archive Thread
 
 ```tsx
-const item = api.threads().item({ id: threadId });
-await item.archive();
+const item = api.threads.item({ id: threadId });
+item.archive();
 
 // Archived threads move to archivedThreads list
 ```
@@ -74,8 +74,8 @@ await item.archive();
 ### Unarchive Thread
 
 ```tsx
-const item = api.threads().item({ id: threadId });
-await item.unarchive();
+const item = api.threads.item({ id: threadId });
+item.unarchive();
 
 // Moves back to regular threads list
 ```
@@ -83,8 +83,8 @@ await item.unarchive();
 ### Delete Thread
 
 ```tsx
-const item = api.threads().item({ id: threadId });
-await item.delete();
+const item = api.threads.item({ id: threadId });
+item.delete();
 
 // Permanently removes thread
 // If deleting current thread, switches to another
@@ -93,8 +93,8 @@ await item.delete();
 ### Generate Title
 
 ```tsx
-const item = api.threads().item({ id: threadId });
-await item.generateTitle();
+const item = api.threads.item({ id: threadId });
+item.generateTitle();
 
 // Uses AI to generate title from conversation
 ```
@@ -142,7 +142,7 @@ function ThreadWatcher() {
 
 ```tsx
 const api = useAui();
-const threads = api.threads();
+const threads = api.threads;
 
 // By ID
 const item1 = threads.item({ id: "thread-123" });
@@ -162,15 +162,15 @@ const item3 = threads.item({ index: 0, archived: true });
 ```tsx
 async function archiveThreadsByTitlePrefix(prefix: string) {
   const api = useAui();
-  const { threadIds } = api.threads().getState();
+  const { threadIds } = api.threads.getState();
 
   for (const threadId of threadIds) {
-    const item = api.threads().item({ id: threadId });
+    const item = api.threads.item({ id: threadId });
     const state = item.getState();
     const title = (state.title || "").toLowerCase();
 
     if (title.startsWith(prefix.toLowerCase())) {
-      await item.archive();
+      item.archive();
     }
   }
 }
@@ -181,7 +181,7 @@ async function archiveThreadsByTitlePrefix(prefix: string) {
 Access thread metadata:
 
 ```tsx
-const item = api.threads().item({ id: threadId });
+const item = api.threads.item({ id: threadId });
 const state = item.getState();
 
 // {
@@ -198,7 +198,7 @@ const state = item.getState();
 When using cloud persistence, threads are lazily initialized:
 
 ```tsx
-const item = api.threads().item({ id: localThreadId });
+const item = api.threads.item({ id: localThreadId });
 
 // Initialize creates remote mapping
 const { remoteId, externalId } = await item.initialize();
@@ -211,10 +211,10 @@ const { remoteId, externalId } = await item.initialize();
 ```tsx
 async function safeDelete(threadId: string) {
   const api = useAui();
-  const item = api.threads().item({ id: threadId });
+  const item = api.threads.item({ id: threadId });
 
   try {
-    await item.delete();
+    item.delete();
   } catch (error) {
     if (error.message.includes("not found")) {
       // Thread already deleted
@@ -235,8 +235,8 @@ function SortedThreadList({ sortBy }: { sortBy: "title" | "id" }) {
   const api = useAui();
 
   const sorted = [...threads].sort((a, b) => {
-    const itemA = api.threads().item({ id: a }).getState();
-    const itemB = api.threads().item({ id: b }).getState();
+    const itemA = api.threads.item({ id: a }).getState();
+    const itemB = api.threads.item({ id: b }).getState();
 
     if (sortBy === "title") {
       return (itemA.title || "").localeCompare(itemB.title || "");
@@ -268,10 +268,10 @@ function KeyboardNav() {
 
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === "ArrowUp" && currentIndex > 0) {
-      api.threads().switchToThread(threads[currentIndex - 1]);
+      api.threads.switchToThread(threads[currentIndex - 1]);
     }
     if (e.key === "ArrowDown" && currentIndex < threads.length - 1) {
-      api.threads().switchToThread(threads[currentIndex + 1]);
+      api.threads.switchToThread(threads[currentIndex + 1]);
     }
   };
 

--- a/assistant-ui/skills/tools/SKILL.md
+++ b/assistant-ui/skills/tools/SKILL.md
@@ -194,7 +194,7 @@ Render props also carry the enriched part state, so `toolUI`, `argsText`, and th
 
 ## Server-Side Approval Gates
 
-AI SDK v7 pauses a tool call server-side via the call-level `toolApproval` option. assistant-ui surfaces the gate as `approval` on the tool part; `respondToApproval` is the only correct way to acknowledge it.
+AI SDK v7 can pause a tool call server-side two ways, and they coexist: `needsApproval` on the tool definition gates that tool everywhere, and the call-level `toolApproval` option gates per call so the decision can vary by input. Either way assistant-ui surfaces the gate as `approval` on the tool part, and `respondToApproval` is the only correct way to acknowledge it.
 
 ```ts
 // Backend

--- a/assistant-ui/skills/tools/SKILL.md
+++ b/assistant-ui/skills/tools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tools
-description: "Registers LLM tools and renders custom tool-call UI in assistant-ui (@assistant-ui/react). Use when adding frontend-only tools with makeAssistantTool / useAssistantTool (browser actions like clipboard, navigation, localStorage, async-generator streaming, AbortSignal), rendering backend AI SDK tool() calls with makeAssistantToolUI / useAssistantToolUI (status.type running/complete/incomplete/requires-action, args, result, artifact via ToolCallMessagePartProps), building generative UI from tool results, or implementing human-in-the-loop and approval flows (addResult, resume with context.human(), respondToApproval for server-side needsApproval gates). Covers registering tool components inside AssistantRuntimeProvider and the case-sensitive toolName matching that connects a tool to its UI. Reach for this when tool UI is not rendering, a tool is not being called, or a result is not showing."
+description: "Registers LLM tools and renders custom tool-call UI in assistant-ui (@assistant-ui/react). Covers the current authoring model: a \"use generative\" file exporting defineToolkit({...}) that co-locates schema, execute, and render and is split across the client/server boundary by the build plugin (withAui from @assistant-ui/next, aui() from @assistant-ui/vite, withAui from @assistant-ui/metro), mounted with Tools({ toolkit }) through useAui and exposed to the model with AISDKToolkit. Covers the tool kinds and their execute markers: backend (plain execute), frontend (\"use client\" inside execute), human via humanTool()/hitl, provider via providerTool(), external via externalTool(), stubs via stubTool() plus useAuiToolOverrides, and MCP via defineMcpToolkit. Also covers the component-scoped path (makeAssistantTool / useAssistantTool / makeAssistantToolUI / useAssistantToolUI), ToolCallMessagePartProps (status.type running/complete/incomplete/requires-action, args, argsText, result, artifact, addResult, resume, respondToApproval), server-side approval gates via the AI SDK v7 toolApproval option, generative UI from tool results, and the v0.15 s.tools.toolUIs registry. Reach for this when tool UI is not rendering, a tool is not being called, or a result is not showing."
 license: MIT
 ---
 
@@ -20,17 +20,64 @@ Tools let LLMs trigger actions with custom UI rendering.
 - [./references/generative-ui.md](./references/generative-ui.md) -- Declarative generative UI
 - [./references/registry-components.md](./references/registry-components.md) -- ToolFallback, ToolGroup, Image renderers
 
-## Tool Types
+## Authoring Model
+
+Toolkits are the supported path:
 
 ```
-Where does the tool execute?
-├─ Backend (LLM calls API) → AI SDK tool()
-│  └─ Want custom UI? → makeAssistantToolUI
-└─ Frontend (browser-only) → makeAssistantTool
-   └─ Want custom UI? → makeAssistantToolUI
+"use generative" file exporting defineToolkit({ ... })
+  → registered with useAui({ tools: Tools({ toolkit }) })
+  → exposed to the model with new AISDKToolkit({ toolkit })
 ```
 
-## Backend Tool with UI
+The component and hook APIs are **deprecated**: `makeAssistantTool`, `useAssistantTool`, `makeAssistantToolUI`, and `useAssistantToolUI` all carry `@deprecated` and point at [the toolkit migration guide](https://assistant-ui.com/docs/migrations/toolkit-tools). They still work, so existing code is not broken, but new tools should be toolkit entries. For per-message UI that used to need `makeAssistantToolUI`, use inline tool render overrides on `MessagePrimitive.Parts`.
+
+See [./references/toolkits.md](./references/toolkits.md) for the full authoring guide.
+
+## Toolkit (recommended)
+
+One file holds the schema, the executor, and the renderer. A build plugin splits it so a backend `execute` never ships to the browser and a `render` never reaches the server.
+
+```tsx
+// app/toolkit.tsx
+"use generative";
+
+import { defineToolkit } from "@assistant-ui/react";
+import { z } from "zod";
+
+export default defineToolkit({
+  get_weather: {
+    description: "Get current weather for a location.",
+    parameters: z.object({ location: z.string() }),
+    execute: async ({ location }) => fetchWeatherAPI(location),
+    render: ({ args, result }) =>
+      result ? <div>{result.temperature}°</div> : <div>Fetching {args.location}…</div>,
+  },
+});
+```
+
+Mount it through `useAui`, and expose the same import to the model on the server:
+
+```tsx
+const runtime = useChatRuntime();
+const aui = useAui({ tools: Tools({ toolkit }) });
+
+<AssistantRuntimeProvider aui={aui} runtime={runtime}>{children}</AssistantRuntimeProvider>
+```
+
+```ts
+// app/api/chat/route.ts
+const aiToolkit = new AISDKToolkit({ toolkit });
+const result = streamText({
+  model: openai("gpt-5.4-nano"),
+  messages: await convertToModelMessages(messages),
+  tools: await aiToolkit.tools({ frontend: tools }),
+});
+```
+
+The directive requires the compiler: `withAui()` from `@assistant-ui/next`, `aui()` from `@assistant-ui/vite`, or `withAui()` from `@assistant-ui/metro`.
+
+## Backend Tool with UI (component model)
 
 ```ts
 // Backend (app/api/chat/route.ts)
@@ -38,8 +85,11 @@ import { openai } from "@ai-sdk/openai";
 import {
   streamText,
   tool,
+  zodSchema,
   stepCountIs,
   convertToModelMessages,
+  createUIMessageStreamResponse,
+  toUIMessageStream,
   type UIMessage,
 } from "ai";
 import { z } from "zod";
@@ -48,19 +98,21 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-4o"),
+    model: openai("gpt-5.4-nano"),
     messages: await convertToModelMessages(messages),
     stopWhen: stepCountIs(5),
     tools: {
       get_weather: tool({
         description: "Get weather for a city",
-        inputSchema: z.object({ city: z.string() }),
+        inputSchema: zodSchema(z.object({ city: z.string() })),
         execute: async ({ city }) => ({ temp: 22, city }),
       }),
     },
   });
 
-  return result.toUIMessageStreamResponse();
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({ stream: result.stream }),
+  });
 }
 ```
 
@@ -124,12 +176,64 @@ interface ToolCallMessagePartProps {
     | { type: "requires-action"; reason: "interrupt" };
 
   // Supply a result from the renderer (instead of a tool execute function)
-  addResult: (result: unknown) => void;
-  // Resume a frontend tool paused via context.human(...)
+  addResult: (result: unknown | ToolResponse<unknown>) => void;
+  // Resume a tool paused for human input
   resume: (payload: unknown) => void;
-  // Respond to a server-side approval gate
-  respondToApproval: (response: { approved: boolean; reason?: string }) => void;
+  // Respond to a server-side approval gate; reads the approval id off the part
+  respondToApproval: (response: ToolApprovalResponse) => void;
 }
+
+// One of:
+type ToolApprovalResponse =
+  | { approved: boolean; reason?: string }
+  | { optionId: string; reason?: string }
+  | { approved: boolean; optionId: string; reason?: string };
+```
+
+Render props also carry the enriched part state, so `toolUI`, `argsText`, and the part `status` are all available without a second lookup.
+
+## Server-Side Approval Gates
+
+AI SDK v7 pauses a tool call server-side via the call-level `toolApproval` option. assistant-ui surfaces the gate as `approval` on the tool part; `respondToApproval` is the only correct way to acknowledge it.
+
+```ts
+// Backend
+const result = streamText({
+  model: openai("gpt-5.4-nano"),
+  messages: await convertToModelMessages(messages),
+  tools: { deploy: tool({ /* ... */ }) },
+  toolApproval: {
+    deploy: (input) =>
+      input.target === "production" ? "user-approval" : "not-applicable",
+  },
+});
+```
+
+```tsx
+// Frontend: post the decision back automatically
+import { lastAssistantMessageIsCompleteWithApprovalResponses } from "ai";
+
+const runtime = useChatRuntime({
+  sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
+});
+```
+
+```tsx
+// Renderer
+render: ({ args, approval, respondToApproval }) => {
+  if (approval?.approved === undefined) {
+    return (
+      <div>
+        <p>Approve deploy to {args.target}?</p>
+        <button onClick={() => respondToApproval({ approved: true })}>Approve</button>
+        <button onClick={() => respondToApproval({ approved: false, reason: "denied" })}>
+          Deny
+        </button>
+      </div>
+    );
+  }
+  return approval.approved ? <p>Approved</p> : <p>Denied</p>;
+};
 ```
 
 ## Human-in-the-Loop
@@ -155,8 +259,11 @@ const DeleteToolUI = makeAssistantToolUI({
 ## Common Gotchas
 
 **Tool UI not rendering**
-- `toolName` must match exactly (case-sensitive)
+- `toolName` must match exactly (case-sensitive); in a toolkit the object key *is* the tool name
 - Register UI inside `AssistantRuntimeProvider`
+
+**`"use generative"` file has no effect**
+- The directive needs a compiler. Add `withAui()` (`@assistant-ui/next`), `aui()` (`@assistant-ui/vite`), or `withAui()` (`@assistant-ui/metro`)
 
 **Tool not being called**
 - Check tool description is clear
@@ -165,3 +272,6 @@ const DeleteToolUI = makeAssistantToolUI({
 **Result not showing**
 - Tool must return a value
 - Check `status.type === "complete"` before accessing result
+
+**Reading the tool UI registry**
+- `s.tools.tools` was removed in 0.15. Select `s.tools.toolUIs[toolName]?.[0]?.render`; entries carry the renderer alongside its presentation options

--- a/assistant-ui/skills/tools/references/human-in-loop.md
+++ b/assistant-ui/skills/tools/references/human-in-loop.md
@@ -18,7 +18,9 @@ Human-in-the-loop tools pause execution waiting for user input. Detect the pause
 
 - `addResult(result)`: the renderer itself supplies the tool result (the pattern used throughout this page).
 - `resume(payload)`: resume a frontend tool that paused by calling `context.human(payload)` inside its `execute` function.
-- `respondToApproval({ approved, reason? })`: answer a server-side approval gate (a backend tool defined with `needsApproval`).
+- `respondToApproval({ approved, reason? })`: answer a server-side approval gate.
+
+AI SDK v7 has two ways to raise that gate, and they coexist rather than replacing one another: `needsApproval` on the tool definition (a boolean or a function of the input) gates that one tool everywhere it is used, while the call-level `toolApproval` option on `streamText` / `generateText` gates per call and can vary by input. Either one pauses the run and surfaces `approval` on the tool part; `respondToApproval` answers both, reading the approval id off the part.
 
 ## Confirmation Pattern
 

--- a/assistant-ui/skills/tools/references/human-in-loop.md
+++ b/assistant-ui/skills/tools/references/human-in-loop.md
@@ -16,9 +16,9 @@ Tools that require user confirmation or input.
 
 Human-in-the-loop tools pause execution waiting for user input. Detect the paused state with `status.type === "requires-action"`. The render props give three ways to respond:
 
-- `addResult(result)` — the renderer itself supplies the tool result (the pattern used throughout this page).
-- `resume(payload)` — resume a frontend tool that paused by calling `context.human(payload)` inside its `execute` function.
-- `respondToApproval({ approved, reason? })` — answer a server-side approval gate (a backend tool defined with `needsApproval`).
+- `addResult(result)`: the renderer itself supplies the tool result (the pattern used throughout this page).
+- `resume(payload)`: resume a frontend tool that paused by calling `context.human(payload)` inside its `execute` function.
+- `respondToApproval({ approved, reason? })`: answer a server-side approval gate (a backend tool defined with `needsApproval`).
 
 ## Confirmation Pattern
 

--- a/assistant-ui/skills/tools/references/make-tool.md
+++ b/assistant-ui/skills/tools/references/make-tool.md
@@ -2,6 +2,8 @@
 
 Create reusable tool definitions that execute in the browser.
 
+> **Deprecated.** `makeAssistantTool` and `useAssistantTool` carry `@deprecated` in the source and point at the [toolkit migration guide](https://assistant-ui.com/docs/migrations/toolkit-tools). New tools belong in a `defineToolkit({ ... })` entry registered with `useAui({ tools: Tools({ toolkit }) })`; see [toolkits.md](./toolkits.md). This page documents the existing API for codebases that still use it.
+
 ## makeAssistantTool
 
 Returns a React component that registers the tool when mounted.

--- a/assistant-ui/skills/tools/references/mcp-server.md
+++ b/assistant-ui/skills/tools/references/mcp-server.md
@@ -85,7 +85,12 @@ const mcpClient = await createMCPClient({
 // app/api/chat/route.ts
 import { createMCPClient } from "@ai-sdk/mcp";
 import { openai } from "@ai-sdk/openai";
-import { streamText, convertToModelMessages } from "ai";
+import {
+  streamText,
+  convertToModelMessages,
+  createUIMessageStreamResponse,
+  toUIMessageStream,
+} from "ai";
 import type { UIMessage } from "ai";
 
 export const maxDuration = 60;
@@ -112,7 +117,9 @@ export async function POST(req: Request) {
     },
   });
 
-  return result.toUIMessageStreamResponse();
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({ stream: result.stream }),
+  });
 }
 ```
 

--- a/assistant-ui/skills/tools/references/tool-ui.md
+++ b/assistant-ui/skills/tools/references/tool-ui.md
@@ -2,6 +2,8 @@
 
 Render custom UI for tool calls.
 
+> **Deprecated.** `makeAssistantToolUI` and `useAssistantToolUI` carry `@deprecated` in the source. Put `render` / `renderText` on the matching toolkit entry, or use the inline tool render overrides on `MessagePrimitive.Parts` for per-message UI. See the [toolkit migration guide](https://assistant-ui.com/docs/migrations/toolkit-tools) and [toolkits.md](./toolkits.md). This page documents the existing API for codebases that still use it.
+
 ## makeAssistantToolUI
 
 Returns a React component that registers the tool UI renderer.

--- a/assistant-ui/skills/tools/references/toolkits.md
+++ b/assistant-ui/skills/tools/references/toolkits.md
@@ -4,6 +4,9 @@ Declare a group of tools as a plain object and mount them with the `<Tools />` c
 
 ## Contents
 
+- [The "use generative" model](#the-use-generative-model)
+- [Tool kinds](#tool-kinds)
+- [Exposing a toolkit to the model](#exposing-a-toolkit-to-the-model)
 - [Toolkit type](#toolkit-type)
 - [ToolDefinition fields](#tooldefinition-fields)
 - [Mounting with Tools](#mounting-with-tools)
@@ -11,6 +14,175 @@ Declare a group of tools as a plain object and mount them with the `<Tools />` c
 - [The tool helper](#the-tool-helper)
 - [mcpApp prop](#mcpapp-prop)
 - [Toolkit vs component tools](#toolkit-vs-component-tools)
+
+## The "use generative" model
+
+The current authoring model puts a tool's schema, executor, and renderer in one file. A build plugin forks that file per target: the server build keeps the schema and backend executors, the client build keeps the schema, renderers, and browser executors. A backend `execute` never reaches the browser and a `render` never reaches the server.
+
+Add the compiler first; the directive is inert without it:
+
+```ts
+// next.config.ts
+import { withAui } from "@assistant-ui/next";
+export default withAui({ /* ...your Next config... */ });
+```
+
+```ts
+// vite.config.ts  (Vite / TanStack Start)
+import { aui } from "@assistant-ui/vite";
+export default defineConfig({ plugins: [aui()] });
+```
+
+```js
+// metro.config.js  (Expo / React Native)
+const { getDefaultConfig } = require("expo/metro-config");
+const { withAui } = require("@assistant-ui/metro");
+module.exports = withAui(getDefaultConfig(__dirname));
+```
+
+Then write the toolkit. The first line is `"use generative"` and the default export is `defineToolkit({ ... })`:
+
+```tsx
+// app/toolkit.tsx
+"use generative";
+
+import { defineToolkit } from "@assistant-ui/react";
+import { z } from "zod";
+
+export default defineToolkit({
+  get_weather: {
+    description: "Get current weather for a location.",
+    parameters: z.object({
+      location: z.string().describe("City name or zip code"),
+      unit: z.enum(["celsius", "fahrenheit"]).default("celsius"),
+    }),
+    execute: async ({ location, unit }) => {
+      "use client";
+      return fetchWeatherAPI(location, unit);
+    },
+    render: ({ args, result }) =>
+      result ? <div>{result.temperature}° {args.unit}</div> : <div>Fetching…</div>,
+  },
+});
+```
+
+Mount it through `useAui` and hand the client to `AssistantRuntimeProvider`:
+
+```tsx
+"use client";
+
+import { AssistantRuntimeProvider, Tools, useAui } from "@assistant-ui/react";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import toolkit from "./toolkit";
+
+export function MyRuntimeProvider({ children }: { children: React.ReactNode }) {
+  const runtime = useChatRuntime();
+  const aui = useAui({ tools: Tools({ toolkit }) });
+
+  return (
+    <AssistantRuntimeProvider aui={aui} runtime={runtime}>
+      {children}
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+## Tool kinds
+
+Inside a `"use generative"` file you never write `type`. The compiler infers the kind from `execute` and writes it back:
+
+| `execute` you write | Inferred kind | Server build keeps | Client build keeps |
+|---|---|---|---|
+| plain `async () => …` | **backend** | schema + `execute` (behind `server-only`) | schema + `render` |
+| `async () => { "use client"; … }` | **frontend** | schema only | schema + `execute` + `render`/`renderText` |
+| `humanTool()` (alias `hitl`) | **human** | schema only | schema + `render` |
+| `stubTool()` | **frontend**, executor supplied at runtime | schema only | schema + `render`/`renderText` |
+| `providerTool({ … })` | **provider** | schema + provider config | schema + provider config |
+| `externalTool()` | **backend**, defined elsewhere | omitted | `type: "backend"` + `render`/`renderText` |
+
+The compiler enforces at build time that every tool declares an `execute`, that a frontend tool declares `render` or `renderText`, and that a human tool declares `render`.
+
+```tsx
+// human: pause until the user supplies a result
+select_date: {
+  description: "Ask the user to select a date.",
+  parameters: z.object({ prompt: z.string() }),
+  execute: humanTool(),
+  render: ({ args, result, addResult }) =>
+    result ? <p>Selected {result.date}</p>
+           : <DatePicker prompt={args.prompt} onChange={(date) => addResult({ date })} />,
+},
+
+// provider: executed by the model provider
+web_search: {
+  execute: providerTool({
+    providerId: "openai.web_search_preview",
+    args: { searchContextSize: "low" },
+  }),
+},
+
+// external: rendered here, executed by another system
+lookup: {
+  parameters: z.object({ query: z.string() }),
+  execute: externalTool(),
+  render: ({ args, result }) => <Results query={args.query} results={result?.results ?? []} />,
+},
+```
+
+For MCP servers, spread `defineMcpToolkit({ ... })` into the toolkit instead of writing executors.
+
+### Tool stubs
+
+When an executor has to close over React state it cannot live in the build-split file. Declare the contract with `stubTool()` and supply the executor at runtime with `useAuiToolOverrides` from the component that owns the state:
+
+```tsx
+// app/toolkit.tsx
+export default defineToolkit({
+  manage_tasks: {
+    description: "Add, toggle, or clear tasks on the board.",
+    parameters: manageTasksParameters,
+    execute: stubTool(),
+    renderText: { running: "Updating tasks…", complete: "Tasks updated" },
+  },
+});
+```
+
+```tsx
+// app/TaskBoard.tsx
+import { useAuiToolOverrides } from "@assistant-ui/react";
+
+useAuiToolOverrides({
+  manage_tasks: { execute: async (args) => setTasks((t) => applyTaskAction(t, args)) },
+});
+```
+
+## Exposing a toolkit to the model
+
+The same import resolves to the server build inside a route handler. Wrap it in `AISDKToolkit` so the model receives every tool's schema:
+
+```ts
+// app/api/chat/route.ts
+import { AISDKToolkit } from "@assistant-ui/react-ai-sdk";
+import { streamText, convertToModelMessages, createUIMessageStreamResponse, toUIMessageStream } from "ai";
+import { openai } from "@ai-sdk/openai";
+import toolkit from "../../toolkit";
+
+const aiToolkit = new AISDKToolkit({ toolkit });
+
+export async function POST(req: Request) {
+  const { messages, tools } = await req.json();
+
+  const result = streamText({
+    model: openai("gpt-5.4-nano"),
+    messages: await convertToModelMessages(messages),
+    tools: await aiToolkit.tools({ frontend: tools }),
+  });
+
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({ stream: result.stream }),
+  });
+}
+```
 
 ## Toolkit type
 
@@ -61,22 +233,25 @@ Note: `render` is required for frontend and human tools that need a UI; tools th
 
 ## Mounting with Tools
 
-Mount `<Tools />` near an assistant subtree. Tool definitions register with model context; renderers register with the tools scope for message rendering.
+`Tools` is a resource, not a component. Call it and pass the result to `useAui` under the `tools` scope, then hand the client to `AssistantRuntimeProvider`. Tool definitions register with model context; renderers register with the tools scope for message rendering.
 
 ```tsx
-import { Tools } from "@assistant-ui/react";
+import { AssistantRuntimeProvider, Tools, useAui } from "@assistant-ui/react";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
 
-function App() {
+function App({ children }: { children: React.ReactNode }) {
+  const runtime = useChatRuntime();
+  const aui = useAui({ tools: Tools({ toolkit }) });
+
   return (
-    <AssistantRuntimeProvider runtime={runtime}>
-      <Tools toolkit={toolkit} />
-      <Thread />
+    <AssistantRuntimeProvider aui={aui} runtime={runtime}>
+      {children}
     </AssistantRuntimeProvider>
   );
 }
 ```
 
-| Prop | Type | Notes |
+| Option | Type | Notes |
 |------|------|-------|
 | `toolkit` | `Toolkit` | Tools and optional renderers to install |
 | `mcpApp` | `ResourceElement<McpAppResourceOutput>` | MCP app whose tools merge into context |
@@ -149,29 +324,34 @@ const getWeather = tool<{ city: string }, string>({
 const toolkit = { get_weather: getWeather } satisfies Toolkit;
 ```
 
-## mcpApp prop
+## mcpApp option
 
-`<Tools mcpApp={...} />` merges the tools of an MCP app into the same context. Build the resource element with `McpAppRenderer` and a host such as `McpAppsRemoteHost`.
+`Tools({ mcpApp })` merges the tools of an MCP app into the same context. Build the resource element with `McpAppRenderer` and a host such as `McpAppsRemoteHost`.
 
 ```tsx
 import {
+  AssistantRuntimeProvider,
   Tools,
+  useAui,
   McpAppRenderer,
   McpAppsRemoteHost,
 } from "@assistant-ui/react";
 
-function App() {
+function App({ children }: { children: React.ReactNode }) {
+  const aui = useAui({
+    tools: Tools({
+      toolkit,
+      mcpApp: McpAppRenderer({
+        host: McpAppsRemoteHost({ url: "/api/mcp-apps" }),
+        hostInfo: { name: "my-app", version: "1.0.0" },
+        hostContext: { theme: "light" },
+      }),
+    }),
+  });
+
   return (
-    <AssistantRuntimeProvider runtime={runtime}>
-      <Tools
-        toolkit={toolkit}
-        mcpApp={McpAppRenderer({
-          host: McpAppsRemoteHost({ url: "/api/mcp-apps" }),
-          hostInfo: { name: "my-app", version: "1.0.0" },
-          hostContext: { theme: "light" },
-        })}
-      />
-      <Thread />
+    <AssistantRuntimeProvider aui={aui} runtime={runtime}>
+      {children}
     </AssistantRuntimeProvider>
   );
 }
@@ -181,4 +361,12 @@ The renderer activates for any tool-call part whose metadata carries a `ui://`-s
 
 ## Toolkit vs component tools
 
-Use a toolkit and `<Tools />` when tool availability should follow the runtime or provider tree rather than a specific component's mount state. Reach for component tools (`makeAssistantTool`, `useAssistantTool`) when a tool should register and unregister with one component's lifecycle.
+Toolkits are the supported path. The component and hook APIs (`makeAssistantTool`, `useAssistantTool`, `makeAssistantToolUI`, `useAssistantToolUI`) are **deprecated** in favor of `Tools({ toolkit })`; see [the toolkit migration guide](https://assistant-ui.com/docs/migrations/toolkit-tools). For per-message UI that used to need `makeAssistantToolUI`, use the inline tool render overrides on `MessagePrimitive.Parts` instead.
+
+Renderers registered either way land in the same scope. Reading it directly:
+
+```tsx
+const Render = useAuiState((s) => s.tools.toolUIs[toolName]?.[0]?.render);
+```
+
+`s.tools.tools` was removed in 0.15; entries in `toolUIs` carry the renderer alongside its presentation options.

--- a/assistant-ui/skills/tools/references/toolkits.md
+++ b/assistant-ui/skills/tools/references/toolkits.md
@@ -1,6 +1,6 @@
 # Toolkits
 
-Declare a group of tools as a plain object and mount them with the `<Tools />` component.
+Declare a group of tools as a plain object and register it with `useAui({ tools: Tools({ toolkit }) })`. `Tools` is a resource, not a component.
 
 ## Contents
 

--- a/assistant-ui/skills/update/SKILL.md
+++ b/assistant-ui/skills/update/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update
-description: "Upgrades an existing assistant-ui project to current releases and executes the resulting migrations. Use when the user wants to update, upgrade, bump, or migrate @assistant-ui/react, @assistant-ui/react-ai-sdk, ai, or @ai-sdk/react, hits peer-dependency conflicts or post-upgrade type errors, or must apply renamed APIs after a version jump. Detects installed versus latest versions via npm ls / npm view, then routes through breaking-change references for each jump (AI SDK v4/v5 to v6; assistant-ui 0.8.x to 0.14.x): useAssistantApi to useAui, runtime.threadList to runtime.threads, ThreadPrimitive.ViewportSlack removal, the primitives components prop to children render functions, toDataStreamResponse to toUIMessageStreamResponse, maxSteps to stopWhen: stepCountIs(n). Runs npx assistant-ui@latest upgrade, pnpm/npm add @latest, and npx tsc --noEmit to verify. For a first-time install or fresh scaffold (not an upgrade) use setup instead."
+description: "Upgrades an existing assistant-ui project to current releases and executes the resulting migrations. Use when the user wants to update, upgrade, bump, or migrate @assistant-ui/react, @assistant-ui/react-ai-sdk, ai, or @ai-sdk/react, hits peer-dependency conflicts or post-upgrade type errors, or must apply renamed APIs after a version jump. Detects installed versus latest versions via npm ls / npm view, then routes through breaking-change references for each jump (AI SDK v4/v5 to v6 to v7; assistant-ui 0.8.x to 0.15.x): aui.thread() accessor calls to aui.thread properties, removal of the legacy context hooks useAssistantRuntime/useThreadRuntime/useThread/useMessage/useComposer in favor of useAui and useAuiState, s.tools.tools to s.tools.toolUIs, the groupPartByType mcp-app key to standalone-tool-call, useAssistantApi to useAui, runtime.threadList to runtime.threads, ThreadPrimitive.ViewportSlack removal, the primitives components prop to children render functions, toDataStreamResponse to toUIMessageStreamResponse, maxSteps to stopWhen: stepCountIs(n). Runs npx assistant-ui@latest upgrade, npx assistant-ui@latest update, npx assistant-ui@latest doctor, and npx tsc --noEmit to verify. For a first-time install or fresh scaffold (not an upgrade) use setup instead."
 license: MIT
 ---
 
@@ -28,11 +28,12 @@ npm view ai version
 
 ### Version Analysis
 
-Current latest: `@assistant-ui/react` 0.14.x, `@assistant-ui/react-ai-sdk` 1.3.x, `assistant-stream` 0.3.x.
+Current latest: `@assistant-ui/react` 0.15.x, `@assistant-ui/react-ai-sdk` 1.4.x, `assistant-stream` 0.3.x, `@assistant-ui/core` 0.3.x, `@assistant-ui/store` 0.3.x.
 
 | Package | Check For |
 |---------|-----------|
 | `ai` | < 6.0.0 → needs AI SDK v6 migration |
+| `@assistant-ui/react` | < 0.15.0 → `aui` scope accessors become properties; legacy context hooks removed; `s.tools.tools` → `s.tools.toolUIs`; `"mcp-app"` group key → `"standalone-tool-call"` |
 | `@assistant-ui/react` | < 0.14.0 → primitives `components` prop replaced by children render functions; deprecated hooks/aliases removed |
 | `@assistant-ui/react` | < 0.13.0 → `ThreadPrimitive.ViewportSlack` removed (top-anchor changes) |
 | `@assistant-ui/react` | < 0.12.0 → unified state API (`useAui`/`useAuiState`/`useAuiEvent`/`AuiIf`) |
@@ -40,6 +41,8 @@ Current latest: `@assistant-ui/react` 0.14.x, `@assistant-ui/react-ai-sdk` 1.3.x
 | `@assistant-ui/react` | < 0.10.0 → ESM only |
 | `@assistant-ui/react` | < 0.8.0 → UI split (shadcn registry) |
 | `@assistant-ui/react-ai-sdk` | < 1.0.0 → needs AI SDK v6 first |
+
+`@assistant-ui/react-ai-sdk` 1.4.x also supports AI SDK v7; v6 remains supported, so an `ai@7` bump is optional and independent of the assistant-ui upgrade.
 
 ## Phase 2: Route to Migration
 
@@ -62,19 +65,32 @@ AI SDK < 6.0.0?
 
 ### Update Packages
 
+The CLI knows which assistant-ui packages are installed and bumps them together:
+
+```bash
+npx assistant-ui@latest update          # add --dry to print the command instead
+```
+
+Equivalent manual form (AI SDK packages are not covered by `update`):
+
 ```bash
 pnpm add @assistant-ui/react@latest @assistant-ui/react-ai-sdk@latest ai@latest @ai-sdk/react@latest
 
 npm install @assistant-ui/react@latest @assistant-ui/react-ai-sdk@latest ai@latest @ai-sdk/react@latest
 ```
 
-### Apply Migrations
+### Apply Codemods
 
-Based on version jump, apply relevant migrations from references.
+```bash
+npx assistant-ui@latest upgrade         # add -d for a dry run, -p to print transformed files
+```
+
+Then apply the remaining hand migrations from the references for the version jump.
 
 ### Verify
 
 ```bash
+npx assistant-ui@latest doctor
 npx tsc --noEmit
 pnpm build
 ```

--- a/assistant-ui/skills/update/references/ai-sdk-v6.md
+++ b/assistant-ui/skills/update/references/ai-sdk-v6.md
@@ -409,7 +409,7 @@ Then re-analyze what went wrong before retrying.
   "@ai-sdk/react": "^3.0.0",
   "@ai-sdk/provider": "^3.0.0",
   "@ai-sdk/provider-utils": "^4.0.0",
-  "@assistant-ui/react": "^0.14.13",
+  "@assistant-ui/react": "^0.15.0",
   "@assistant-ui/react-ai-sdk": "^1.3.31"
 }
 ```
@@ -1872,7 +1872,7 @@ npx @ai-sdk/codemod v6       # v5→v6 only
 - [ ] Update `@ai-sdk/provider-utils` to `^4.0.0`
 - [ ] Update all `@ai-sdk/*` provider packages to `^3.0.0`
 - [ ] Update `zod` to `^3.25.76` or `^4.1.8` (both supported)
-- [ ] Update `@assistant-ui/react` to `^0.14.13`
+- [ ] Update `@assistant-ui/react` to `^0.15.0` (or `latest`)
 - [ ] Update `@assistant-ui/react-ai-sdk` to `^1.3.31`
 - [ ] If using MCP: Install `@ai-sdk/mcp` to `^1.0.0`
 

--- a/assistant-ui/skills/update/references/assistant-ui.md
+++ b/assistant-ui/skills/update/references/assistant-ui.md
@@ -5,6 +5,7 @@ Migrations for upgrading between assistant-ui versions.
 ## Contents
 
 - [Version Detection](#version-detection)
+- [Migration: → 0.15.x (Property accessors, legacy hook removal)](#migration--015x-property-accessors-legacy-hook-removal)
 - [Migration: → 0.14.x (Children API, deprecated removals)](#migration--014x-children-api-deprecated-removals)
 - [Migration: → 0.13.x (Top-turn anchoring)](#migration--013x-top-turn-anchoring)
 - [Migration: → 0.12.x (Unified State API)](#migration--012x-unified-state-api)
@@ -26,6 +27,98 @@ Migrations for upgrading between assistant-ui versions.
 npm ls @assistant-ui/react
 npm view @assistant-ui/react version  # Latest
 ```
+
+## Migration: → 0.15.x (Property accessors, legacy hook removal)
+
+### From 0.14.x
+
+Two themes: `aui` scope accessors become properties, and the v0.12-era legacy context hooks are removed. Upstream guide: https://assistant-ui.com/docs/migrations/v0-15
+
+**Automatic migration:**
+
+```bash
+npx assistant-ui@latest upgrade
+```
+
+This runs the `v0-15/aui-accessor-calls-to-properties` codemod, which rewrites nullary accessor calls to property access. It also migrates the still-deprecated primitive `If` components onto `AuiIf`.
+
+**Scope accessors are properties.** Calling them still works but is deprecated:
+
+```diff
+- aui.thread().getState();
+- aui.threads().switchToNewThread();
++ aui.thread.getState();
++ aui.threads.switchToNewThread();
+```
+
+Methods *on* a scope keep their parentheses: `aui.thread.composer()`, `aui.thread.message({ index: 0 })`, `aui.message.part({ index: 0 })`.
+
+Selecting an unavailable scope no longer throws. `aui.thread` always succeeds and is always truthy; `source` is `null` when unavailable and any other property read (or a call) throws:
+
+```diff
+- try { aui.message; } catch { /* unavailable */ }
++ if (aui.message.source != null) { /* available */ }
+```
+
+`source`, `query`, and `name` are reserved accessor property names and never resolve to scope methods.
+
+**Legacy context hooks removed.** Read state with `useAuiState` and take actions with `useAui`:
+
+| Removed | Replacement |
+|---------|-------------|
+| `useAssistantRuntime()` | `useAui()` |
+| `useThreadList(selector)` | `useAuiState((s) => s.threads)` |
+| `useThreadRuntime()` | `useAui().thread` |
+| `useThread(selector)` | `useAuiState((s) => s.thread)` |
+| `useThreadComposer(selector)` | `useAuiState((s) => s.thread.composer)` |
+| `useThreadModelContext(selector)` | `useAuiState((s) => s.modelContext)` |
+| `useMessageRuntime()` | `useAui().message` |
+| `useMessage(selector)` | `useAuiState((s) => s.message)` |
+| `useEditComposer(selector)` | `useAuiState((s) => s.message.composer)` |
+| `useComposerRuntime()` | `useAui().composer` |
+| `useComposer(selector)` | `useAuiState((s) => s.composer)` |
+| `useMessagePartRuntime()` | `useAui().part` |
+| `useMessagePart(selector)` | `useAuiState((s) => s.part)` |
+| `useAttachmentRuntime()` | `useAui().attachment` |
+| `useAttachment(selector)` | `useAuiState((s) => s.attachment)` |
+| `useThreadListItemRuntime()` | `useAui().threadListItem` |
+| `useThreadListItem(selector)` | `useAuiState((s) => s.threadListItem)` |
+
+The attachment variants (`useThreadComposerAttachment(Runtime)`, `useEditComposerAttachment(Runtime)`, `useMessageAttachment(Runtime)`) go with them; use `useAui().attachment` / `useAuiState((s) => s.attachment)`.
+
+**`ToolsState.tools` removed.** `toolUIs` entries carry the renderer alongside its presentation options:
+
+```diff
+- const Render = useAuiState((s) => s.tools.tools[toolName]?.[0]);
++ const Render = useAuiState((s) => s.tools.toolUIs[toolName]?.[0]?.render);
+```
+
+**`"mcp-app"` group key removed.** `"standalone-tool-call"` is a superset matching MCP-app tool calls plus any tool call whose registered UI opts into standalone display:
+
+```diff
+  groupPartByType({
+    "tool-call": ["group-tool"],
+-   "mcp-app": [],
++   "standalone-tool-call": [],
+  })
+```
+
+**`useAui(clients, { parent })` second argument removed.** Provide the parent through context:
+
+```diff
+- const aui = useAui(scopes, { parent });
++ const Scoped = ({ children }) => {
++   const aui = useAui(scopes); // extends the AuiProvider parent
++   return <AuiProvider value={aui}>{children}</AuiProvider>;
++ };
++ <AuiProvider value={parent}><Scoped /></AuiProvider>
+```
+
+Where `{ parent: null }` detached from context, `<AuiProvider value={null}>` now provides an isolated empty root (experimental).
+
+**Public enums are `as const` objects.** The packages adopted `erasableSyntaxOnly`, so exported TypeScript `enum`s became const objects. Value usage is unchanged; `enum`-only type positions may need `(typeof X)[keyof typeof X]`.
+
+**Still deprecated, not yet removed:** primitive `If` components (`ThreadPrimitive.If`, `MessagePrimitive.If`, `ThreadPrimitive.Empty`) in favor of `AuiIf`; `useMessagePartText` / `useMessagePartReasoning` / `useMessagePartSource` / `useMessagePartImage` / `useMessagePartFile` / `useMessagePartData` in favor of selecting and narrowing `s.part`; and the `components` prop on primitives.
 
 ## Migration: → 0.14.x (Children API, deprecated removals)
 
@@ -185,29 +278,29 @@ npx assistant-ui@latest upgrade
 
 **Context hooks replaced with unified state API:**
 
-All individual context hooks replaced by `useAuiState` / `useAui`:
+All individual context hooks replaced by `useAuiState` / `useAui`. The right-hand side below is the 0.15 landing form (property accessors), since a project migrating today upgrades past 0.15:
 
 ```diff
 - const { messages } = useThread();
 + const messages = useAuiState(s => s.thread.messages);
 
 - const runtime = useThreadRuntime();
-+ const thread = useAui().thread();
++ const thread = useAui().thread;
 
 - const { isEditing } = useComposer();
 + const isEditing = useAuiState(s => s.composer.isEditing);
 
 - const runtime = useComposerRuntime();
-+ const composer = useAui().composer();
++ const composer = useAui().composer;
 
 - const { status } = useMessage();
 + const status = useAuiState(s => s.message.status);
 
 - const runtime = useMessageRuntime();
-+ const message = useAui().message();
++ const message = useAui().message;
 ```
 
-Other deprecated hooks: `useAssistantRuntime`, `useEditComposer`, `useThreadListItem`, `useThreadListItemRuntime`, `useMessagePart`, `useMessagePartRuntime`, `useAttachment`, `useAttachmentRuntime`, `useThreadModelContext`, `useThreadComposer`, `useThreadList`.
+Deprecated alongside them and removed outright in 0.15: `useAssistantRuntime`, `useEditComposer`, `useThreadListItem`, `useThreadListItemRuntime`, `useMessagePart`, `useMessagePartRuntime`, `useAttachment`, `useAttachmentRuntime`, `useThreadModelContext`, `useThreadComposer`, `useThreadList`. See the [0.15 section](#migration--015x-property-accessors-legacy-hook-removal) for the full mapping table.
 
 **Event names changed to camelCase:**
 
@@ -229,12 +322,12 @@ Unchanged: `thread.initialize`, `composer.send`.
 + aui.thread().composer().send();
 ```
 
-**`submitMode` prop (0.12.10) — deprecates `submitOnEnter`:**
-- `"enter"` (default) — submit on Enter
-- `"ctrlEnter"` — submit on Ctrl/Cmd+Enter, plain Enter for newlines
-- `"none"` — disable keyboard submission
+**`submitMode` prop (0.12.10), deprecating `submitOnEnter`:**
+- `"enter"` (default): submit on Enter
+- `"ctrlEnter"`: submit on Ctrl/Cmd+Enter, plain Enter for newlines
+- `"none"`: disable keyboard submission
 
-**Zod**: AI SDK v6 (used by `@assistant-ui/react-ai-sdk` 1.3.x) requires `zod@^3.25.76 || ^4.1.8`; both Zod 3.25+ and Zod 4 work.
+**Zod**: AI SDK v6+ (used by `@assistant-ui/react-ai-sdk` 1.3.x and later) requires `zod@^3.25.76 || ^4.1.8`; both Zod 3.25+ and Zod 4 work.
 
 **New primitives:**
 - `ChainOfThoughtPrimitive` (0.12.8)
@@ -248,6 +341,13 @@ Unchanged: `thread.initialize`, `composer.send`.
 **Search for deprecated patterns:**
 ```bash
 grep -rn "useAssistantApi\|useAssistantState\|useAssistantEvent\|AssistantIf\|submitOnEnter\|useThread()\|useComposer()\|useMessage()\|useThreadRuntime\|useComposerRuntime\|useMessageRuntime" --include="*.tsx" --include="*.ts"
+```
+
+Add the 0.15 patterns to the same sweep:
+
+```bash
+grep -rnE "\b(aui|api)\.(thread|threads|message|part|composer|attachment|threadListItem|modelContext|tools)\(\)" --include="*.tsx" --include="*.ts"
+grep -rn "s\.tools\.tools\|\"mcp-app\"" --include="*.tsx" --include="*.ts"
 ```
 
 ---

--- a/assistant-ui/skills/update/references/assistant-ui.md
+++ b/assistant-ui/skills/update/references/assistant-ui.md
@@ -40,7 +40,19 @@ Two themes: `aui` scope accessors become properties, and the v0.12-era legacy co
 npx assistant-ui@latest upgrade
 ```
 
-This runs the `v0-15/aui-accessor-calls-to-properties` codemod, which rewrites nullary accessor calls to property access. It also migrates the still-deprecated primitive `If` components onto `AuiIf`.
+`upgrade` runs the whole codemod bundle in order, not just the newest one:
+
+```
+v0-8/ui-package-split
+v0-9/edge-package-split
+v0-11/content-part-to-message-part
+v0-12/assistant-api-to-aui
+v0-12/event-names-to-camelcase
+v0-12/primitive-if-to-aui-if
+v0-15/aui-accessor-calls-to-properties
+```
+
+`v0-15/aui-accessor-calls-to-properties` is the one that rewrites nullary accessor calls to property access. The primitive `If` migration onto `AuiIf` comes from `v0-12/primitive-if-to-aui-if`, so running the v0-15 codemod alone (`npx assistant-ui@latest codemod v0-15/aui-accessor-calls-to-properties ./src`) does not do it.
 
 **Scope accessors are properties.** Calling them still works but is deprecated:
 

--- a/assistant-ui/skills/update/references/breaking-changes.md
+++ b/assistant-ui/skills/update/references/breaking-changes.md
@@ -6,6 +6,7 @@ Fast lookup for breaking changes by version.
 
 | Version | Breaking Change | Migration |
 |---------|-----------------|-----------|
+| **0.15.0** | `aui` scope accessors become properties; v0.12-era legacy context hooks removed; `ToolsState.tools` removed; `"mcp-app"` group key removed; `useAui(clients, { parent })` removed | `aui.thread` not `aui.thread()`; `useAui`/`useAuiState`; `s.tools.toolUIs[n]?.[0]?.render`; `"standalone-tool-call"`; `AuiProvider` |
 | **0.14.0** | `components` prop → children render functions; deprecated hooks/aliases removed | Children render functions; `useAui`/`useAuiState`/`useAuiEvent`/`AuiIf`; drop `unstable_` prefixes |
 | **0.13.0** | `ThreadPrimitive.ViewportSlack` removed | Use `topAnchorMessageClamp` on `ThreadPrimitive.Viewport` |
 | **0.12.0** | Unified state API | Use `useAui`, `useAuiState`, `useAuiEvent`, `AuiIf` |
@@ -36,7 +37,7 @@ Fast lookup for breaking changes by version.
 - import type { AssistantMessage, UserMessage } from "@assistant-ui/react";
 + import type { ThreadAssistantMessage, ThreadUserMessage } from "@assistant-ui/react";
 
-# AI SDK v6 (react-ai-sdk 1.0+)
+# AI SDK v6+ (react-ai-sdk 1.0+)
 - import { useChat } from "ai/react";
 - import { useAISDKRuntime } from "@assistant-ui/react-ai-sdk";
 + import { useChatRuntime, AssistantChatTransport } from "@assistant-ui/react-ai-sdk";
@@ -64,7 +65,21 @@ Fast lookup for breaking changes by version.
 
 # Actions (0.11.0+)
 - useThreadActions().append(...)
-+ useAui().thread().append(...)
++ useAui().thread.append(...)
+
+# Scope accessors are properties (0.15.0+)
+- aui.thread().getState();
+- aui.threads().switchToNewThread();
++ aui.thread.getState();
++ aui.threads.switchToNewThread();
+
+# Tool UI registry (0.15.0+)
+- useAuiState((s) => s.tools.tools[toolName]?.[0]);
++ useAuiState((s) => s.tools.toolUIs[toolName]?.[0]?.render);
+
+# Part grouping (0.15.0+)
+- groupPartByType({ "mcp-app": [] });
++ groupPartByType({ "standalone-tool-call": [] });
 ```
 
 ### Config Changes
@@ -88,11 +103,11 @@ grep -rn "from ['\"]@assistant-ui/react['\"]" --include="*.tsx" | grep -v Primit
 grep -rn "Message\.InProgress" --include="*.tsx"  # 0.3.0
 ```
 
-## AI SDK v6 Changes (Separate)
+## AI SDK Changes (Separate)
 
-See [./ai-sdk-v6.md](./ai-sdk-v6.md) for AI SDK specific migrations:
+See [./ai-sdk-v6.md](./ai-sdk-v6.md) for the v4/v5 → v6 migration, which is still the bulk of the work for older projects:
 
-| Old | New |
+| Old (v4/v5) | v6 |
 |-----|-----|
 | `maxSteps` | `stopWhen: stepCountIs(n)` |
 | `parameters` | `inputSchema` (in `tool()`) |
@@ -101,12 +116,22 @@ See [./ai-sdk-v6.md](./ai-sdk-v6.md) for AI SDK specific migrations:
 | `CoreMessage` | `ModelMessage` |
 | `Message` | `UIMessage` |
 
+v6 → v7 is a much smaller step, but the route response and the `@ai-sdk/*` major line both move:
+
+| v6 | v7 |
+|----|----|
+| `ai@^6`, `@ai-sdk/react@^3`, `@ai-sdk/openai@^3` | `ai@^7`, `@ai-sdk/react@^4`, `@ai-sdk/openai@^4` |
+| `result.toUIMessageStreamResponse()` | `createUIMessageStreamResponse({ stream: toUIMessageStream({ stream: result.stream }) })` (the method still compiles but is deprecated) |
+| `inputSchema: z.object({...})` | `inputSchema: zodSchema(z.object({...}))` |
+| n/a | `toolApproval` call-level option + `lastAssistantMessageIsCompleteWithApprovalResponses` |
+
 ## Version Compatibility
 
-Current latest: `@assistant-ui/react` 0.14.x, `@assistant-ui/react-ai-sdk` 1.3.x.
+Current latest: `@assistant-ui/react` 0.15.x, `@assistant-ui/react-ai-sdk` 1.4.x, `@assistant-ui/core` 0.3.x, `@assistant-ui/store` 0.3.x, `assistant-stream` 0.3.x.
 
 | @assistant-ui/react | react-ai-sdk | AI SDK | Zod |
 |---------------------|--------------|--------|-----|
+| 0.15.x | 1.4.x | 7.x | 3.25+ or 4.x |
 | 0.14.x | 1.3.x | 6.x | 3.25+ or 4.x |
 | 0.12.x to 0.13.x | 1.3.x | 6.x | 3.25+ or 4.x |
 | 0.11.x | 1.2.x | 6.x | 3.25+ or 4.x |


### PR DESCRIPTION
## summary

- brings the skills up to `@assistant-ui/react` 0.15 and AI SDK v7. the previous baseline was 0.14 on AI SDK v6, which is 927 upstream commits ago.
- adopts the v0.15 breaking changes: `aui` scope accessors are properties, the v0.12-era context hooks are removed, `s.tools.tools` becomes `s.tools.toolUIs`, and the `mcp-app` group key becomes `standalone-tool-call`.
- documents AI SDK v7 as the required version rather than an optional upgrade. `react-ai-sdk@1.4` depends on `ai@^7` directly, so every route sample moves to `createUIMessageStreamResponse` + `toUIMessageStream`, and older majors get a pinned adapter release each.
- leads the tools skill with `"use generative"` + `defineToolkit` and flags `makeAssistantTool` / `useAssistantTool` / `makeAssistantToolUI` / `useAssistantToolUI` as deprecated, matching the `@deprecated` tags upstream.
- covers surface the skills had missed entirely: the current `unstable_` interactables API, MCP elicitation, server-side tool approval, the new CLI verbs, the 43-item registry, and 18 previously unlisted packages.
- corrects API signatures that never matched the source, including several that were not callable as written (see the `fix:` commits).

no test plan, every changed file is markdown.

## notes

- everything here was checked against the assistant-ui working tree (`api-surface/*.ts`, package.json versions, CLI source, registry output), not written from memory. the checks were scripted so they can be re-run:
  - 478 import specifiers against the generated per-package export lists
  - every `s.<scope>.<field>` selector against the 16 registered scope state types
  - every `aui.<scope>.<method>()` call against the 13 scope method types
  - `adapters.*` keys and `RuntimeCapabilities` names, parsed with brace matching rather than regex
  - code fences, relative links, frontmatter, and skill-list agreement across `marketplace.json` and `README.md`
- the legacy interactables API is scheduled for removal on or after 2026-09-14, so that section wants deleting rather than updating next cycle.
- `0.15.2` and `1.4.3` exist in the monorepo but npm `latest` is still `0.15.1` and `1.4.2`, so version pins here use minor ranges instead of exact patches.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.MX9p6fH4Hcj1DMpDKvvygpeVvtheAQk8ta3vj1b3bDwOzfVYrZ5J5JCz334?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->